### PR TITLE
feat: enhance registry and scan APIs with Artifactory repository support

### DIFF
--- a/services/backend/database/migrations/56_add_registry_xray_repository.go
+++ b/services/backend/database/migrations/56_add_registry_xray_repository.go
@@ -1,0 +1,39 @@
+package migrations
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/uptrace/bun"
+)
+
+func init() {
+	Migrations.MustRegister(func(ctx context.Context, db *bun.DB) error {
+		exists, err := columnExists(ctx, db, "registries", "xray_repository")
+		if err != nil {
+			return fmt.Errorf("migration 56 (check registries.xray_repository): %w", err)
+		}
+		if exists {
+			return nil
+		}
+
+		if _, err := db.NewRaw(`ALTER TABLE registries ADD COLUMN xray_repository TEXT NOT NULL DEFAULT ''`).Exec(ctx); err != nil {
+			return fmt.Errorf("migration 56 (add registries.xray_repository): %w", err)
+		}
+
+		return nil
+	}, func(ctx context.Context, db *bun.DB) error {
+		exists, err := columnExists(ctx, db, "registries", "xray_repository")
+		if err != nil {
+			return fmt.Errorf("migration 56 rollback (check registries.xray_repository): %w", err)
+		}
+		if !exists {
+			return nil
+		}
+
+		if _, err := db.NewRaw(`ALTER TABLE registries DROP COLUMN xray_repository`).Exec(ctx); err != nil {
+			return fmt.Errorf("migration 56 rollback (drop registries.xray_repository): %w", err)
+		}
+		return nil
+	})
+}

--- a/services/backend/handlers/admins/global_registries.go
+++ b/services/backend/handlers/admins/global_registries.go
@@ -22,6 +22,7 @@ type globalRegistryPayload struct {
 	URL               *string `json:"url" binding:"omitempty"`
 	XrayURL           *string `json:"xray_url"`
 	XrayArtifactoryID *string `json:"xray_artifactory_id"`
+	XrayRepository    *string `json:"xray_repository"`
 	AuthType          *string `json:"auth_type" binding:"omitempty,oneof=basic token aws_ecr none"`
 	ScanProvider      *string `json:"scan_provider" binding:"omitempty,oneof=trivy artifactory_xray"`
 	Username          *string `json:"username"`
@@ -76,6 +77,7 @@ func CreateGlobalRegistry(c *gin.Context, db *bun.DB) {
 	}
 	xrayURL := strings.TrimSpace(stringValue(body.XrayURL))
 	xrayArtifactoryID := strings.TrimSpace(stringValue(body.XrayArtifactoryID))
+	xrayRepository := strings.Trim(strings.TrimSpace(stringValue(body.XrayRepository)), "/")
 	if scanProvider == models.ScanProviderArtifactoryXray {
 		if xrayArtifactoryID == "" {
 			xrayArtifactoryID = "default"
@@ -83,6 +85,7 @@ func CreateGlobalRegistry(c *gin.Context, db *bun.DB) {
 	} else {
 		xrayURL = ""
 		xrayArtifactoryID = "default"
+		xrayRepository = ""
 	}
 	username := strings.TrimSpace(stringValue(body.Username))
 	encryptedPassword := ""
@@ -100,6 +103,7 @@ func CreateGlobalRegistry(c *gin.Context, db *bun.DB) {
 		URL:               url,
 		XrayURL:           xrayURL,
 		XrayArtifactoryID: xrayArtifactoryID,
+		XrayRepository:    xrayRepository,
 		AuthType:          authType,
 		ScanProvider:      scanProvider,
 		Username:          username,
@@ -182,6 +186,9 @@ func UpdateGlobalRegistry(c *gin.Context, db *bun.DB) {
 	if body.XrayArtifactoryID != nil {
 		registry.XrayArtifactoryID = strings.TrimSpace(*body.XrayArtifactoryID)
 	}
+	if body.XrayRepository != nil {
+		registry.XrayRepository = strings.Trim(strings.TrimSpace(*body.XrayRepository), "/")
+	}
 	if registry.ScanProvider == models.ScanProviderArtifactoryXray {
 		if registry.XrayArtifactoryID == "" {
 			registry.XrayArtifactoryID = "default"
@@ -189,6 +196,7 @@ func UpdateGlobalRegistry(c *gin.Context, db *bun.DB) {
 	} else {
 		registry.XrayURL = ""
 		registry.XrayArtifactoryID = "default"
+		registry.XrayRepository = ""
 	}
 	if body.Password != nil {
 		trimmed := strings.TrimSpace(*body.Password)
@@ -207,7 +215,7 @@ func UpdateGlobalRegistry(c *gin.Context, db *bun.DB) {
 
 	registry.UpdatedAt = time.Now()
 	if _, err := db.NewUpdate().Model(registry).
-		Column("name", "url", "xray_url", "xray_artifactory_id", "auth_type", "scan_provider", "username", "password", "updated_at").
+		Column("name", "url", "xray_url", "xray_artifactory_id", "xray_repository", "auth_type", "scan_provider", "username", "password", "updated_at").
 		Where("id = ? AND owner_type = ?", id, models.OwnerTypeSystem).
 		Exec(c.Request.Context()); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to update global registry"})

--- a/services/backend/handlers/registries/registries.go
+++ b/services/backend/handlers/registries/registries.go
@@ -10,6 +10,7 @@ import (
 	"justscan-backend/pkg/crypto"
 	"justscan-backend/pkg/models"
 	"justscan-backend/scanner"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
@@ -56,6 +57,7 @@ func CreateRegistry(db *bun.DB) gin.HandlerFunc {
 			URL               string `json:"url" binding:"required"`
 			XrayURL           string `json:"xray_url"`
 			XrayArtifactoryID string `json:"xray_artifactory_id"`
+			XrayRepository    string `json:"xray_repository"`
 			OrgID             string `json:"org_id"`
 			AuthType          string `json:"auth_type" binding:"omitempty,oneof=basic token aws_ecr none"`
 			ScanProvider      string `json:"scan_provider" binding:"omitempty,oneof=trivy artifactory_xray"`
@@ -105,6 +107,7 @@ func CreateRegistry(db *bun.DB) gin.HandlerFunc {
 			URL:               body.URL,
 			XrayURL:           body.XrayURL,
 			XrayArtifactoryID: body.XrayArtifactoryID,
+			XrayRepository:    strings.Trim(strings.TrimSpace(body.XrayRepository), "/"),
 			AuthType:          body.AuthType,
 			ScanProvider:      body.ScanProvider,
 			Username:          body.Username,
@@ -147,6 +150,7 @@ func UpdateRegistry(db *bun.DB) gin.HandlerFunc {
 			URL               string `json:"url"`
 			XrayURL           string `json:"xray_url"`
 			XrayArtifactoryID string `json:"xray_artifactory_id"`
+			XrayRepository    string `json:"xray_repository"`
 			AuthType          string `json:"auth_type"`
 			ScanProvider      string `json:"scan_provider"`
 			Username          string `json:"username"`
@@ -172,6 +176,9 @@ func UpdateRegistry(db *bun.DB) gin.HandlerFunc {
 		if body.XrayArtifactoryID != "" {
 			registry.XrayArtifactoryID = body.XrayArtifactoryID
 		}
+		if body.XrayRepository != "" || registry.ScanProvider == models.ScanProviderArtifactoryXray {
+			registry.XrayRepository = strings.Trim(strings.TrimSpace(body.XrayRepository), "/")
+		}
 		if body.AuthType != "" {
 			registry.AuthType = body.AuthType
 		}
@@ -181,6 +188,11 @@ func UpdateRegistry(db *bun.DB) gin.HandlerFunc {
 		if err := scanner.ValidateRegistryProviderSelection(registry.ScanProvider); err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 			return
+		}
+		if registry.ScanProvider != models.ScanProviderArtifactoryXray {
+			registry.XrayURL = ""
+			registry.XrayArtifactoryID = "default"
+			registry.XrayRepository = ""
 		}
 		if body.Username != "" {
 			registry.Username = body.Username
@@ -196,7 +208,7 @@ func UpdateRegistry(db *bun.DB) gin.HandlerFunc {
 		}
 		registry.UpdatedAt = time.Now()
 		if _, err := db.NewUpdate().Model(registry).
-			Column("name", "url", "xray_url", "xray_artifactory_id", "auth_type", "scan_provider", "username", "password", "updated_at").
+			Column("name", "url", "xray_url", "xray_artifactory_id", "xray_repository", "auth_type", "scan_provider", "username", "password", "updated_at").
 			Where("id = ?", registryID).
 			Exec(c.Request.Context()); err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to update registry"})

--- a/services/backend/handlers/registries/repositories.go
+++ b/services/backend/handlers/registries/repositories.go
@@ -1,0 +1,50 @@
+package registries
+
+import (
+	"net/http"
+	"sort"
+
+	"justscan-backend/functions/authz"
+	"justscan-backend/pkg/models"
+	"justscan-backend/scanner"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/uptrace/bun"
+)
+
+func ListArtifactoryRepositories(db *bun.DB) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		registryID, err := uuid.Parse(c.Param("id"))
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid registry ID"})
+			return
+		}
+
+		registry, _, _, ok := authz.LoadAccessibleRegistry(c, db, registryID)
+		if !ok {
+			return
+		}
+		if registry.ScanProvider != models.ScanProviderArtifactoryXray {
+			c.JSON(http.StatusConflict, gin.H{"error": "artifactory repositories are only available for Artifactory Xray registries"})
+			return
+		}
+
+		client, err := scanner.NewRegistryXrayTestClient(registry)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+
+		repositories, err := client.ListDockerRepositories(c.Request.Context())
+		if err != nil {
+			c.JSON(http.StatusBadGateway, gin.H{"error": err.Error()})
+			return
+		}
+		sort.SliceStable(repositories, func(i, j int) bool {
+			return repositories[i].Key < repositories[j].Key
+		})
+
+		c.JSON(http.StatusOK, gin.H{"data": repositories})
+	}
+}

--- a/services/backend/handlers/scans/create.go
+++ b/services/backend/handlers/scans/create.go
@@ -18,20 +18,22 @@ import (
 )
 
 type CreateScanRequest struct {
-	Image      string   `json:"image" binding:"required"`
-	Tag        string   `json:"tag" binding:"required"`
-	Platform   string   `json:"platform"`
-	RegistryID string   `json:"registry_id"`
-	OrgID      string   `json:"org_id"`
-	TagIDs     []string `json:"tag_ids"`
+	Image          string   `json:"image" binding:"required"`
+	Tag            string   `json:"tag" binding:"required"`
+	Platform       string   `json:"platform"`
+	RegistryID     string   `json:"registry_id"`
+	XrayRepository string   `json:"xray_repository"`
+	OrgID          string   `json:"org_id"`
+	TagIDs         []string `json:"tag_ids"`
 }
 
 type CreateScansRequest struct {
-	Images     []string `json:"images" binding:"required,min=1"`
-	Platform   string   `json:"platform"`
-	RegistryID string   `json:"registry_id"`
-	OrgID      string   `json:"org_id"`
-	TagIDs     []string `json:"tag_ids"`
+	Images         []string `json:"images" binding:"required,min=1"`
+	Platform       string   `json:"platform"`
+	RegistryID     string   `json:"registry_id"`
+	XrayRepository string   `json:"xray_repository"`
+	OrgID          string   `json:"org_id"`
+	TagIDs         []string `json:"tag_ids"`
 }
 
 func CreateScan(db *bun.DB) gin.HandlerFunc {
@@ -82,7 +84,7 @@ func CreateScan(db *bun.DB) gin.HandlerFunc {
 			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 			return
 		}
-		normalizedImageName, normalizedImageTag := scanner.NormalizeScanTarget(req.Image, req.Tag, registry)
+		normalizedImageName, normalizedImageTag := scanner.NormalizeScanTargetWithXrayRepository(req.Image, req.Tag, registry, req.XrayRepository)
 
 		scan := &models.Scan{
 			ImageName:    normalizedImageName,
@@ -213,7 +215,7 @@ func CreateScans(db *bun.DB) gin.HandlerFunc {
 				return
 			}
 
-			normalizedImageName, normalizedImageTag := scanner.NormalizeScanTarget(imageName, imageTag, registry)
+			normalizedImageName, normalizedImageTag := scanner.NormalizeScanTargetWithXrayRepository(imageName, imageTag, registry, req.XrayRepository)
 			scan := models.Scan{
 				ImageName:    normalizedImageName,
 				ImageTag:     normalizedImageTag,

--- a/services/backend/pkg/models/registries.go
+++ b/services/backend/pkg/models/registries.go
@@ -15,6 +15,7 @@ type Registry struct {
 	URL               string     `bun:"url,type:text,notnull" json:"url"`
 	XrayURL           string     `bun:"xray_url,type:text,default:''" json:"xray_url"`
 	XrayArtifactoryID string     `bun:"xray_artifactory_id,type:text,notnull,default:'default'" json:"xray_artifactory_id"`
+	XrayRepository    string     `bun:"xray_repository,type:text,notnull,default:''" json:"xray_repository,omitempty"`
 	AuthType          string     `bun:"auth_type,type:text,notnull,default:'basic'" json:"auth_type"`
 	ScanProvider      string     `bun:"scan_provider,type:text,notnull,default:'trivy'" json:"scan_provider"`
 	Username          string     `bun:"username,type:text,default:''" json:"-"`

--- a/services/backend/router/registry.go
+++ b/services/backend/router/registry.go
@@ -20,5 +20,6 @@ func Registries(router *gin.RouterGroup, db *bun.DB) {
 		r.POST("/:id/shares", registries.ShareRegistry(db))
 		r.DELETE("/:id/shares/:orgId", registries.UnshareRegistry(db))
 		r.POST("/:id/test", registries.TestRegistry(db))
+		r.GET("/:id/artifactory-repositories", registries.ListArtifactoryRepositories(db))
 	}
 }

--- a/services/backend/scanner/registry.go
+++ b/services/backend/scanner/registry.go
@@ -109,13 +109,20 @@ func normalizeRegistryHost(url string) string {
 // NormalizeScanTarget trims user input, removes accidental leading/trailing
 // separators, and qualifies unqualified image names when a registry is chosen.
 func NormalizeScanTarget(imageName, imageTag string, registry *models.Registry) (string, string) {
+	return NormalizeScanTargetWithXrayRepository(imageName, imageTag, registry, "")
+}
+
+// NormalizeScanTargetWithXrayRepository applies the same normalization as
+// NormalizeScanTarget plus an optional Xray repository override used for
+// Artifactory-backed scans.
+func NormalizeScanTargetWithXrayRepository(imageName, imageTag string, registry *models.Registry, xrayRepository string) (string, string) {
 	trimmedName := strings.TrimSpace(imageName)
 	trimmedName = strings.TrimSuffix(trimmedName, ":")
 	trimmedTag := strings.TrimSpace(imageTag)
 	trimmedTag = strings.TrimPrefix(trimmedTag, ":")
 
 	if registry != nil {
-		trimmedName = QualifyImageNameForRegistry(trimmedName, registry)
+		trimmedName = QualifyImageNameForRegistryWithXrayRepository(trimmedName, registry, xrayRepository)
 	}
 
 	return trimmedName, trimmedTag
@@ -124,14 +131,56 @@ func NormalizeScanTarget(imageName, imageTag string, registry *models.Registry) 
 // QualifyImageNameForRegistry prefixes an image with the selected registry host
 // when the image name is not already fully qualified.
 func QualifyImageNameForRegistry(imageName string, registry *models.Registry) string {
+	return QualifyImageNameForRegistryWithXrayRepository(imageName, registry, "")
+}
+
+func QualifyImageNameForRegistryWithXrayRepository(imageName string, registry *models.Registry, xrayRepository string) string {
 	trimmedName := strings.TrimSpace(imageName)
 	if trimmedName == "" || registry == nil {
 		return trimmedName
 	}
+
+	host := normalizeRegistryHost(registry.URL)
+	prefix := ""
+	remainder := strings.TrimPrefix(strings.Trim(trimmedName, "/"), "/")
+	if hasRegistryHost(trimmedName) {
+		if host == "" || !strings.HasPrefix(trimmedName, host+"/") {
+			return trimmedName
+		}
+		prefix = host + "/"
+		remainder = strings.TrimPrefix(trimmedName, prefix)
+	}
+
+	remainder = qualifyXrayRepositoryPath(remainder, effectiveXrayRepository(registry, xrayRepository))
+	if prefix != "" {
+		return prefix + remainder
+	}
 	if hasRegistryHost(trimmedName) {
 		return trimmedName
 	}
-	return normalizeRegistryHost(registry.URL) + "/" + strings.TrimPrefix(trimmedName, "/")
+	return host + "/" + remainder
+}
+
+func effectiveXrayRepository(registry *models.Registry, xrayRepository string) string {
+	if registry == nil || registry.ScanProvider != models.ScanProviderArtifactoryXray {
+		return ""
+	}
+	if trimmed := strings.Trim(strings.TrimSpace(xrayRepository), "/"); trimmed != "" {
+		return trimmed
+	}
+	return strings.Trim(strings.TrimSpace(registry.XrayRepository), "/")
+}
+
+func qualifyXrayRepositoryPath(imagePath, xrayRepository string) string {
+	trimmedPath := strings.Trim(strings.TrimSpace(imagePath), "/")
+	if trimmedPath == "" {
+		return trimmedPath
+	}
+	trimmedRepo := strings.Trim(strings.TrimSpace(xrayRepository), "/")
+	if trimmedRepo == "" || trimmedPath == trimmedRepo || strings.HasPrefix(trimmedPath, trimmedRepo+"/") {
+		return trimmedPath
+	}
+	return trimmedRepo + "/" + trimmedPath
 }
 
 func hasRegistryHost(imageName string) bool {

--- a/services/backend/scanner/registry_test.go
+++ b/services/backend/scanner/registry_test.go
@@ -1,0 +1,87 @@
+package scanner
+
+import (
+	"testing"
+
+	"justscan-backend/pkg/models"
+)
+
+func TestNormalizeScanTargetWithXrayRepository_DefaultRepoApplied(t *testing.T) {
+	registry := &models.Registry{
+		URL:            "https://registry.example.com",
+		ScanProvider:   models.ScanProviderArtifactoryXray,
+		XrayRepository: "docker-remote",
+	}
+
+	imageName, imageTag := NormalizeScanTargetWithXrayRepository("n8nio/n8n", "latest", registry, "")
+	if imageName != "registry.example.com/docker-remote/n8nio/n8n" {
+		t.Fatalf("expected default repo prefix, got %q", imageName)
+	}
+	if imageTag != "latest" {
+		t.Fatalf("expected tag latest, got %q", imageTag)
+	}
+}
+
+func TestNormalizeScanTargetWithXrayRepository_OverrideWins(t *testing.T) {
+	registry := &models.Registry{
+		URL:            "https://registry.example.com",
+		ScanProvider:   models.ScanProviderArtifactoryXray,
+		XrayRepository: "docker-remote",
+	}
+
+	imageName, _ := NormalizeScanTargetWithXrayRepository("n8nio/n8n", "latest", registry, "docker-prod")
+	if imageName != "registry.example.com/docker-prod/n8nio/n8n" {
+		t.Fatalf("expected override repo prefix, got %q", imageName)
+	}
+}
+
+func TestNormalizeScanTargetWithXrayRepository_DoesNotDoublePrefix(t *testing.T) {
+	registry := &models.Registry{
+		URL:            "https://registry.example.com",
+		ScanProvider:   models.ScanProviderArtifactoryXray,
+		XrayRepository: "docker-remote",
+	}
+
+	imageName, _ := NormalizeScanTargetWithXrayRepository("docker-remote/n8nio/n8n", "latest", registry, "")
+	if imageName != "registry.example.com/docker-remote/n8nio/n8n" {
+		t.Fatalf("expected existing repo prefix to be preserved, got %q", imageName)
+	}
+}
+
+func TestNormalizeScanTargetWithXrayRepository_InsertsRepoAfterMatchingHost(t *testing.T) {
+	registry := &models.Registry{
+		URL:            "https://registry.example.com",
+		ScanProvider:   models.ScanProviderArtifactoryXray,
+		XrayRepository: "docker-remote",
+	}
+
+	imageName, _ := NormalizeScanTargetWithXrayRepository("registry.example.com/n8nio/n8n", "latest", registry, "")
+	if imageName != "registry.example.com/docker-remote/n8nio/n8n" {
+		t.Fatalf("expected repo insertion after matching host, got %q", imageName)
+	}
+}
+
+func TestNormalizeScanTargetWithXrayRepository_LeavesOtherHostsAlone(t *testing.T) {
+	registry := &models.Registry{
+		URL:            "https://registry.example.com",
+		ScanProvider:   models.ScanProviderArtifactoryXray,
+		XrayRepository: "docker-remote",
+	}
+
+	imageName, _ := NormalizeScanTargetWithXrayRepository("other.example.com/n8nio/n8n", "latest", registry, "")
+	if imageName != "other.example.com/n8nio/n8n" {
+		t.Fatalf("expected non-matching host to be preserved, got %q", imageName)
+	}
+}
+
+func TestNormalizeScanTargetWithXrayRepository_TrivyBehaviorUnchanged(t *testing.T) {
+	registry := &models.Registry{
+		URL:          "https://registry.example.com",
+		ScanProvider: models.ScanProviderTrivy,
+	}
+
+	imageName, _ := NormalizeScanTargetWithXrayRepository("nginx", "latest", registry, "docker-remote")
+	if imageName != "registry.example.com/nginx" {
+		t.Fatalf("expected trivy normalization to stay unchanged, got %q", imageName)
+	}
+}

--- a/services/backend/scanner/xray.go
+++ b/services/backend/scanner/xray.go
@@ -51,6 +51,13 @@ type RegistryXrayTestClient struct {
 	client *xrayClient
 }
 
+type ArtifactoryRepository struct {
+	Key         string `json:"key"`
+	PackageType string `json:"package_type,omitempty"`
+	Class       string `json:"class,omitempty"`
+	Description string `json:"description,omitempty"`
+}
+
 type xrayHTTPError struct {
 	StatusCode int
 	Body       string
@@ -581,9 +588,50 @@ func (c *RegistryXrayTestClient) Ping(ctx context.Context) error {
 	return c.client.ping(ctx)
 }
 
+func (c *RegistryXrayTestClient) ListDockerRepositories(ctx context.Context) ([]ArtifactoryRepository, error) {
+	return c.client.listDockerRepositories(ctx)
+}
+
 func (c *xrayClient) ping(ctx context.Context) error {
 	_, err := c.doJSON(ctx, http.MethodGet, "/xray/api/v1/system/ping", nil, nil, http.StatusOK)
 	return err
+}
+
+func (c *xrayClient) listDockerRepositories(ctx context.Context) ([]ArtifactoryRepository, error) {
+	type artifactoryRepositoryResponse struct {
+		Key         string `json:"key"`
+		PackageType string `json:"packageType"`
+		Class       string `json:"rclass"`
+		Description string `json:"description"`
+	}
+
+	var payload []artifactoryRepositoryResponse
+	body, err := c.doRawJSON(ctx, http.MethodGet, "/artifactory/api/repositories?packageType=docker", nil, "application/json", http.StatusOK)
+	if err != nil {
+		return nil, err
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return nil, fmt.Errorf("failed to parse artifactory repositories: %w", err)
+	}
+
+	repositories := make([]ArtifactoryRepository, 0, len(payload))
+	for _, entry := range payload {
+		if !strings.EqualFold(strings.TrimSpace(entry.PackageType), "docker") {
+			continue
+		}
+		key := strings.Trim(strings.TrimSpace(entry.Key), "/")
+		if key == "" {
+			continue
+		}
+		repositories = append(repositories, ArtifactoryRepository{
+			Key:         key,
+			PackageType: strings.TrimSpace(entry.PackageType),
+			Class:       strings.TrimSpace(entry.Class),
+			Description: strings.TrimSpace(entry.Description),
+		})
+	}
+
+	return repositories, nil
 }
 
 func (c *xrayClient) scanNow(ctx context.Context, repoPath string) error {

--- a/services/frontend/app/(app)/admin/_components/legacy-admin-page.tsx
+++ b/services/frontend/app/(app)/admin/_components/legacy-admin-page.tsx
@@ -4,90 +4,90 @@ import { FormField } from '@/components/ui/form-field';
 import { heroSelectTriggerClassName, nativeFieldClassName } from '@/components/ui/form-styles';
 import { RowActionsMenu } from '@/components/ui/row-actions-menu';
 import {
-  addTagToScan,
-  adminCreateGlobalRegistry,
-  adminCreateGroupMapping,
-  adminCreateOIDCRoleOverride,
-  adminCreateOIDCProvider,
-  adminDeleteGlobalRegistry,
-  adminDeleteGroupMapping,
-  adminDeleteOIDCRoleOverride,
-  adminDeleteOIDCProvider,
-  adminListGlobalRegistries,
-  adminListGroupMappings,
-  adminListOIDCRoleOverrides,
-  adminListOIDCProviders,
-  adminPreviewOIDCClaimSync,
-  AdminScan,
-  adminSetDefaultRegistry,
-  AdminToken,
-  adminUnsetDefaultRegistry,
-  adminUpdateGroupMapping,
-  adminUpdateAuthSettings,
-  adminUpdateOIDCRoleOverride,
-  adminUpdateGlobalRegistry,
-  adminUpdateOIDCProvider,
-  adminUpdateScannerSettings,
-  AdminUser,
-  APIRequestLog,
-  APIRequestLogFilters,
-  APIUsageStats,
-  AuditLog,
-  AuditLogFilters,
-  AutoTagRule,
-  cancelScan,
-  createAdminUser,
-  createAutoTagRule,
-  createNotificationChannel,
-  createShare,
-  deleteAdminToken,
-  deleteAdminUser,
-  deleteAutoTagRule,
-  deleteNotificationChannel,
-  deleteShare,
-  disableAdminUser,
-  getAdminSettings,
-  getAPIUsageStats,
-  getXRayUsageStats,
-  getScannerHealth,
-  listAdminScans,
-  listAdminTokens,
-  listAdminUsers,
-  listAPIRequestLogs,
-  listAuditLogs,
-  listAutoTagRules,
-  listNotificationChannels,
-  listNotificationDeliveries,
-  listOrgs,
-  listTags,
-  listXRayRequestLogs,
-  NotificationChannel,
-  NotificationDelivery,
-  OIDCClaimSyncPreview,
-  OIDCGroupMapping,
-  OIDCOrgRoleOverride,
-  OIDCProviderAdmin,
-  Org,
-  Registry,
-  RegistryWithHealth,
-  reScan,
-  ScannerCapabilities,
-  ScannerHealth,
-  ScannerSettings,
-  setPublicScanEnabled,
-  Tag,
-  testNotificationChannel,
-  updateAdminToken,
-  updateAdminUser,
-  updateAPILogRetention,
-  updateAutoTagRule,
-  updateNotificationChannel,
-  updateRateLimit,
-  updateRegisterRateLimit,
-  updateXRayLogRetention,
-  XRayRequestLog,
-  XRayRequestLogFilters,
-  XRayUsageStats,
+    addTagToScan,
+    adminCreateGlobalRegistry,
+    adminCreateGroupMapping,
+    adminCreateOIDCProvider,
+    adminCreateOIDCRoleOverride,
+    adminDeleteGlobalRegistry,
+    adminDeleteGroupMapping,
+    adminDeleteOIDCProvider,
+    adminDeleteOIDCRoleOverride,
+    adminListGlobalRegistries,
+    adminListGroupMappings,
+    adminListOIDCProviders,
+    adminListOIDCRoleOverrides,
+    adminPreviewOIDCClaimSync,
+    AdminScan,
+    adminSetDefaultRegistry,
+    AdminToken,
+    adminUnsetDefaultRegistry,
+    adminUpdateAuthSettings,
+    adminUpdateGlobalRegistry,
+    adminUpdateGroupMapping,
+    adminUpdateOIDCProvider,
+    adminUpdateOIDCRoleOverride,
+    adminUpdateScannerSettings,
+    AdminUser,
+    APIRequestLog,
+    APIRequestLogFilters,
+    APIUsageStats,
+    AuditLog,
+    AuditLogFilters,
+    AutoTagRule,
+    cancelScan,
+    createAdminUser,
+    createAutoTagRule,
+    createNotificationChannel,
+    createShare,
+    deleteAdminToken,
+    deleteAdminUser,
+    deleteAutoTagRule,
+    deleteNotificationChannel,
+    deleteShare,
+    disableAdminUser,
+    getAdminSettings,
+    getAPIUsageStats,
+    getScannerHealth,
+    getXRayUsageStats,
+    listAdminScans,
+    listAdminTokens,
+    listAdminUsers,
+    listAPIRequestLogs,
+    listAuditLogs,
+    listAutoTagRules,
+    listNotificationChannels,
+    listNotificationDeliveries,
+    listOrgs,
+    listTags,
+    listXRayRequestLogs,
+    NotificationChannel,
+    NotificationDelivery,
+    OIDCClaimSyncPreview,
+    OIDCGroupMapping,
+    OIDCOrgRoleOverride,
+    OIDCProviderAdmin,
+    Org,
+    Registry,
+    RegistryWithHealth,
+    reScan,
+    ScannerCapabilities,
+    ScannerHealth,
+    ScannerSettings,
+    setPublicScanEnabled,
+    Tag,
+    testNotificationChannel,
+    updateAdminToken,
+    updateAdminUser,
+    updateAPILogRetention,
+    updateAutoTagRule,
+    updateNotificationChannel,
+    updateRateLimit,
+    updateRegisterRateLimit,
+    updateXRayLogRetention,
+    XRayRequestLog,
+    XRayRequestLogFilters,
+    XRayUsageStats,
 } from '@/lib/api';
 import { APP_COPYRIGHT, APP_FRONTEND_VERSION } from '@/lib/build-info';
 import { fullDate, timeAgo } from '@/lib/time';
@@ -4691,6 +4691,7 @@ function GlobalRegistriesTab() {
   const [url, setUrl] = useState('');
   const [xrayUrl, setXrayUrl] = useState('');
   const [xrayArtifactoryId, setXrayArtifactoryId] = useState('default');
+  const [xrayRepository, setXrayRepository] = useState('');
   const [authType, setAuthType] = useState<'none' | 'basic' | 'token' | 'aws_ecr'>('none');
   const [scanProvider, setScanProvider] = useState<'trivy' | 'artifactory_xray'>('trivy');
   const [username, setUsername] = useState('');
@@ -4724,6 +4725,7 @@ function GlobalRegistriesTab() {
     setUrl(registry?.url ?? '');
     setXrayUrl(registry?.xray_url ?? '');
     setXrayArtifactoryId(registry?.xray_artifactory_id ?? 'default');
+    setXrayRepository(registry?.xray_repository ?? '');
     setAuthType(registry?.auth_type ?? 'none');
     setScanProvider(registry?.scan_provider ?? (capabilities.enable_trivy ? 'trivy' : 'artifactory_xray'));
     setUsername('');
@@ -4751,6 +4753,7 @@ function GlobalRegistriesTab() {
         url: url.trim(),
         xray_url: scanProvider === 'artifactory_xray' ? xrayUrl.trim() || undefined : undefined,
         xray_artifactory_id: scanProvider === 'artifactory_xray' ? xrayArtifactoryId.trim() || 'default' : undefined,
+        xray_repository: scanProvider === 'artifactory_xray' ? xrayRepository.trim() || undefined : undefined,
         auth_type: authType,
         scan_provider: scanProvider,
         ...(!editingRegistry || username.trim() ? { username: username.trim() } : {}),
@@ -4919,7 +4922,7 @@ function GlobalRegistriesTab() {
                     </div>
                   </div>
                   {scanProvider === 'artifactory_xray' ? (
-                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
                       <div className="space-y-1.5">
                         <label className="text-sm font-medium text-zinc-600 dark:text-zinc-300">Xray URL</label>
                         <input className={inputCls} value={xrayUrl} onChange={(event) => setXrayUrl(event.target.value)} placeholder="https://xray.example.com" />
@@ -4927,6 +4930,11 @@ function GlobalRegistriesTab() {
                       <div className="space-y-1.5">
                         <label className="text-sm font-medium text-zinc-600 dark:text-zinc-300">Artifactory ID</label>
                         <input className={inputCls} value={xrayArtifactoryId} onChange={(event) => setXrayArtifactoryId(event.target.value)} placeholder="default" />
+                      </div>
+                      <div className="space-y-1.5">
+                        <label className="text-sm font-medium text-zinc-600 dark:text-zinc-300">Default Artifactory Repo</label>
+                        <input className={inputCls} value={xrayRepository} onChange={(event) => setXrayRepository(event.target.value)} placeholder="docker-remote" />
+                        <p className="text-xs text-zinc-500">Optional repo key used to prepend Docker Hub-style image names for Xray scans.</p>
                       </div>
                     </div>
                   ) : null}

--- a/services/frontend/app/(app)/registries/page.tsx
+++ b/services/frontend/app/(app)/registries/page.tsx
@@ -65,6 +65,7 @@ export default function RegistriesPage() {
   const [url, setUrl] = useState('');
   const [xrayUrl, setXrayUrl] = useState('');
   const [xrayArtifactoryId, setXrayArtifactoryId] = useState('default');
+  const [xrayRepository, setXrayRepository] = useState('');
   const [authType, setAuthType] = useState<'none' | 'basic' | 'token' | 'aws_ecr'>('none');
   const [scanProvider, setScanProvider] = useState<'trivy' | 'artifactory_xray'>('trivy');
   const [username, setUsername] = useState('');
@@ -99,11 +100,11 @@ export default function RegistriesPage() {
   useEffect(() => { load(); }, [load, scopeKey]);
 
   function openCreate() {
-    setEditing(null); setName(''); setUrl(''); setXrayUrl(''); setXrayArtifactoryId('default'); setAuthType('none'); setScanProvider(capabilities.enable_trivy ? 'trivy' : 'artifactory_xray'); setUsername(''); setPassword(''); setFormError('');
+    setEditing(null); setName(''); setUrl(''); setXrayUrl(''); setXrayArtifactoryId('default'); setXrayRepository(''); setAuthType('none'); setScanProvider(capabilities.enable_trivy ? 'trivy' : 'artifactory_xray'); setUsername(''); setPassword(''); setFormError('');
     modal.open();
   }
   function openEdit(r: RegistryWithHealth) {
-    setEditing(r); setName(r.name); setUrl(r.url); setXrayUrl(r.xray_url ?? ''); setXrayArtifactoryId(r.xray_artifactory_id ?? 'default'); setAuthType(r.auth_type ?? 'none'); setScanProvider(r.scan_provider ?? 'trivy'); setUsername(r.username ?? ''); setPassword(''); setFormError('');
+    setEditing(r); setName(r.name); setUrl(r.url); setXrayUrl(r.xray_url ?? ''); setXrayArtifactoryId(r.xray_artifactory_id ?? 'default'); setXrayRepository(r.xray_repository ?? ''); setAuthType(r.auth_type ?? 'none'); setScanProvider(r.scan_provider ?? 'trivy'); setUsername(r.username ?? ''); setPassword(''); setFormError('');
     modal.open();
   }
   async function handleSubmit(e: React.FormEvent) {
@@ -115,6 +116,7 @@ export default function RegistriesPage() {
         url,
         xray_url: scanProvider === 'artifactory_xray' ? xrayUrl || undefined : undefined,
         xray_artifactory_id: scanProvider === 'artifactory_xray' ? xrayArtifactoryId || 'default' : undefined,
+        xray_repository: scanProvider === 'artifactory_xray' ? xrayRepository.trim() || undefined : undefined,
         auth_type: authType,
         scan_provider: scanProvider,
         username,
@@ -385,6 +387,14 @@ export default function RegistriesPage() {
                         onChange={(e) => setXrayArtifactoryId(e.target.value)}
                         placeholder="default"
                         value={xrayArtifactoryId}
+                      />
+                      <FormField
+                        className="font-mono"
+                        description="Optional default Docker repo key for this registry, for example docker-remote. JustScan will prepend it for Xray scans when users enter Docker Hub-style image names."
+                        label="Default Artifactory Repo"
+                        onChange={(e) => setXrayRepository(e.target.value)}
+                        placeholder="docker-remote"
+                        value={xrayRepository}
                       />
                     </>
                   )}

--- a/services/frontend/app/(app)/scans/page.tsx
+++ b/services/frontend/app/(app)/scans/page.tsx
@@ -12,32 +12,35 @@ import { useConditionalInterval } from '@/hooks/use-conditional-interval';
 import { useOrgNameMap } from '@/hooks/use-org-name-map';
 import { useWorkScope } from '@/hooks/use-work-scope';
 import {
-    cancelScan,
-    createScans,
-    deleteScan,
-    getDefaultScannerCapabilities,
-    getWorkScope,
-    ImageSummary,
-    listRegistriesWithCapabilities,
-    listScanImages,
-    listTags,
-    RegistryWithHealth,
-    ScannerCapabilities,
-    Tag
+  ArtifactoryRepository,
+  cancelScan,
+  createScans,
+  deleteScan,
+  getDefaultScannerCapabilities,
+  getWorkScope,
+  ImageSummary,
+  listArtifactoryRepositories,
+  listRegistriesWithCapabilities,
+  listScanImages,
+  listTags,
+  RegistryWithHealth,
+  ScannerCapabilities,
+  Tag
 } from '@/lib/api';
 import { fullDate, timeAgo } from '@/lib/time';
-import { Checkbox, ListBox, Modal, Popover, Select, useOverlayState } from '@heroui/react';
+import { Autocomplete, Checkbox, ListBox, Modal, Popover, SearchField, Select, useFilter, useOverlayState } from '@heroui/react';
 import {
-    ArrowDown01Icon,
-    ArrowRight01Icon,
-    Cancel01Icon,
-    FilterIcon,
-    GitCompareIcon,
-    PlusSignIcon,
-    Shield01Icon,
+  ArrowDown01Icon,
+  ArrowRight01Icon,
+  Cancel01Icon,
+  FilterIcon,
+  GitCompareIcon,
+  PlusSignIcon,
+  Shield01Icon,
 } from 'hugeicons-react';
 import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
+import type { Key } from 'react';
 import { Fragment, useCallback, useEffect, useRef, useState } from 'react';
 
 const inputCls = nativeFieldClassName;
@@ -123,8 +126,97 @@ function MobileSevStat({ label, count, tone }: { label: string; count: number; t
   );
 }
 
+type ScanSourceKind = 'public' | 'private_registry' | 'artifactory_xray';
+
+const SCAN_WIZARD_STEPS = [
+  { id: 'source', label: 'Source' },
+  { id: 'routing', label: 'Routing' },
+  { id: 'details', label: 'Details' },
+  { id: 'review', label: 'Review & start' },
+] as const;
+
+function ScanWizardStep({ active, complete, index, label }: { active: boolean; complete: boolean; index: number; label: string }) {
+  return (
+    <div
+      className="rounded-2xl px-3 py-2.5 transition-all"
+      style={{
+        background: active ? 'linear-gradient(145deg, rgba(124,58,237,0.14) 0%, rgba(124,58,237,0.08) 100%)' : 'var(--row-hover)',
+        border: active ? '1px solid rgba(167,139,250,0.3)' : '1px solid var(--glass-border)',
+        boxShadow: active ? '0 10px 26px rgba(124,58,237,0.12)' : 'none',
+      }}
+    >
+      <div className="flex items-center gap-3">
+        <span
+          className="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-[11px] font-semibold"
+          style={{
+            background: complete || active ? 'rgba(124,58,237,0.18)' : 'rgba(148,163,184,0.12)',
+            color: complete || active ? '#8b5cf6' : '#94a3b8',
+            border: complete || active ? '1px solid rgba(167,139,250,0.28)' : '1px solid rgba(148,163,184,0.18)',
+          }}
+        >
+          {complete ? '✓' : index + 1}
+        </span>
+        <div className="min-w-0">
+          <p className="text-[10px] uppercase tracking-[0.18em] text-zinc-500">Step {index + 1}</p>
+          <p className="truncate text-sm font-medium text-zinc-800 dark:text-zinc-200">{label}</p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ScanSourceCard({
+  description,
+  disabled = false,
+  eyebrow,
+  onClick,
+  selected,
+  title,
+}: {
+  description: string;
+  disabled?: boolean;
+  eyebrow: string;
+  onClick: () => void;
+  selected: boolean;
+  title: string;
+}) {
+  return (
+    <button
+      aria-pressed={selected}
+      className="rounded-[22px] p-4 text-left transition-all duration-150 disabled:cursor-not-allowed disabled:opacity-60"
+      disabled={disabled}
+      onClick={onClick}
+      type="button"
+      style={{
+        background: selected ? 'linear-gradient(145deg, rgba(124,58,237,0.16) 0%, rgba(124,58,237,0.08) 100%)' : 'var(--row-hover)',
+        border: selected ? '1px solid rgba(167,139,250,0.32)' : '1px solid var(--glass-border)',
+        boxShadow: selected ? '0 12px 28px rgba(124,58,237,0.12)' : 'none',
+      }}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <p className="text-[10px] uppercase tracking-[0.2em] text-violet-500">{eyebrow}</p>
+          <p className="mt-2 text-base font-semibold text-zinc-900 dark:text-white">{title}</p>
+          <p className="mt-2 text-sm leading-6 text-zinc-600 dark:text-zinc-300">{description}</p>
+        </div>
+        <span
+          className="mt-0.5 inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-[11px] font-semibold"
+          style={{
+            background: selected ? 'rgba(124,58,237,0.18)' : 'rgba(148,163,184,0.12)',
+            color: selected ? '#8b5cf6' : '#94a3b8',
+            border: selected ? '1px solid rgba(167,139,250,0.28)' : '1px solid rgba(148,163,184,0.18)',
+          }}
+        >
+          {selected ? '✓' : ''}
+        </span>
+      </div>
+    </button>
+  );
+}
+
 // ── Main page ─────────────────────────────────────────────────────────
 export default function ScansPage() {
+  const { contains } = useFilter({ sensitivity: 'base' });
   const router = useRouter();
   const searchParams = useSearchParams();
   const toast = useToast();
@@ -160,8 +252,16 @@ export default function ScansPage() {
   const [imageTag, setImageTag] = useState('latest');
   const [additionalImageDraft, setAdditionalImageDraft] = useState('');
   const [additionalImageEntries, setAdditionalImageEntries] = useState<string[]>([]);
+  const [scanSource, setScanSource] = useState<ScanSourceKind | null>(null);
+  const [scanStepIndex, setScanStepIndex] = useState(0);
+  const [advancedOptionsOpen, setAdvancedOptionsOpen] = useState(false);
   const [platform, setPlatform] = useState('');
   const [registryId, setRegistryId] = useState('');
+  const [xrayRepository, setXrayRepository] = useState('');
+  const [useManualXrayRepository, setUseManualXrayRepository] = useState(false);
+  const [artifactoryRepositoriesByRegistry, setArtifactoryRepositoriesByRegistry] = useState<Record<string, ArtifactoryRepository[]>>({});
+  const [artifactoryRepositoriesLoading, setArtifactoryRepositoriesLoading] = useState<string | null>(null);
+  const [artifactoryRepositoriesErrorByRegistry, setArtifactoryRepositoriesErrorByRegistry] = useState<Record<string, string>>({});
   const [creating, setCreating] = useState(false);
   const [createError, setCreateError] = useState('');
 
@@ -207,13 +307,187 @@ export default function ScansPage() {
   }, [scopeKey]);
 
   const selectableRegistries = registries.filter((registry) => registry.scan_provider === 'artifactory_xray' || capabilities.enable_trivy);
+  const privateRegistries = selectableRegistries.filter((registry) => registry.scan_provider !== 'artifactory_xray');
+  const xrayRegistries = registries.filter((registry) => registry.scan_provider === 'artifactory_xray');
+
   const xrayOnlyWithoutRegistries = !capabilities.enable_trivy && selectableRegistries.length === 0;
   const pendingAdditionalImages = parseImageReferences(additionalImageDraft);
+  const primaryImage = imageName.trim() ? `${imageName.trim()}${imageTag.trim() ? `:${imageTag.trim()}` : ''}` : '';
+  const requestedImages = mergeUniqueStringLists(
+    primaryImage ? [primaryImage] : [],
+    additionalImageEntries,
+    pendingAdditionalImages,
+  );
+  const selectedRegistry = registries.find((registry) => registry.id === registryId) ?? null;
+  const selectedRegistryIsXray = scanSource === 'artifactory_xray' && selectedRegistry?.scan_provider === 'artifactory_xray';
+  const selectedRegistryRepositories = selectedRegistry ? artifactoryRepositoriesByRegistry[selectedRegistry.id] ?? [] : [];
+  const selectedRegistryRepositoriesError = selectedRegistry ? artifactoryRepositoriesErrorByRegistry[selectedRegistry.id] ?? '' : '';
+  const xrayRepositoryAutocompleteValue = useManualXrayRepository || (xrayRepository && !selectedRegistryRepositories.some((repository) => repository.key === xrayRepository))
+    ? '__manual__'
+    : xrayRepository || '__none__';
+  const detailsStepTitle = scanSource === 'artifactory_xray'
+    ? 'What image should Xray analyze?'
+    : scanSource === 'private_registry'
+      ? 'What image should JustScan pull?'
+      : 'What image should JustScan scan?';
+  const detailsStepDescription = scanSource === 'artifactory_xray'
+    ? 'Keep this step focused on the image reference. We will ask about registry routing and Artifactory repo in the next step.'
+    : scanSource === 'private_registry'
+      ? 'Enter the image reference first. The private registry routing comes in the next step.'
+      : 'Enter the image reference first. Public scans do not need any registry routing after this.';
+  const routingStepTitle = scanSource === 'artifactory_xray'
+    ? 'Where inside Artifactory should this image resolve?'
+    : scanSource === 'private_registry'
+      ? 'Which private registry hosts this image?'
+      : 'No routing setup is needed';
+  const routingStepDescription = scanSource === 'artifactory_xray'
+    ? 'Choose the Xray-backed registry first, then optionally override the Artifactory repo key for mirrors or remotes.'
+    : scanSource === 'private_registry'
+      ? 'Choose the configured private registry that should authenticate and pull this image.'
+      : 'This image will be scanned directly from its public source.';
+
+  function resetCreateForm() {
+    setScanSource(null);
+    setScanStepIndex(0);
+    setCreateError('');
+    setCreating(false);
+    setImageName('');
+    setImageTag('latest');
+    setAdditionalImageDraft('');
+    setAdditionalImageEntries([]);
+    setAdvancedOptionsOpen(false);
+    setPlatform('');
+    setRegistryId('');
+    setXrayRepository('');
+    setUseManualXrayRepository(false);
+  }
+
+  function openCreateModal() {
+    resetCreateForm();
+    modal.open();
+  }
+
+  function selectScanSource(source: ScanSourceKind) {
+    setScanSource(source);
+    setCreateError('');
+    if (source === 'public') {
+      setRegistryId('');
+      setXrayRepository('');
+      setUseManualXrayRepository(false);
+    } else if (source === 'private_registry') {
+      const nextRegistry = privateRegistries.find((registry) => registry.id === registryId)
+        ?? privateRegistries.find((registry) => registry.is_default)
+        ?? privateRegistries[0]
+        ?? null;
+      setRegistryId(nextRegistry?.id ?? '');
+      setXrayRepository('');
+      setUseManualXrayRepository(false);
+    } else {
+      const nextRegistry = xrayRegistries.find((registry) => registry.id === registryId)
+        ?? xrayRegistries.find((registry) => registry.is_default)
+        ?? xrayRegistries[0]
+        ?? null;
+      setRegistryId(nextRegistry?.id ?? '');
+      setXrayRepository(nextRegistry?.xray_repository ?? '');
+      setUseManualXrayRepository(false);
+    }
+    setScanStepIndex(1);
+  }
+
+  function validateWizardStep(stepIndex: number) {
+    if (stepIndex === 0) {
+      if (!scanSource) {
+        return 'Choose where this image is hosted to continue.';
+      }
+      if (scanSource === 'public' && !capabilities.enable_trivy) {
+        return 'Public Docker Hub scans are unavailable in this deployment.';
+      }
+      if (scanSource === 'private_registry' && !capabilities.enable_trivy) {
+        return 'Private registry scans are unavailable because local Trivy scanning is disabled.';
+      }
+      if (scanSource === 'private_registry' && privateRegistries.length === 0) {
+        return 'Add a private registry first, or choose a different source.';
+      }
+      if (scanSource === 'artifactory_xray' && xrayRegistries.length === 0) {
+        return 'Add an Artifactory Xray registry first, or choose a different source.';
+      }
+      return '';
+    }
+
+    if (stepIndex >= 1) {
+      if (scanSource === 'private_registry' && !registryId) {
+        return 'Choose the private registry that hosts this image.';
+      }
+      if (scanSource === 'artifactory_xray' && !registryId) {
+        return 'Choose the Artifactory registry that should route this scan.';
+      }
+    }
+
+    if (stepIndex >= 2 && requestedImages.length === 0) {
+      return 'Provide at least one image to scan.';
+    }
+
+    return '';
+  }
+
+  function handleWizardNext() {
+    const validationError = validateWizardStep(scanStepIndex);
+    if (validationError) {
+      setCreateError(validationError);
+      return;
+    }
+    setCreateError('');
+    setScanStepIndex((current) => Math.min(current + 1, SCAN_WIZARD_STEPS.length - 1));
+  }
+
+  function handleWizardBack() {
+    setCreateError('');
+    setScanStepIndex((current) => Math.max(current - 1, 0));
+  }
+
+  useEffect(() => {
+    if (!selectedRegistryIsXray || !selectedRegistry) {
+      setXrayRepository('');
+      setUseManualXrayRepository(false);
+      return;
+    }
+
+    setXrayRepository(selectedRegistry.xray_repository ?? '');
+    setUseManualXrayRepository(false);
+
+    if (artifactoryRepositoriesByRegistry[selectedRegistry.id] || artifactoryRepositoriesLoading === selectedRegistry.id) {
+      return;
+    }
+
+    setArtifactoryRepositoriesLoading(selectedRegistry.id);
+    setArtifactoryRepositoriesErrorByRegistry((previous) => {
+      const next = { ...previous };
+      delete next[selectedRegistry.id];
+      return next;
+    });
+
+    void listArtifactoryRepositories(selectedRegistry.id)
+      .then((repositories) => {
+        setArtifactoryRepositoriesByRegistry((previous) => ({
+          ...previous,
+          [selectedRegistry.id]: repositories,
+        }));
+      })
+      .catch((repositoryError: unknown) => {
+        setArtifactoryRepositoriesErrorByRegistry((previous) => ({
+          ...previous,
+          [selectedRegistry.id]: repositoryError instanceof Error ? repositoryError.message : 'Failed to load Artifactory repositories',
+        }));
+      })
+      .finally(() => {
+        setArtifactoryRepositoriesLoading((current) => (current === selectedRegistry.id ? null : current));
+      });
+  }, [artifactoryRepositoriesByRegistry, artifactoryRepositoriesLoading, selectedRegistry, selectedRegistryIsXray]);
 
   // Auto-open new scan modal when navigated from sidebar CTA (?new=1)
   useEffect(() => {
     if (searchParams.get('new') === '1') {
-      modal.open();
+      openCreateModal();
       router.replace('/scans');
     }
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
@@ -272,30 +546,25 @@ export default function ScansPage() {
         return;
       }
 
-      const primaryImage = imageName.trim() ? `${imageName.trim()}${imageTag.trim() ? `:${imageTag.trim()}` : ''}` : '';
-      const requestedImages = mergeUniqueStringLists(
-        primaryImage ? [primaryImage] : [],
-        additionalImageEntries,
-        pendingAdditionalImages,
-      );
-
-      if (requestedImages.length === 0) {
-        setCreateError('Provide at least one image to scan');
+      const validationError = validateWizardStep(3);
+      if (validationError) {
+        setCreateError(validationError);
         return;
       }
 
       const currentScope = getWorkScope();
       const result = await createScans(
         requestedImages,
-        registryId || undefined,
+        scanSource === 'public' ? undefined : registryId || undefined,
         undefined,
         platform || undefined,
         currentScope.kind === 'org' ? currentScope.orgId : undefined,
+        selectedRegistryIsXray ? xrayRepository.trim() || undefined : undefined,
       );
       const createdScans = Array.isArray(result.scans) ? result.scans : [];
 
       modal.close();
-      setImageName(''); setImageTag('latest'); setAdditionalImageDraft(''); setAdditionalImageEntries([]); setPlatform(''); setRegistryId('');
+      resetCreateForm();
       toast.success(`${createdScans.length} image${createdScans.length === 1 ? '' : 's'} queued`);
       setExpanded(prev => {
         const next = new Set(prev);
@@ -403,7 +672,7 @@ export default function ScansPage() {
             Compare
           </Link>
           <button
-            onClick={modal.open}
+            onClick={openCreateModal}
             className="btn-primary flex flex-1 min-w-[130px] items-center justify-center gap-2 sm:flex-none"
           >
             <PlusSignIcon size={15} />
@@ -546,7 +815,7 @@ export default function ScansPage() {
             icon={<Shield01Icon size={28} />}
             title={imageFilter ? 'No images match your filter' : 'No scans yet'}
             description={imageFilter ? 'Try a different search term or clear the filter.' : 'Scan a Docker image to discover vulnerabilities, SBOMs, and more.'}
-            action={imageFilter ? undefined : { label: '+ New Scan', onClick: modal.open }}
+            action={imageFilter ? undefined : { label: '+ New Scan', onClick: openCreateModal }}
           />
         ) : (
           images.map((img) => {
@@ -675,7 +944,7 @@ export default function ScansPage() {
                     icon={<Shield01Icon size={28} />}
                     title={imageFilter ? 'No images match your filter' : 'No scans yet'}
                     description={imageFilter ? 'Try a different search term or clear the filter.' : 'Scan a Docker image to discover vulnerabilities, SBOMs, and more.'}
-                    action={imageFilter ? undefined : { label: '+ New Scan', onClick: modal.open }}
+                    action={imageFilter ? undefined : { label: '+ New Scan', onClick: openCreateModal }}
                   />
                 </td>
               </tr>
@@ -821,8 +1090,8 @@ export default function ScansPage() {
       {/* Create scan modal */}
       <Modal state={modal}>
         <Modal.Backdrop isDismissable>
-          <Modal.Container size="md" placement="center">
-            <Modal.Dialog className="glass-modal rounded-2xl overflow-hidden">
+          <Modal.Container size="lg" placement="center">
+            <Modal.Dialog className="glass-modal w-[min(94vw,72rem)] max-w-none rounded-2xl overflow-hidden">
               <Modal.Header className="px-6 py-4" style={{ borderBottom: '1px solid var(--border-subtle)' }}>
                 <Modal.Heading className="text-zinc-900 dark:text-white font-semibold">New Scan</Modal.Heading>
                 <Modal.CloseTrigger className="text-zinc-500 hover:text-zinc-700 dark:hover:text-zinc-300" />
@@ -830,130 +1099,427 @@ export default function ScansPage() {
               <Modal.Body className="px-6 py-5">
                 <form id="create-scan-form" onSubmit={handleCreate} className="space-y-4">
                   {createError ? <FormAlert description={createError} title="Scan creation failed" /> : null}
-                  <FormField className="font-mono" label="Image Name" onChange={e => setImageName(e.target.value)} placeholder="nginx" value={imageName} />
-                  <FormField className="font-mono" label="Tag" onChange={e => setImageTag(e.target.value)} placeholder="latest" required value={imageTag} />
-                  <div className="space-y-1.5">
-                    <label className="text-sm font-medium text-zinc-600 dark:text-zinc-300">
-                      Additional Images <span className="text-zinc-400 dark:text-zinc-600 font-normal">(optional)</span>
-                    </label>
-                    <textarea
-                      className={joinClassNames(inputCls, 'min-h-24 font-mono resize-y')}
-                      placeholder={'Paste one or more full image references here\nExample: ghcr.io/example/api:1.2.3, registry.example.com/team/worker:latest'}
-                      value={additionalImageDraft}
-                      onChange={e => setAdditionalImageDraft(e.target.value)}
-                    />
-                    <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-                      <p className="text-xs text-zinc-500">
-                        Paste one or many full image references, separated by commas or new lines. Anything still in this box is included when you start the scan.
-                      </p>
-                      <button
-                        className="btn-secondary-sm shrink-0"
-                        onClick={addAdditionalImagesFromDraft}
-                        type="button"
-                      >
-                        Add {pendingAdditionalImages.length > 1 ? `${pendingAdditionalImages.length} refs` : 'to list'}
-                      </button>
-                    </div>
-                    {additionalImageEntries.length > 0 ? (
-                      <div className="rounded-2xl p-3" style={{ background: 'var(--row-hover)', border: '1px solid var(--glass-border)' }}>
-                        <div className="flex items-center justify-between gap-3">
-                          <p className="text-xs font-medium uppercase tracking-[0.18em] text-zinc-500">Queued additional images</p>
-                          <span className="rounded-full px-2 py-0.5 text-xs font-medium text-zinc-500" style={{ background: 'rgba(255,255,255,0.05)', border: '1px solid var(--glass-border)' }}>
-                            {additionalImageEntries.length}
-                          </span>
-                        </div>
-                        <div className="mt-3 space-y-2 max-h-40 overflow-y-auto pr-1">
-                          {additionalImageEntries.map((image) => (
-                            <div key={image} className="flex items-start justify-between gap-3 rounded-xl px-3 py-2" style={{ background: 'rgba(255,255,255,0.03)', border: '1px solid var(--glass-border)' }}>
-                              <span className="min-w-0 break-all font-mono text-xs text-zinc-600 dark:text-zinc-300">{image}</span>
-                              <button
-                                aria-label={`Remove ${image}`}
-                                className="btn-icon-subtle h-8 w-8 shrink-0 rounded-lg"
-                                onClick={() => removeAdditionalImageEntry(image)}
-                                type="button"
-                              >
-                                <Cancel01Icon aria-hidden size={14} />
-                              </button>
-                            </div>
-                          ))}
-                        </div>
+                  <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
+                    {SCAN_WIZARD_STEPS.map((step, index) => (
+                      <ScanWizardStep
+                        key={step.id}
+                        active={index === scanStepIndex}
+                        complete={index < scanStepIndex}
+                        index={index}
+                        label={step.label}
+                      />
+                    ))}
+                  </div>
+
+                  {scanStepIndex === 0 ? (
+                    <div className="space-y-5">
+                      <div className="space-y-2">
+                        <p className="text-[11px] uppercase tracking-[0.22em] text-violet-500">Step 1</p>
+                        <h2 className="text-2xl font-semibold tracking-tight text-zinc-900 dark:text-white">Where is this image hosted?</h2>
+                        <p className="text-sm leading-7 text-zinc-600 dark:text-zinc-300">
+                          Start with the source, then JustScan will only ask for the routing details that matter for that path.
+                        </p>
                       </div>
-                    ) : null}
-                    <p className="text-xs text-zinc-500">
-                      Use Image Name and Tag for the primary image. Untagged full references default to <span className="font-mono">latest</span>.
-                    </p>
-                  </div>
-                  <div className="space-y-1.5">
-                    <label className="text-sm font-medium text-zinc-600 dark:text-zinc-300">
-                      Registry <span className="text-zinc-400 dark:text-zinc-600 font-normal">(optional)</span>
-                    </label>
-                    <Select selectedKey={registryId || '__auto__'} onSelectionChange={k => setRegistryId(String(k === '__auto__' ? '' : k))}>
-                      <Select.Trigger className={selectTriggerCls}>
-                        <Select.Value />
-                        <Select.Indicator />
-                      </Select.Trigger>
-                      <Select.Popover>
-                        <ListBox>
-                          <ListBox.Item id="__auto__">{capabilities.enable_trivy ? 'Auto-match from image hostname' : 'Auto-match from configured Xray registries'}</ListBox.Item>
-                          {selectableRegistries.map(registry => (
-                            <ListBox.Item key={registry.id} id={registry.id}>
-                              {registry.name} · {PROVIDER_LABEL[registry.scan_provider] ?? registry.scan_provider}
-                            </ListBox.Item>
-                          ))}
-                        </ListBox>
-                      </Select.Popover>
-                    </Select>
-                    <p className="text-xs text-zinc-500">
-                      {capabilities.enable_trivy
-                        ? 'Leave this empty to let JustScan match a registry automatically from the image hostname.'
-                        : 'Auto-match only considers registries configured for Artifactory Xray.'}
-                    </p>
-                    {xrayOnlyWithoutRegistries && (
-                      <p className="text-xs" style={{ color: '#f87171' }}>No Xray-backed registry is available for this deployment yet.</p>
-                    )}
-                  </div>
-                  <div className="space-y-1.5">
-                    <label className="text-sm font-medium text-zinc-600 dark:text-zinc-300">
-                      Platform <span className="text-zinc-400 dark:text-zinc-600 font-normal">(optional)</span>
-                    </label>
-                    <Select selectedKey={platform || '__auto__'} onSelectionChange={k => setPlatform(String(k === '__auto__' ? '' : k))}>
-                      <Select.Trigger className={selectTriggerCls}>
-                        <Select.Value />
-                        <Select.Indicator />
-                      </Select.Trigger>
-                      <Select.Popover>
-                        <ListBox>
-                          <ListBox.Item id="__auto__">Auto-detect</ListBox.Item>
-                          <ListBox.Item id="linux/amd64">linux/amd64</ListBox.Item>
-                          <ListBox.Item id="linux/arm64">linux/arm64</ListBox.Item>
-                          <ListBox.Item id="linux/arm/v7">linux/arm/v7</ListBox.Item>
-                          <ListBox.Item id="linux/arm/v6">linux/arm/v6</ListBox.Item>
-                          <ListBox.Item id="linux/386">linux/386</ListBox.Item>
-                          <ListBox.Item id="linux/s390x">linux/s390x</ListBox.Item>
-                          <ListBox.Item id="linux/ppc64le">linux/ppc64le</ListBox.Item>
-                          <ListBox.Item id="windows/amd64">windows/amd64</ListBox.Item>
-                        </ListBox>
-                      </Select.Popover>
-                    </Select>
-                  </div>
-                  <p className="text-xs text-zinc-500">Tags can be added from the scan detail page after creation.</p>
+
+                      <div className="grid gap-3">
+                        <ScanSourceCard
+                          description={capabilities.enable_trivy ? 'Scan public images like nginx or n8nio/n8n directly without choosing a registry first.' : 'Unavailable because local Trivy scanning is disabled in this deployment.'}
+                          disabled={!capabilities.enable_trivy}
+                          eyebrow="Public"
+                          onClick={() => selectScanSource('public')}
+                          selected={scanSource === 'public'}
+                          title="Public / Docker Hub"
+                        />
+                        <ScanSourceCard
+                          description={capabilities.enable_trivy ? (privateRegistries.length > 0 ? 'Use one of your configured private registries and keep the image field focused on what you want to scan.' : 'Unavailable until you configure at least one private registry.') : 'Unavailable because local Trivy scanning is disabled in this deployment.'}
+                          disabled={!capabilities.enable_trivy || privateRegistries.length === 0}
+                          eyebrow="Private"
+                          onClick={() => selectScanSource('private_registry')}
+                          selected={scanSource === 'private_registry'}
+                          title="Private registry"
+                        />
+                        <ScanSourceCard
+                          description={xrayRegistries.length > 0 ? 'Route scans through Artifactory Xray and add the Artifactory repo only when this path needs it.' : 'Unavailable until you configure at least one Artifactory Xray registry.'}
+                          disabled={xrayRegistries.length === 0}
+                          eyebrow="Xray"
+                          onClick={() => selectScanSource('artifactory_xray')}
+                          selected={scanSource === 'artifactory_xray'}
+                          title="Artifactory Xray"
+                        />
+                      </div>
+                    </div>
+                  ) : null}
+
+                  {scanStepIndex === 1 ? (
+                    <div className="space-y-5">
+                      <div className="space-y-2">
+                        <p className="text-[11px] uppercase tracking-[0.22em] text-violet-500">Step 2</p>
+                        <h2 className="text-2xl font-semibold tracking-tight text-zinc-900 dark:text-white">{routingStepTitle}</h2>
+                        <p className="text-sm leading-7 text-zinc-600 dark:text-zinc-300">{routingStepDescription}</p>
+                      </div>
+
+                      <div className="rounded-[24px] p-4" style={{ background: 'var(--row-hover)', border: '1px solid var(--glass-border)' }}>
+                        <p className="text-[11px] uppercase tracking-[0.18em] text-violet-500">Selected source</p>
+                        <p className="mt-2 text-sm font-medium text-zinc-800 dark:text-zinc-200">
+                          {scanSource === 'artifactory_xray' ? 'Artifactory Xray' : scanSource === 'private_registry' ? 'Private registry' : 'Public / Docker Hub'}
+                        </p>
+                      </div>
+
+                      {scanSource === 'public' ? (
+                        <div className="rounded-[24px] p-5" style={{ background: 'var(--row-hover)', border: '1px solid var(--glass-border)' }}>
+                          <p className="text-[11px] uppercase tracking-[0.18em] text-violet-500">Public image</p>
+                          <p className="mt-2 text-base font-semibold text-zinc-900 dark:text-white">No registry or repo selection needed</p>
+                          <p className="mt-2 text-sm leading-7 text-zinc-600 dark:text-zinc-300">
+                            JustScan will use the image reference from the next step exactly as entered.
+                          </p>
+                        </div>
+                      ) : null}
+
+                      {scanSource === 'private_registry' ? (
+                        <div className="space-y-1.5 rounded-[24px] p-5" style={{ background: 'var(--row-hover)', border: '1px solid var(--glass-border)' }}>
+                          <label className="text-sm font-medium text-zinc-600 dark:text-zinc-300">Private registry</label>
+                          <Select selectedKey={registryId || '__none__'} onSelectionChange={key => setRegistryId(String(key === '__none__' ? '' : key))}>
+                            <Select.Trigger className={selectTriggerCls}>
+                              <Select.Value />
+                              <Select.Indicator />
+                            </Select.Trigger>
+                            <Select.Popover>
+                              <ListBox>
+                                {privateRegistries.map((registry) => (
+                                  <ListBox.Item key={registry.id} id={registry.id}>
+                                    {registry.name}
+                                  </ListBox.Item>
+                                ))}
+                              </ListBox>
+                            </Select.Popover>
+                          </Select>
+                          <p className="text-xs text-zinc-500">Choose the configured registry that hosts this image so JustScan can authenticate and pull it correctly.</p>
+                        </div>
+                      ) : null}
+
+                      {scanSource === 'artifactory_xray' ? (
+                        <div className="space-y-4">
+                          <div className="space-y-1.5 rounded-[24px] p-5" style={{ background: 'var(--row-hover)', border: '1px solid var(--glass-border)' }}>
+                            <label className="text-sm font-medium text-zinc-600 dark:text-zinc-300">Artifactory registry</label>
+                            <Select selectedKey={registryId || '__none__'} onSelectionChange={key => setRegistryId(String(key === '__none__' ? '' : key))}>
+                              <Select.Trigger className={selectTriggerCls}>
+                                <Select.Value />
+                                <Select.Indicator />
+                              </Select.Trigger>
+                              <Select.Popover>
+                                <ListBox>
+                                  {xrayRegistries.map((registry) => (
+                                    <ListBox.Item key={registry.id} id={registry.id}>
+                                      {registry.name}
+                                    </ListBox.Item>
+                                  ))}
+                                </ListBox>
+                              </Select.Popover>
+                            </Select>
+                            <p className="text-xs text-zinc-500">Choose the Xray-backed registry that should resolve and analyze this image.</p>
+                          </div>
+
+                          <div className="space-y-1.5 rounded-[24px] p-5" style={{ background: 'var(--row-hover)', border: '1px solid var(--glass-border)' }}>
+                            <label className="text-sm font-medium text-zinc-600 dark:text-zinc-300">
+                              Artifactory Repo <span className="text-zinc-400 dark:text-zinc-600 font-normal">(optional override)</span>
+                            </label>
+                            <Autocomplete
+                              value={xrayRepositoryAutocompleteValue}
+                              onChange={(key: Key | null) => {
+                                const value = String(key ?? '__none__');
+                                if (value === '__manual__') {
+                                  setUseManualXrayRepository(true);
+                                  return;
+                                }
+                                setUseManualXrayRepository(false);
+                                setXrayRepository(value === '__none__' ? '' : value);
+                              }}
+                            >
+                              <Autocomplete.Trigger className={selectTriggerCls}>
+                                <Autocomplete.Value />
+                                <Autocomplete.ClearButton />
+                                <Autocomplete.Indicator />
+                              </Autocomplete.Trigger>
+                              <Autocomplete.Popover>
+                                <Autocomplete.Filter filter={contains}>
+                                  <SearchField autoFocus name="artifactory-repo-search" variant="secondary">
+                                    <SearchField.Group>
+                                      <SearchField.SearchIcon />
+                                      <SearchField.Input placeholder="Search Artifactory repos..." />
+                                      <SearchField.ClearButton />
+                                    </SearchField.Group>
+                                  </SearchField>
+                                  <ListBox renderEmptyState={() => <div className="px-3 py-2 text-sm text-zinc-500">No matching repositories</div>}>
+                                    <ListBox.Item id="__none__" textValue="No repo override">
+                                      No repo override
+                                    </ListBox.Item>
+                                    {selectedRegistryRepositories.map((repository) => (
+                                      <ListBox.Item key={repository.key} id={repository.key} textValue={`${repository.key} ${repository.class ?? ''}`.trim()}>
+                                        {repository.key}{repository.class ? ` · ${repository.class}` : ''}
+                                      </ListBox.Item>
+                                    ))}
+                                    <ListBox.Item id="__manual__" textValue="Enter manually">
+                                      Enter manually
+                                    </ListBox.Item>
+                                  </ListBox>
+                                </Autocomplete.Filter>
+                              </Autocomplete.Popover>
+                            </Autocomplete>
+                            <p className="text-xs text-zinc-500">
+                              Pick a repo like <span className="font-mono">docker-remote</span> so you can scan <span className="font-mono">n8nio/n8n</span> instead of typing <span className="font-mono">docker-remote/n8nio/n8n</span>.
+                            </p>
+                            {selectedRegistry && artifactoryRepositoriesLoading === selectedRegistry.id ? (
+                              <p className="text-xs text-zinc-500">Loading available Artifactory repos…</p>
+                            ) : null}
+                            {selectedRegistryRepositoriesError ? (
+                              <p className="text-xs" style={{ color: '#f59e0b' }}>
+                                {selectedRegistryRepositoriesError}. You can still enter the repo manually.
+                              </p>
+                            ) : null}
+                            {(useManualXrayRepository || !!selectedRegistryRepositoriesError) ? (
+                              <FormField
+                                className="font-mono"
+                                description="Manual fallback when the repo list is unavailable or you need a repo key that is not listed."
+                                label="Manual Artifactory Repo"
+                                onChange={(event) => setXrayRepository(event.target.value)}
+                                placeholder="docker-remote"
+                                value={xrayRepository}
+                              />
+                            ) : null}
+                          </div>
+                        </div>
+                      ) : null}
+                    </div>
+                  ) : null}
+
+                  {scanStepIndex === 2 ? (
+                    <div className="space-y-5">
+                      <div className="space-y-2">
+                        <p className="text-[11px] uppercase tracking-[0.22em] text-violet-500">Step 3</p>
+                        <h2 className="text-2xl font-semibold tracking-tight text-zinc-900 dark:text-white">{detailsStepTitle}</h2>
+                        <p className="text-sm leading-7 text-zinc-600 dark:text-zinc-300">{detailsStepDescription}</p>
+                      </div>
+
+                      <div className="rounded-[24px] p-4" style={{ background: 'var(--row-hover)', border: '1px solid var(--glass-border)' }}>
+                        <p className="text-[11px] uppercase tracking-[0.18em] text-violet-500">Selected source</p>
+                        <p className="mt-2 text-sm font-medium text-zinc-800 dark:text-zinc-200">
+                          {scanSource === 'artifactory_xray' ? 'Artifactory Xray' : scanSource === 'private_registry' ? 'Private registry' : 'Public / Docker Hub'}
+                        </p>
+                      </div>
+
+                      <FormField className="font-mono" label="Image Name" onChange={e => setImageName(e.target.value)} placeholder="nginx or n8nio/n8n" value={imageName} />
+                      <FormField className="font-mono" label="Tag" onChange={e => setImageTag(e.target.value)} placeholder="latest" required value={imageTag} />
+
+                      <div className="rounded-[24px] p-4" style={{ background: 'var(--row-hover)', border: '1px solid var(--glass-border)' }}>
+                        <button
+                          aria-expanded={advancedOptionsOpen}
+                          className="flex w-full items-start justify-between gap-4 text-left"
+                          onClick={() => setAdvancedOptionsOpen((current) => !current)}
+                          type="button"
+                        >
+                          <div className="space-y-1">
+                            <p className="text-[11px] uppercase tracking-[0.18em] text-zinc-500">Advanced options</p>
+                            <p className="text-sm text-zinc-600 dark:text-zinc-300">Optional scan settings for multiple images or platform-specific artifacts.</p>
+                          </div>
+                          <span className="mt-0.5 flex h-8 w-8 items-center justify-center rounded-full border border-zinc-200/50 text-zinc-500 dark:border-zinc-700/60 dark:text-zinc-300">
+                            {advancedOptionsOpen ? <ArrowDown01Icon size={16} /> : <ArrowRight01Icon size={16} />}
+                          </span>
+                        </button>
+
+                        {advancedOptionsOpen ? (
+                          <div className="mt-4 space-y-4">
+                            <div className="space-y-1.5">
+                              <label className="text-sm font-medium text-zinc-600 dark:text-zinc-300">
+                                Additional Images <span className="text-zinc-400 dark:text-zinc-600 font-normal">(optional)</span>
+                              </label>
+                              <textarea
+                                className={joinClassNames(inputCls, 'min-h-24 font-mono resize-y')}
+                                placeholder={'Paste one or more full image references here\nExample: ghcr.io/example/api:1.2.3, registry.example.com/team/worker:latest'}
+                                value={additionalImageDraft}
+                                onChange={e => setAdditionalImageDraft(e.target.value)}
+                              />
+                              <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                                <p className="text-xs text-zinc-500">
+                                  Paste one or many full image references, separated by commas or new lines. Anything still in this box is included when you continue.
+                                </p>
+                                <button
+                                  className="btn-secondary-sm shrink-0"
+                                  onClick={addAdditionalImagesFromDraft}
+                                  type="button"
+                                >
+                                  Add {pendingAdditionalImages.length > 1 ? `${pendingAdditionalImages.length} refs` : 'to list'}
+                                </button>
+                              </div>
+                              {additionalImageEntries.length > 0 ? (
+                                <div className="rounded-2xl p-3" style={{ background: 'rgba(255,255,255,0.03)', border: '1px solid var(--glass-border)' }}>
+                                  <div className="flex items-center justify-between gap-3">
+                                    <p className="text-xs font-medium uppercase tracking-[0.18em] text-zinc-500">Queued additional images</p>
+                                    <span className="rounded-full px-2 py-0.5 text-xs font-medium text-zinc-500" style={{ background: 'rgba(255,255,255,0.05)', border: '1px solid var(--glass-border)' }}>
+                                      {additionalImageEntries.length}
+                                    </span>
+                                  </div>
+                                  <div className="mt-3 space-y-2 max-h-40 overflow-y-auto pr-1">
+                                    {additionalImageEntries.map((image) => (
+                                      <div key={image} className="flex items-start justify-between gap-3 rounded-xl px-3 py-2" style={{ background: 'rgba(255,255,255,0.03)', border: '1px solid var(--glass-border)' }}>
+                                        <span className="min-w-0 break-all font-mono text-xs text-zinc-600 dark:text-zinc-300">{image}</span>
+                                        <button
+                                          aria-label={`Remove ${image}`}
+                                          className="btn-icon-subtle h-8 w-8 shrink-0 rounded-lg"
+                                          onClick={() => removeAdditionalImageEntry(image)}
+                                          type="button"
+                                        >
+                                          <Cancel01Icon aria-hidden size={14} />
+                                        </button>
+                                      </div>
+                                    ))}
+                                  </div>
+                                </div>
+                              ) : null}
+                            </div>
+
+                            <div className="space-y-1.5">
+                              <label className="text-sm font-medium text-zinc-600 dark:text-zinc-300">
+                                Platform <span className="text-zinc-400 dark:text-zinc-600 font-normal">(optional)</span>
+                              </label>
+                              <Select selectedKey={platform || '__auto__'} onSelectionChange={k => setPlatform(String(k === '__auto__' ? '' : k))}>
+                                <Select.Trigger className={selectTriggerCls}>
+                                  <Select.Value />
+                                  <Select.Indicator />
+                                </Select.Trigger>
+                                <Select.Popover>
+                                  <ListBox>
+                                    <ListBox.Item id="__auto__">Auto-detect</ListBox.Item>
+                                    <ListBox.Item id="linux/amd64">linux/amd64</ListBox.Item>
+                                    <ListBox.Item id="linux/arm64">linux/arm64</ListBox.Item>
+                                    <ListBox.Item id="linux/arm/v7">linux/arm/v7</ListBox.Item>
+                                    <ListBox.Item id="linux/arm/v6">linux/arm/v6</ListBox.Item>
+                                    <ListBox.Item id="linux/386">linux/386</ListBox.Item>
+                                    <ListBox.Item id="linux/s390x">linux/s390x</ListBox.Item>
+                                    <ListBox.Item id="linux/ppc64le">linux/ppc64le</ListBox.Item>
+                                    <ListBox.Item id="windows/amd64">windows/amd64</ListBox.Item>
+                                  </ListBox>
+                                </Select.Popover>
+                              </Select>
+                            </div>
+                          </div>
+                        ) : (
+                          <p className="mt-4 text-xs text-zinc-500">
+                            Collapsed by default. Open this only if you want to queue more images or force a platform.
+                          </p>
+                        )}
+                      </div>
+                    </div>
+                  ) : null}
+
+                  {scanStepIndex === 3 ? (
+                    <div className="space-y-5">
+                      <div className="space-y-2">
+                        <p className="text-[11px] uppercase tracking-[0.22em] text-violet-500">Step 4</p>
+                        <h2 className="text-2xl font-semibold tracking-tight text-zinc-900 dark:text-white">Review &amp; start</h2>
+                        <p className="text-sm leading-7 text-zinc-600 dark:text-zinc-300">
+                          Confirm the scan target and routing details before JustScan queues the work.
+                        </p>
+                      </div>
+
+                      <div className="grid gap-4 md:grid-cols-2">
+                        <div className="rounded-[24px] p-4" style={{ background: 'var(--row-hover)', border: '1px solid var(--glass-border)' }}>
+                          <p className="text-[11px] uppercase tracking-[0.18em] text-zinc-500">Source</p>
+                          <p className="mt-2 text-base font-semibold text-zinc-900 dark:text-white">
+                            {scanSource === 'artifactory_xray' ? 'Artifactory Xray' : scanSource === 'private_registry' ? 'Private registry' : 'Public / Docker Hub'}
+                          </p>
+                          <p className="mt-2 text-sm text-zinc-600 dark:text-zinc-300">
+                            {scanSource === 'artifactory_xray'
+                              ? 'JustScan will route this scan through your selected Xray-backed Artifactory registry.'
+                              : scanSource === 'private_registry'
+                                ? 'JustScan will authenticate against the selected private registry before scanning.'
+                                : 'JustScan will scan the public image directly.'}
+                          </p>
+                        </div>
+
+                        <div className="rounded-[24px] p-4" style={{ background: 'var(--row-hover)', border: '1px solid var(--glass-border)' }}>
+                          <p className="text-[11px] uppercase tracking-[0.18em] text-zinc-500">Images</p>
+                          <p className="mt-2 text-base font-semibold text-zinc-900 dark:text-white">{requestedImages.length} target{requestedImages.length === 1 ? '' : 's'}</p>
+                          <p className="mt-2 break-all font-mono text-sm text-zinc-600 dark:text-zinc-300">{primaryImage || 'No primary image provided'}</p>
+                          {requestedImages.length > 1 ? (
+                            <p className="mt-2 text-xs text-zinc-500">Includes {requestedImages.length - 1} additional image{requestedImages.length - 1 === 1 ? '' : 's'}.</p>
+                          ) : null}
+                        </div>
+
+                        {scanSource !== 'public' ? (
+                          <div className="rounded-[24px] p-4" style={{ background: 'var(--row-hover)', border: '1px solid var(--glass-border)' }}>
+                            <p className="text-[11px] uppercase tracking-[0.18em] text-zinc-500">Registry routing</p>
+                            <p className="mt-2 text-base font-semibold text-zinc-900 dark:text-white">{selectedRegistry?.name ?? '—'}</p>
+                            <p className="mt-2 text-sm text-zinc-600 dark:text-zinc-300">{selectedRegistry?.url ?? 'No registry selected.'}</p>
+                          </div>
+                        ) : null}
+
+                        {selectedRegistryIsXray ? (
+                          <div className="rounded-[24px] p-4" style={{ background: 'var(--row-hover)', border: '1px solid var(--glass-border)' }}>
+                            <p className="text-[11px] uppercase tracking-[0.18em] text-zinc-500">Artifactory repo</p>
+                            <p className="mt-2 text-base font-semibold text-zinc-900 dark:text-white">{xrayRepository.trim() || 'Use image path as-is'}</p>
+                            <p className="mt-2 text-sm text-zinc-600 dark:text-zinc-300">Override the repo when the image lives behind a remote or mirror key like docker-remote.</p>
+                          </div>
+                        ) : null}
+                      </div>
+
+                      <div className="rounded-[24px] p-4" style={{ background: 'linear-gradient(145deg, rgba(124,58,237,0.1) 0%, rgba(124,58,237,0.04) 100%)', border: '1px solid rgba(167,139,250,0.18)' }}>
+                        <div className="grid gap-3 md:grid-cols-2">
+                          <div>
+                            <p className="text-[11px] uppercase tracking-[0.18em] text-violet-500">Platform</p>
+                            <p className="mt-2 text-sm font-medium text-zinc-800 dark:text-zinc-200">{platform || 'Auto-detect'}</p>
+                          </div>
+                          <div>
+                            <p className="text-[11px] uppercase tracking-[0.18em] text-violet-500">Additional images</p>
+                            <p className="mt-2 text-sm font-medium text-zinc-800 dark:text-zinc-200">{requestedImages.length > 1 ? `${requestedImages.length - 1} queued` : 'None added'}</p>
+                          </div>
+                        </div>
+                        <p className="mt-4 text-xs text-zinc-600 dark:text-zinc-300">Tags can be added from the scan detail page after creation.</p>
+                      </div>
+                    </div>
+                  ) : null}
                 </form>
               </Modal.Body>
-              <Modal.Footer className="px-6 py-4 flex gap-3 justify-end" style={{ borderTop: '1px solid var(--border-subtle)' }}>
-                <button
-                  onClick={modal.close}
-                  className="btn-secondary"
-                  type="button"
-                >
-                  Cancel
-                </button>
-                <button
-                  type="submit" form="create-scan-form" disabled={creating || xrayOnlyWithoutRegistries}
-                  className="btn-primary inline-flex items-center gap-2"
-                >
-                  {creating && <div className="w-3.5 h-3.5 border-2 border-white/30 border-t-white rounded-full animate-spin" />}
-                  Start Scan
-                </button>
+              <Modal.Footer className="px-6 py-4" style={{ borderTop: '1px solid var(--border-subtle)' }}>
+                <div className="flex w-full flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                  <div className="text-xs text-zinc-500">Step {scanStepIndex + 1} of {SCAN_WIZARD_STEPS.length}</div>
+                  <div className="flex items-center justify-end gap-3">
+                    <button
+                      onClick={modal.close}
+                      className="btn-secondary"
+                      type="button"
+                    >
+                      Cancel
+                    </button>
+                    {scanStepIndex > 0 ? (
+                      <button
+                        onClick={handleWizardBack}
+                        className="btn-secondary"
+                        type="button"
+                      >
+                        Back
+                      </button>
+                    ) : null}
+                    {scanStepIndex < SCAN_WIZARD_STEPS.length - 1 ? (
+                      <button
+                        key="wizard-continue"
+                        onClick={handleWizardNext}
+                        className="btn-primary"
+                        type="button"
+                      >
+                        Continue
+                      </button>
+                    ) : (
+                      <button
+                        key="wizard-submit"
+                        type="submit" form="create-scan-form" disabled={creating || xrayOnlyWithoutRegistries}
+                        className="btn-primary inline-flex items-center gap-2"
+                      >
+                        {creating && <div className="w-3.5 h-3.5 border-2 border-white/30 border-t-white rounded-full animate-spin" />}
+                        Start Scan
+                      </button>
+                    )}
+                  </div>
+                </div>
               </Modal.Footer>
             </Modal.Dialog>
           </Modal.Container>

--- a/services/frontend/lib/api/registries.ts
+++ b/services/frontend/lib/api/registries.ts
@@ -1,7 +1,7 @@
 import { req } from './core';
 import { appendScope } from './scope';
 import type { ResourceShare } from './types/orgs';
-import type { Registry, RegistryListResponse, ScannerCapabilities, ScanProvider } from './types/registries';
+import type { ArtifactoryRepository, Registry, RegistryListResponse, ScannerCapabilities, ScanProvider } from './types/registries';
 
 export function getDefaultScannerCapabilities(): ScannerCapabilities {
   return {
@@ -65,3 +65,6 @@ export const getDefaultRegistry = () =>
 
 export const testRegistry = (id: string) =>
   req<{ health_status: string; health_message: string; last_health_check_at: string }>('POST', `/api/v1/registries/${id}/test`);
+
+export const listArtifactoryRepositories = (id: string) =>
+  req<{ data: ArtifactoryRepository[] }>('GET', `/api/v1/registries/${id}/artifactory-repositories`).then((result) => result.data ?? []);

--- a/services/frontend/lib/api/scans.ts
+++ b/services/frontend/lib/api/scans.ts
@@ -25,11 +25,11 @@ export const listScanImages = (page = 1, limit = 30, image?: string, status?: st
 export const getScan = (id: string) =>
   req<Scan>('GET', `/api/v1/scans/${id}`);
 
-export const createScan = (imageName: string, imageTag: string, registryId?: string, tagIds?: string[], platform?: string, orgId?: string) =>
-  req<Scan>('POST', '/api/v1/scans/', { image: imageName, tag: imageTag, registry_id: registryId, tag_ids: tagIds, platform, org_id: orgId });
+export const createScan = (imageName: string, imageTag: string, registryId?: string, tagIds?: string[], platform?: string, orgId?: string, xrayRepository?: string) =>
+  req<Scan>('POST', '/api/v1/scans/', { image: imageName, tag: imageTag, registry_id: registryId, tag_ids: tagIds, platform, org_id: orgId, xray_repository: xrayRepository });
 
-export const createScans = (images: string[], registryId?: string, tagIds?: string[], platform?: string, orgId?: string) =>
-  req<{ scans: Scan[] }>('POST', '/api/v1/scans/batch', { images, registry_id: registryId, tag_ids: tagIds, platform, org_id: orgId });
+export const createScans = (images: string[], registryId?: string, tagIds?: string[], platform?: string, orgId?: string, xrayRepository?: string) =>
+  req<{ scans: Scan[] }>('POST', '/api/v1/scans/batch', { images, registry_id: registryId, tag_ids: tagIds, platform, org_id: orgId, xray_repository: xrayRepository });
 
 export const deleteScan = (id: string) =>
   req<{ result: string }>('DELETE', `/api/v1/scans/${id}`);

--- a/services/frontend/lib/api/types/registries.ts
+++ b/services/frontend/lib/api/types/registries.ts
@@ -9,6 +9,7 @@ export interface Registry {
   url: string;
   xray_url?: string;
   xray_artifactory_id?: string;
+  xray_repository?: string;
   auth_type: 'none' | 'basic' | 'token' | 'aws_ecr';
   scan_provider: ScanProvider;
   username: string;
@@ -159,6 +160,13 @@ export interface RegistryWithHealth extends Registry {
 export interface RegistryListResponse {
   data: RegistryWithHealth[];
   capabilities?: ScannerCapabilities;
+}
+
+export interface ArtifactoryRepository {
+  key: string;
+  package_type?: string;
+  class?: string;
+  description?: string;
 }
 
 export interface PublicSettings {


### PR DESCRIPTION
- Added `listArtifactoryRepositories` function to fetch Artifactory repositories for a given registry.
- Updated `createScan` and `createScans` functions to include an optional `xrayRepository` parameter.
- Introduced `ArtifactoryRepository` type in the registries types definition to represent Artifactory repository details.
- Modified `Registry` interface to include an optional `xray_repository` field.