### PR TITLE
feat: add versioned vulnerability intelligence (#298)

### DIFF
--- a/services/backend/database/migrations/91_vulnerability_intelligence.go
+++ b/services/backend/database/migrations/91_vulnerability_intelligence.go
@@ -1,0 +1,110 @@
+package migrations
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/uptrace/bun"
+)
+
+func init() {
+	Migrations.MustRegister(func(ctx context.Context, db *bun.DB) error {
+		statements := []string{
+			`CREATE TABLE IF NOT EXISTS vulnerability_intelligence_versions (
+				id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+				source TEXT NOT NULL,
+				version TEXT NOT NULL,
+				feed_observed_at TIMESTAMPTZ,
+				metadata JSONB NOT NULL DEFAULT '{}',
+				created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+				UNIQUE (source, version)
+			)`,
+			`CREATE TABLE IF NOT EXISTS scan_intelligence_versions (
+				scan_id UUID NOT NULL REFERENCES scans(id) ON DELETE CASCADE,
+				intelligence_version_id UUID NOT NULL REFERENCES vulnerability_intelligence_versions(id) ON DELETE CASCADE,
+				created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+				PRIMARY KEY (scan_id, intelligence_version_id)
+			)`,
+			`CREATE TABLE IF NOT EXISTS vulnerability_intelligence_evidence (
+				id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+				finding_id UUID REFERENCES vulnerabilities(id) ON DELETE CASCADE,
+				intelligence_version_id UUID NOT NULL REFERENCES vulnerability_intelligence_versions(id) ON DELETE CASCADE,
+				vuln_id TEXT NOT NULL,
+				package_name TEXT NOT NULL DEFAULT '',
+				installed_version TEXT NOT NULL DEFAULT '',
+				record_key TEXT NOT NULL DEFAULT '',
+				evidence_kind TEXT NOT NULL DEFAULT 'scan',
+				source TEXT NOT NULL,
+				observed_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+				cve_state TEXT NOT NULL DEFAULT 'unknown',
+				severity TEXT NOT NULL DEFAULT 'UNKNOWN',
+				cvss_score DOUBLE PRECISION NOT NULL DEFAULT 0,
+				cvss_vector TEXT NOT NULL DEFAULT '',
+				affected_ranges JSONB NOT NULL DEFAULT '[]',
+				fixed_versions JSONB NOT NULL DEFAULT '[]',
+				exploit_signals JSONB NOT NULL DEFAULT '[]',
+				raw_evidence JSONB NOT NULL DEFAULT '{}',
+				created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+				UNIQUE (intelligence_version_id, source, record_key)
+			)`,
+			`CREATE TABLE IF NOT EXISTS vulnerability_postures (
+				id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+				finding_id UUID NOT NULL UNIQUE REFERENCES vulnerabilities(id) ON DELETE CASCADE,
+				scan_id UUID NOT NULL REFERENCES scans(id) ON DELETE CASCADE,
+				state TEXT NOT NULL DEFAULT 'needs_rescan',
+				cve_state TEXT NOT NULL DEFAULT 'unknown',
+				severity TEXT NOT NULL DEFAULT 'UNKNOWN',
+				cvss_score DOUBLE PRECISION NOT NULL DEFAULT 0,
+				cvss_vector TEXT NOT NULL DEFAULT '',
+				affected_ranges JSONB NOT NULL DEFAULT '[]',
+				fixed_versions JSONB NOT NULL DEFAULT '[]',
+				exploit_signals JSONB NOT NULL DEFAULT '[]',
+				source TEXT NOT NULL DEFAULT '',
+				observed_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+				reason TEXT NOT NULL DEFAULT '',
+				intelligence_version_id UUID REFERENCES vulnerability_intelligence_versions(id) ON DELETE SET NULL,
+				intelligence_version TEXT NOT NULL DEFAULT '',
+				conflict_sources JSONB NOT NULL DEFAULT '[]',
+				updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+			)`,
+			`CREATE TABLE IF NOT EXISTS vulnerability_posture_events (
+				id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+				finding_id UUID NOT NULL REFERENCES vulnerabilities(id) ON DELETE CASCADE,
+				previous_state TEXT NOT NULL DEFAULT '',
+				state TEXT NOT NULL,
+				source TEXT NOT NULL,
+				observed_at TIMESTAMPTZ NOT NULL,
+				reason TEXT NOT NULL,
+				intelligence_version_id UUID REFERENCES vulnerability_intelligence_versions(id) ON DELETE SET NULL,
+				conflict_sources JSONB NOT NULL DEFAULT '[]',
+				created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+			)`,
+			`CREATE INDEX IF NOT EXISTS idx_scan_intelligence_versions_scan ON scan_intelligence_versions(scan_id)`,
+			`CREATE INDEX IF NOT EXISTS idx_vulnerability_intelligence_evidence_finding ON vulnerability_intelligence_evidence(finding_id)`,
+			`CREATE INDEX IF NOT EXISTS idx_vulnerability_intelligence_evidence_key ON vulnerability_intelligence_evidence(vuln_id, package_name, observed_at DESC)`,
+			`CREATE INDEX IF NOT EXISTS idx_vulnerability_intelligence_evidence_record_key ON vulnerability_intelligence_evidence(intelligence_version_id, source, record_key)`,
+			`CREATE INDEX IF NOT EXISTS idx_vulnerability_intelligence_evidence_version ON vulnerability_intelligence_evidence(intelligence_version_id)`,
+			`CREATE INDEX IF NOT EXISTS idx_vulnerability_posture_events_finding ON vulnerability_posture_events(finding_id, created_at DESC)`,
+		}
+
+		for _, statement := range statements {
+			if _, err := db.NewRaw(statement).Exec(ctx); err != nil {
+				return fmt.Errorf("migration 91 vulnerability intelligence: %w", err)
+			}
+		}
+		return nil
+	}, func(ctx context.Context, db *bun.DB) error {
+		for _, statement := range []string{
+			`DROP TABLE IF EXISTS vulnerability_posture_events`,
+			`DROP TABLE IF EXISTS vulnerability_postures`,
+			`DROP TABLE IF EXISTS vulnerability_intelligence_evidence`,
+			`DROP TABLE IF EXISTS scan_intelligence_versions`,
+			`DROP TABLE IF EXISTS vulnerability_intelligence_versions`,
+		} {
+			if _, err := db.NewRaw(statement).Exec(ctx); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}

--- a/services/backend/handlers/admins/vulnerability_intelligence.go
+++ b/services/backend/handlers/admins/vulnerability_intelligence.go
@@ -1,0 +1,35 @@
+package admins
+
+import (
+	"errors"
+	"net/http"
+
+	"justscan-backend/scanner"
+
+	"github.com/gin-gonic/gin"
+	"github.com/uptrace/bun"
+)
+
+// IngestVulnerabilityIntelligence accepts a normalized, source-attributed
+// feed snapshot and applies it to current posture records for historical
+// findings. The admin boundary keeps external feed writes privileged.
+func IngestVulnerabilityIntelligence(c *gin.Context, db *bun.DB) {
+	var request scanner.IntelligenceIngestRequest
+	if err := c.ShouldBindJSON(&request); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	result, err := scanner.IngestIntelligence(c.Request.Context(), db, request)
+	if err != nil {
+		var validationErr *scanner.IntelligenceValidationError
+		if errors.As(err, &validationErr) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": validationErr.Error()})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to ingest vulnerability intelligence"})
+		return
+	}
+
+	c.JSON(http.StatusCreated, result)
+}

--- a/services/backend/handlers/scans/get.go
+++ b/services/backend/handlers/scans/get.go
@@ -75,6 +75,10 @@ func GetScan(db *bun.DB) gin.HandlerFunc {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to load scan initiator"})
 			return
 		}
+		if scan.IntelligenceVersions, err = scanner.LoadScanIntelligenceVersions(c.Request.Context(), db, scanID); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to load scan intelligence versions"})
+			return
+		}
 
 		c.JSON(http.StatusOK, scan)
 	}

--- a/services/backend/handlers/scans/vulnerabilities.go
+++ b/services/backend/handlers/scans/vulnerabilities.go
@@ -144,6 +144,10 @@ func ListVulnerabilities(db *bun.DB) gin.HandlerFunc {
 				Scan(c.Request.Context()) //nolint:errcheck
 			vulns[i].Comments = comments
 		}
+		if err := scanner.AttachVulnerabilityIntelligence(c.Request.Context(), db, vulns); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to load vulnerability intelligence"})
+			return
+		}
 
 		// Batch-query first_seen_at for each vuln_id+pkg_name combination across
 		// all OTHER completed scans of the same image. Excluding the current scan

--- a/services/backend/pkg/models/scans.go
+++ b/services/backend/pkg/models/scans.go
@@ -63,9 +63,10 @@ type Scan struct {
 	PipelineInitiator       *PipelineInitiator     `bun:"-" json:"pipeline_initiator,omitempty"`
 
 	// Relations (not stored in DB, populated on join)
-	Tags            []Tag           `bun:"m2m:scan_tags,join:Scan=Tag" json:"tags,omitempty"`
-	Vulnerabilities []Vulnerability `bun:"rel:has-many,join:id=scan_id" json:"vulnerabilities,omitempty"`
-	StepLogs        []ScanStepLog   `bun:"rel:has-many,join:id=scan_id" json:"step_logs,omitempty"`
+	Tags                 []Tag                              `bun:"m2m:scan_tags,join:Scan=Tag" json:"tags,omitempty"`
+	Vulnerabilities      []Vulnerability                    `bun:"rel:has-many,join:id=scan_id" json:"vulnerabilities,omitempty"`
+	StepLogs             []ScanStepLog                      `bun:"rel:has-many,join:id=scan_id" json:"step_logs,omitempty"`
+	IntelligenceVersions []VulnerabilityIntelligenceVersion `bun:"-" json:"intelligence_versions,omitempty"`
 }
 
 type BlockedPolicyDetails struct {

--- a/services/backend/pkg/models/vulnerabilities.go
+++ b/services/backend/pkg/models/vulnerabilities.go
@@ -40,9 +40,11 @@ type Vulnerability struct {
 	CreatedAt                  time.Time    `bun:"created_at,type:timestamptz,default:now()" json:"created_at"`
 
 	// Relations (populated on join)
-	Suppression *Suppression `bun:"-" json:"suppression,omitempty"`
-	Comments    []Comment    `bun:"rel:has-many,join:id=vulnerability_id" json:"comments,omitempty"`
-	KBEntry     *VulnKBEntry `bun:"-" json:"kb,omitempty"`
+	Suppression          *Suppression                        `bun:"-" json:"suppression,omitempty"`
+	Comments             []Comment                           `bun:"rel:has-many,join:id=vulnerability_id" json:"comments,omitempty"`
+	KBEntry              *VulnKBEntry                        `bun:"-" json:"kb,omitempty"`
+	ScanTimeIntelligence []VulnerabilityIntelligenceEvidence `bun:"-" json:"scan_time_intelligence,omitempty"`
+	CurrentPosture       *VulnerabilityPosture               `bun:"-" json:"current_posture,omitempty"`
 }
 
 // Severity constants

--- a/services/backend/pkg/models/vulnerability_intelligence.go
+++ b/services/backend/pkg/models/vulnerability_intelligence.go
@@ -1,0 +1,121 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/uptrace/bun"
+)
+
+// VulnerabilityIntelligenceVersion identifies the feed snapshot used to produce
+// one or more scan-time evidence records.
+type VulnerabilityIntelligenceVersion struct {
+	bun.BaseModel `bun:"table:vulnerability_intelligence_versions"`
+
+	ID             uuid.UUID  `bun:",pk,type:uuid,default:gen_random_uuid()" json:"id"`
+	Source         string     `bun:"source,type:text,notnull" json:"source"`
+	Version        string     `bun:"version,type:text,notnull" json:"version"`
+	FeedObservedAt *time.Time `bun:"feed_observed_at,type:timestamptz" json:"feed_observed_at,omitempty"`
+	Metadata       JSONObject `bun:"metadata,type:jsonb,notnull,default:'{}'" json:"metadata,omitempty"`
+	CreatedAt      time.Time  `bun:"created_at,type:timestamptz,notnull,default:now()" json:"created_at"`
+}
+
+// ScanIntelligenceVersion records every intelligence snapshot used by a scan,
+// including scans that produced no findings.
+type ScanIntelligenceVersion struct {
+	bun.BaseModel `bun:"table:scan_intelligence_versions"`
+
+	ScanID                uuid.UUID `bun:"scan_id,type:uuid,pk" json:"scan_id"`
+	IntelligenceVersionID uuid.UUID `bun:"intelligence_version_id,type:uuid,pk" json:"intelligence_version_id"`
+	CreatedAt             time.Time `bun:"created_at,type:timestamptz,notnull,default:now()" json:"created_at"`
+}
+
+// VulnerabilityIntelligenceEvidence is immutable source evidence captured for
+// one scanner finding. New feeds append records rather than rewriting this
+// snapshot.
+type VulnerabilityIntelligenceEvidence struct {
+	bun.BaseModel `bun:"table:vulnerability_intelligence_evidence"`
+
+	ID                    uuid.UUID    `bun:",pk,type:uuid,default:gen_random_uuid()" json:"id"`
+	FindingID             *uuid.UUID   `bun:"finding_id,type:uuid" json:"finding_id,omitempty"`
+	IntelligenceVersionID uuid.UUID    `bun:"intelligence_version_id,type:uuid,notnull" json:"intelligence_version_id"`
+	VulnID                string       `bun:"vuln_id,type:text,notnull" json:"vuln_id"`
+	PackageName           string       `bun:"package_name,type:text,notnull,default:''" json:"package_name"`
+	InstalledVersion      string       `bun:"installed_version,type:text,notnull,default:''" json:"installed_version"`
+	RecordKey             string       `bun:"record_key,type:text,notnull,default:''" json:"record_key"`
+	EvidenceKind          string       `bun:"evidence_kind,type:text,notnull,default:'scan'" json:"evidence_kind"`
+	Source                string       `bun:"source,type:text,notnull" json:"source"`
+	ObservedAt            time.Time    `bun:"observed_at,type:timestamptz,notnull,default:now()" json:"observed_at"`
+	CVEState              string       `bun:"cve_state,type:text,notnull,default:'unknown'" json:"cve_state"`
+	Severity              string       `bun:"severity,type:text,notnull,default:'UNKNOWN'" json:"severity"`
+	CVSSScore             float64      `bun:"cvss_score,type:double precision,notnull,default:0" json:"cvss_score"`
+	CVSSVector            string       `bun:"cvss_vector,type:text,notnull,default:''" json:"cvss_vector"`
+	AffectedRanges        []JSONObject `bun:"affected_ranges,type:jsonb,notnull,default:'[]'" json:"affected_ranges"`
+	FixedVersions         []string     `bun:"fixed_versions,type:jsonb,notnull,default:'[]'" json:"fixed_versions"`
+	ExploitSignals        []JSONObject `bun:"exploit_signals,type:jsonb,notnull,default:'[]'" json:"exploit_signals"`
+	RawEvidence           JSONObject   `bun:"raw_evidence,type:jsonb,notnull,default:'{}'" json:"raw_evidence"`
+	CreatedAt             time.Time    `bun:"created_at,type:timestamptz,notnull,default:now()" json:"created_at"`
+}
+
+// VulnerabilityPosture is the latest derived assessment for a historical
+// finding. It is intentionally separate from Vulnerability, whose scanner
+// result remains immutable.
+type VulnerabilityPosture struct {
+	bun.BaseModel `bun:"table:vulnerability_postures"`
+
+	ID                    uuid.UUID    `bun:",pk,type:uuid,default:gen_random_uuid()" json:"id"`
+	FindingID             uuid.UUID    `bun:"finding_id,type:uuid,notnull" json:"finding_id"`
+	ScanID                uuid.UUID    `bun:"scan_id,type:uuid,notnull" json:"scan_id"`
+	State                 string       `bun:"state,type:text,notnull,default:'needs_rescan'" json:"state"`
+	CVEState              string       `bun:"cve_state,type:text,notnull,default:'unknown'" json:"cve_state"`
+	Severity              string       `bun:"severity,type:text,notnull,default:'UNKNOWN'" json:"severity"`
+	CVSSScore             float64      `bun:"cvss_score,type:double precision,notnull,default:0" json:"cvss_score"`
+	CVSSVector            string       `bun:"cvss_vector,type:text,notnull,default:''" json:"cvss_vector"`
+	AffectedRanges        []JSONObject `bun:"affected_ranges,type:jsonb,notnull,default:'[]'" json:"affected_ranges"`
+	FixedVersions         []string     `bun:"fixed_versions,type:jsonb,notnull,default:'[]'" json:"fixed_versions"`
+	ExploitSignals        []JSONObject `bun:"exploit_signals,type:jsonb,notnull,default:'[]'" json:"exploit_signals"`
+	Source                string       `bun:"source,type:text,notnull,default:''" json:"source"`
+	ObservedAt            time.Time    `bun:"observed_at,type:timestamptz,notnull,default:now()" json:"observed_at"`
+	Reason                string       `bun:"reason,type:text,notnull,default:''" json:"reason"`
+	IntelligenceVersionID *uuid.UUID   `bun:"intelligence_version_id,type:uuid" json:"intelligence_version_id,omitempty"`
+	IntelligenceVersion   string       `bun:"intelligence_version,type:text,notnull,default:''" json:"intelligence_version"`
+	ConflictSources       []string     `bun:"conflict_sources,type:jsonb,notnull,default:'[]'" json:"conflict_sources"`
+	UpdatedAt             time.Time    `bun:"updated_at,type:timestamptz,notnull,default:now()" json:"updated_at"`
+}
+
+// VulnerabilityPostureEvent is the append-only audit trail for derived
+// posture changes.
+type VulnerabilityPostureEvent struct {
+	bun.BaseModel `bun:"table:vulnerability_posture_events"`
+
+	ID                    uuid.UUID  `bun:",pk,type:uuid,default:gen_random_uuid()" json:"id"`
+	FindingID             uuid.UUID  `bun:"finding_id,type:uuid,notnull" json:"finding_id"`
+	PreviousState         string     `bun:"previous_state,type:text,notnull,default:''" json:"previous_state"`
+	State                 string     `bun:"state,type:text,notnull" json:"state"`
+	Source                string     `bun:"source,type:text,notnull" json:"source"`
+	ObservedAt            time.Time  `bun:"observed_at,type:timestamptz,notnull" json:"observed_at"`
+	Reason                string     `bun:"reason,type:text,notnull" json:"reason"`
+	IntelligenceVersionID *uuid.UUID `bun:"intelligence_version_id,type:uuid" json:"intelligence_version_id,omitempty"`
+	ConflictSources       []string   `bun:"conflict_sources,type:jsonb,notnull,default:'[]'" json:"conflict_sources"`
+	CreatedAt             time.Time  `bun:"created_at,type:timestamptz,notnull,default:now()" json:"created_at"`
+}
+
+const (
+	IntelligenceSourceTrivy = "trivy"
+	IntelligenceSourceXray  = "xray"
+
+	IntelligenceCVEStateAffected    = "affected"
+	IntelligenceCVEStateDisputed    = "disputed"
+	IntelligenceCVEStateRejected    = "rejected"
+	IntelligenceCVEStateNotAffected = "not_affected"
+	IntelligenceCVEStateUnknown     = "unknown"
+
+	PostureStateUnchanged         = "unchanged"
+	PostureStateSeverityIncreased = "severity_increased"
+	PostureStateSeverityReduced   = "severity_reduced"
+	PostureStateFixAvailable      = "fix_available"
+	PostureStateNotAffected       = "not_affected"
+	PostureStateDisputed          = "disputed"
+	PostureStateRejected          = "rejected"
+	PostureStateNeedsRescan       = "needs_rescan"
+)

--- a/services/backend/router/admin.go
+++ b/services/backend/router/admin.go
@@ -15,6 +15,10 @@ func Admin(router *gin.RouterGroup, db *bun.DB) {
 		admin.GET("/dashboard", func(c *gin.Context) {
 			admins.GetDashboard(c, db)
 		})
+		// vulnerability intelligence
+		admin.POST("/vulnerability-intelligence", func(c *gin.Context) {
+			admins.IngestVulnerabilityIntelligence(c, db)
+		})
 		// users
 		admin.GET("/users", func(c *gin.Context) {
 			admins.GetUsers(c, db)

--- a/services/backend/scanner/intelligence.go
+++ b/services/backend/scanner/intelligence.go
@@ -1,0 +1,1039 @@
+package scanner
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+	"time"
+
+	"justscan-backend/pkg/models"
+
+	"github.com/google/uuid"
+	"github.com/sirupsen/logrus"
+	"github.com/uptrace/bun"
+)
+
+type intelligenceSnapshotDescriptor struct {
+	Source         string
+	Version        string
+	FeedObservedAt *time.Time
+	Metadata       models.JSONObject
+}
+
+type intelligenceFindingKey struct {
+	VulnID      string
+	PackageName string
+}
+
+// IntelligenceIngestRequest is the normalized feed contract used to add a
+// new immutable intelligence version without running a scan. An empty
+// PackageName applies the record to every historical finding for the VulnID.
+type IntelligenceIngestRequest struct {
+	Source         string                     `json:"source"`
+	Version        string                     `json:"version"`
+	FeedObservedAt *time.Time                 `json:"feed_observed_at,omitempty"`
+	Metadata       models.JSONObject          `json:"metadata,omitempty"`
+	Records        []IntelligenceIngestRecord `json:"records"`
+}
+
+// IntelligenceIngestRecord contains source-attributed state for one
+// vulnerability/package key. Feed records are independent of scan findings;
+// their FindingID is intentionally left unset when persisted.
+type IntelligenceIngestRecord struct {
+	VulnID           string              `json:"vuln_id"`
+	PackageName      string              `json:"package_name,omitempty"`
+	InstalledVersion string              `json:"installed_version,omitempty"`
+	Source           string              `json:"source,omitempty"`
+	ObservedAt       *time.Time          `json:"observed_at,omitempty"`
+	CVEState         string              `json:"cve_state"`
+	Severity         string              `json:"severity"`
+	CVSSScore        float64             `json:"cvss_score"`
+	CVSSVector       string              `json:"cvss_vector,omitempty"`
+	AffectedRanges   []models.JSONObject `json:"affected_ranges,omitempty"`
+	FixedVersions    []string            `json:"fixed_versions,omitempty"`
+	ExploitSignals   []models.JSONObject `json:"exploit_signals,omitempty"`
+	RawEvidence      models.JSONObject   `json:"raw_evidence,omitempty"`
+}
+
+// IntelligenceIngestResult reports the immutable feed version and the
+// historical postures recalculated from newly inserted records.
+type IntelligenceIngestResult struct {
+	Version         models.VulnerabilityIntelligenceVersion `json:"version"`
+	RecordsReceived int                                     `json:"records_received"`
+	RecordsInserted int                                     `json:"records_inserted"`
+	PosturesChanged int                                     `json:"postures_changed"`
+}
+
+// IntelligenceValidationError marks caller-provided feed data that cannot be
+// safely normalized. In particular, unknown applicability is accepted and
+// normalized to unknown so it becomes needs_rescan rather than not_affected.
+type IntelligenceValidationError struct {
+	Message string
+}
+
+func (e *IntelligenceValidationError) Error() string {
+	return e.Message
+}
+
+// RecordIntelligenceSnapshot stores the source evidence available at scan
+// time, then refreshes the derived posture for every historical finding with
+// the same vulnerability and package key. The scanner finding itself is never
+// updated by this operation.
+func RecordIntelligenceSnapshot(ctx context.Context, db *bun.DB, scan *models.Scan) error {
+	if db == nil {
+		return fmt.Errorf("database is required")
+	}
+	if scan == nil {
+		return fmt.Errorf("scan is required")
+	}
+
+	var findings []models.Vulnerability
+	if err := db.NewSelect().Model(&findings).Where("scan_id = ?", scan.ID).Scan(ctx); err != nil {
+		return fmt.Errorf("load scan findings: %w", err)
+	}
+
+	kbByID := make(map[string]models.VulnKBEntry)
+	if len(findings) > 0 {
+		vulnIDs := make([]string, 0, len(findings))
+		seen := make(map[string]bool, len(findings))
+		for _, finding := range findings {
+			if finding.VulnID == "" || seen[finding.VulnID] {
+				continue
+			}
+			seen[finding.VulnID] = true
+			vulnIDs = append(vulnIDs, finding.VulnID)
+		}
+		if len(vulnIDs) > 0 {
+			var entries []models.VulnKBEntry
+			if err := db.NewSelect().Model(&entries).Where("vuln_id IN (?)", bun.In(vulnIDs)).Scan(ctx); err != nil {
+				return fmt.Errorf("load knowledge-base entries: %w", err)
+			}
+			for _, entry := range entries {
+				kbByID[entry.VulnID] = entry
+			}
+		}
+	}
+
+	descriptor := intelligenceDescriptorForScan(scan)
+	observedAt := intelligenceObservedAt(scan)
+
+	return db.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
+		version, err := ensureIntelligenceVersion(ctx, tx, descriptor)
+		if err != nil {
+			return err
+		}
+
+		link := &models.ScanIntelligenceVersion{
+			ScanID:                scan.ID,
+			IntelligenceVersionID: version.ID,
+		}
+		if _, err := tx.NewInsert().Model(link).On("CONFLICT DO NOTHING").Exec(ctx); err != nil {
+			return fmt.Errorf("link scan to intelligence version: %w", err)
+		}
+
+		evidence := make([]models.VulnerabilityIntelligenceEvidence, 0, len(findings))
+		keys := make([]intelligenceFindingKey, 0, len(findings))
+		seenKeys := make(map[string]bool, len(findings))
+		for _, finding := range findings {
+			if finding.VulnID == "" {
+				continue
+			}
+
+			key := intelligenceFindingKey{VulnID: finding.VulnID, PackageName: finding.PkgName}
+			keyString := intelligenceKeyString(key)
+			if !seenKeys[keyString] {
+				seenKeys[keyString] = true
+				keys = append(keys, key)
+			}
+
+			entry := kbByID[finding.VulnID]
+			evidence = append(evidence, models.VulnerabilityIntelligenceEvidence{
+				FindingID:             uuidPointer(finding.ID),
+				IntelligenceVersionID: version.ID,
+				VulnID:                finding.VulnID,
+				PackageName:           finding.PkgName,
+				InstalledVersion:      finding.InstalledVersion,
+				RecordKey:             scanEvidenceRecordKey(finding.ID),
+				EvidenceKind:          "scan",
+				Source:                intelligenceEvidenceSource(scan, finding),
+				ObservedAt:            observedAt,
+				CVEState:              models.IntelligenceCVEStateAffected,
+				Severity:              finding.Severity,
+				CVSSScore:             finding.CVSSScore,
+				CVSSVector:            finding.CVSSVector,
+				AffectedRanges:        []models.JSONObject{},
+				FixedVersions:         splitFixedVersions(finding.FixedVersion),
+				ExploitSignals:        exploitSignals(entry),
+				RawEvidence:           rawEvidenceForFinding(scan, finding, entry),
+			})
+		}
+
+		if len(evidence) > 0 {
+			if _, err := tx.NewInsert().Model(&evidence).
+				On("CONFLICT (intelligence_version_id, source, record_key) DO NOTHING").
+				Exec(ctx); err != nil {
+				return fmt.Errorf("store intelligence evidence: %w", err)
+			}
+		}
+
+		if _, err := refreshPostures(ctx, tx, keys); err != nil {
+			return err
+		}
+		return nil
+	})
+}
+
+func intelligenceDescriptorForScan(scan *models.Scan) intelligenceSnapshotDescriptor {
+	descriptor := intelligenceSnapshotDescriptor{
+		Source:   canonicalIntelligenceSource(scan.ScanProvider),
+		Metadata: models.JSONObject{},
+	}
+	if descriptor.Source == "" {
+		descriptor.Source = models.IntelligenceSourceTrivy
+	}
+	descriptor.Metadata["scan_provider"] = scan.ScanProvider
+	descriptor.Metadata["trivy_version"] = scan.TrivyVersion
+	descriptor.Metadata["grype_version"] = scan.GrypeVersion
+
+	if scan.ScanProvider == models.ScanProviderArtifactoryXray {
+		descriptor.Source = models.IntelligenceSourceXray
+		descriptor.Metadata["xray_mode"] = scan.XrayMode
+		descriptor.Metadata["external_scan_id"] = scan.ExternalScanID
+		if scan.XrayProviderScannedAt != nil {
+			descriptor.FeedObservedAt = scan.XrayProviderScannedAt
+			descriptor.Version = "provider:" + scan.XrayProviderScannedAt.UTC().Format(time.RFC3339Nano)
+		}
+	} else if scan.TrivyVulnDBUpdatedAt != nil {
+		descriptor.FeedObservedAt = scan.TrivyVulnDBUpdatedAt
+		descriptor.Version = "vuln-db:" + scan.TrivyVulnDBUpdatedAt.UTC().Format(time.RFC3339Nano)
+	}
+
+	if descriptor.Version == "" && scan.TrivyVersion != "" {
+		descriptor.Version = "scanner:" + strings.TrimSpace(scan.TrivyVersion)
+	}
+	if descriptor.Version == "" && scan.GrypeVersion != "" {
+		descriptor.Version = "scanner:" + strings.TrimSpace(scan.GrypeVersion)
+	}
+	if descriptor.Version == "" {
+		descriptor.Version = "scan:" + scan.ID.String()
+	}
+
+	if scan.TrivyVulnDBDownloadedAt != nil {
+		descriptor.Metadata["trivy_vuln_db_downloaded_at"] = scan.TrivyVulnDBDownloadedAt.UTC().Format(time.RFC3339Nano)
+	}
+	if scan.TrivyJavaDBUpdatedAt != nil {
+		descriptor.Metadata["trivy_java_db_updated_at"] = scan.TrivyJavaDBUpdatedAt.UTC().Format(time.RFC3339Nano)
+	}
+	return descriptor
+}
+
+func intelligenceObservedAt(scan *models.Scan) time.Time {
+	if scan.CompletedAt != nil {
+		return scan.CompletedAt.UTC()
+	}
+	if !scan.CreatedAt.IsZero() {
+		return scan.CreatedAt.UTC()
+	}
+	return time.Now().UTC()
+}
+
+func ensureIntelligenceVersion(ctx context.Context, db bun.IDB, descriptor intelligenceSnapshotDescriptor) (models.VulnerabilityIntelligenceVersion, error) {
+	descriptor.Source = canonicalIntelligenceSource(descriptor.Source)
+	descriptor.Version = strings.TrimSpace(descriptor.Version)
+	version := models.VulnerabilityIntelligenceVersion{
+		Source:         descriptor.Source,
+		Version:        descriptor.Version,
+		FeedObservedAt: descriptor.FeedObservedAt,
+		Metadata:       descriptor.Metadata,
+	}
+	if _, err := db.NewInsert().Model(&version).
+		On("CONFLICT (source, version) DO NOTHING").
+		Exec(ctx); err != nil {
+		return version, fmt.Errorf("create intelligence version: %w", err)
+	}
+
+	var persisted models.VulnerabilityIntelligenceVersion
+	if err := db.NewSelect().Model(&persisted).
+		Where("source = ? AND version = ?", descriptor.Source, descriptor.Version).
+		Scan(ctx); err != nil {
+		return version, fmt.Errorf("load intelligence version: %w", err)
+	}
+	return persisted, nil
+}
+
+func intelligenceEvidenceSource(scan *models.Scan, finding models.Vulnerability) string {
+	if scan.ScanProvider == models.ScanProviderArtifactoryXray {
+		if source := strings.TrimSpace(finding.XraySource); source != "" {
+			return canonicalIntelligenceSource(source)
+		}
+		if source := strings.TrimSpace(finding.DataSource); source != "" {
+			return canonicalIntelligenceSource(source)
+		}
+		return models.IntelligenceSourceXray
+	}
+	if source := strings.TrimSpace(finding.DataSource); source != "" {
+		return canonicalIntelligenceSource(source)
+	}
+	if scan.ScanProvider != "" {
+		return canonicalIntelligenceSource(scan.ScanProvider)
+	}
+	return models.IntelligenceSourceTrivy
+}
+
+func canonicalIntelligenceSource(value string) string {
+	return strings.ToLower(strings.TrimSpace(value))
+}
+
+func scanEvidenceRecordKey(findingID uuid.UUID) string {
+	return "scan:" + findingID.String()
+}
+
+func splitFixedVersions(value string) []string {
+	parts := strings.Split(value, ",")
+	versions := make([]string, 0, len(parts))
+	seen := make(map[string]bool, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" || seen[part] {
+			continue
+		}
+		seen[part] = true
+		versions = append(versions, part)
+	}
+	return versions
+}
+
+func exploitSignals(entry models.VulnKBEntry) []models.JSONObject {
+	signals := make([]models.JSONObject, 0)
+	if entry.ExploitAvailable {
+		signals = append(signals, models.JSONObject{
+			"type":      "known_exploit",
+			"available": true,
+		})
+	}
+	for _, reference := range entry.References {
+		url := strings.ToLower(strings.TrimSpace(reference.URL))
+		if url == "" || (!strings.Contains(url, "exploit") && !strings.Contains(url, "packetstormsecurity")) {
+			continue
+		}
+		signals = append(signals, models.JSONObject{
+			"type":   "exploit_reference",
+			"url":    reference.URL,
+			"source": reference.Source,
+		})
+	}
+	return signals
+}
+
+func rawEvidenceForFinding(scan *models.Scan, finding models.Vulnerability, entry models.VulnKBEntry) models.JSONObject {
+	raw := models.JSONObject{
+		"scan_provider": scan.ScanProvider,
+		"data_source":   finding.DataSource,
+		"references":    finding.References,
+	}
+	if entry.VulnID != "" {
+		raw["kb_fetched_at"] = entry.FetchedAt.UTC().Format(time.RFC3339Nano)
+		raw["kb_exploit_available"] = entry.ExploitAvailable
+	}
+	if finding.XraySource != "" {
+		raw["xray_source"] = finding.XraySource
+		raw["xray_source_version"] = finding.XraySourceVersion
+		raw["xray_source_id"] = finding.XraySourceID
+	}
+	return raw
+}
+
+func intelligenceKeyString(key intelligenceFindingKey) string {
+	return key.VulnID + "\x00" + key.PackageName
+}
+
+func refreshPostures(ctx context.Context, db bun.IDB, keys []intelligenceFindingKey) (int, error) {
+	if len(keys) == 0 {
+		return 0, nil
+	}
+	changed := 0
+
+	vulnIDs := make([]string, 0, len(keys))
+	seenVulnIDs := make(map[string]bool, len(keys))
+	for _, key := range keys {
+		if !seenVulnIDs[key.VulnID] {
+			seenVulnIDs[key.VulnID] = true
+			vulnIDs = append(vulnIDs, key.VulnID)
+		}
+	}
+
+	var findings []models.Vulnerability
+	if err := db.NewSelect().Model(&findings).Where("vuln_id IN (?)", bun.In(vulnIDs)).Scan(ctx); err != nil {
+		return 0, fmt.Errorf("load historical findings for posture refresh: %w", err)
+	}
+
+	var evidence []models.VulnerabilityIntelligenceEvidence
+	if err := db.NewSelect().Model(&evidence).
+		Where("vuln_id IN (?)", bun.In(vulnIDs)).
+		OrderExpr("observed_at DESC, created_at DESC, id DESC").
+		Scan(ctx); err != nil {
+		return 0, fmt.Errorf("load intelligence evidence for posture refresh: %w", err)
+	}
+
+	versionIDs := make([]uuid.UUID, 0, len(evidence))
+	seenVersionIDs := make(map[uuid.UUID]bool, len(evidence))
+	for _, record := range evidence {
+		if !seenVersionIDs[record.IntelligenceVersionID] {
+			seenVersionIDs[record.IntelligenceVersionID] = true
+			versionIDs = append(versionIDs, record.IntelligenceVersionID)
+		}
+	}
+	versionNames := make(map[uuid.UUID]string, len(versionIDs))
+	if len(versionIDs) > 0 {
+		var versions []models.VulnerabilityIntelligenceVersion
+		if err := db.NewSelect().Model(&versions).Where("id IN (?)", bun.In(versionIDs)).Scan(ctx); err != nil {
+			return 0, fmt.Errorf("load intelligence version names: %w", err)
+		}
+		for _, version := range versions {
+			versionNames[version.ID] = version.Version
+		}
+	}
+
+	evidenceByKey := make(map[string][]models.VulnerabilityIntelligenceEvidence)
+	wildcardEvidenceByVuln := make(map[string][]models.VulnerabilityIntelligenceEvidence)
+	for _, record := range evidence {
+		if strings.TrimSpace(record.PackageName) == "" {
+			wildcardEvidenceByVuln[record.VulnID] = append(wildcardEvidenceByVuln[record.VulnID], record)
+			continue
+		}
+		key := intelligenceKeyString(intelligenceFindingKey{VulnID: record.VulnID, PackageName: record.PackageName})
+		evidenceByKey[key] = append(evidenceByKey[key], record)
+	}
+
+	requestedKeys := make(map[string]bool, len(keys))
+	for _, key := range keys {
+		requestedKeys[intelligenceKeyString(key)] = true
+	}
+
+	for _, finding := range findings {
+		if !intelligenceKeyRequested(requestedKeys, finding) {
+			continue
+		}
+
+		exactKey := intelligenceKeyString(intelligenceFindingKey{VulnID: finding.VulnID, PackageName: finding.PkgName})
+		latest := latestEvidenceForFinding(evidenceByKey[exactKey], wildcardEvidenceByVuln[finding.VulnID])
+		if len(latest) == 0 {
+			continue
+		}
+
+		posture := derivePosture(finding, latest, versionNames)
+		var existing models.VulnerabilityPosture
+		err := db.NewSelect().Model(&existing).Where("finding_id = ?", finding.ID).Scan(ctx)
+		if err != nil && err != sql.ErrNoRows {
+			return 0, fmt.Errorf("load current posture for finding %s: %w", finding.ID, err)
+		}
+
+		hasExisting := err == nil
+		if hasExisting && !postureChanged(existing, posture) {
+			continue
+		}
+
+		previousState := ""
+		if hasExisting {
+			previousState = existing.State
+			if _, err := db.NewUpdate().Model(&posture).
+				Column("scan_id", "state", "cve_state", "severity", "cvss_score", "cvss_vector", "affected_ranges", "fixed_versions", "exploit_signals", "source", "observed_at", "reason", "intelligence_version_id", "intelligence_version", "conflict_sources", "updated_at").
+				Where("finding_id = ?", finding.ID).Exec(ctx); err != nil {
+				return 0, fmt.Errorf("update posture for finding %s: %w", finding.ID, err)
+			}
+		} else {
+			if _, err := db.NewInsert().Model(&posture).Exec(ctx); err != nil {
+				return 0, fmt.Errorf("create posture for finding %s: %w", finding.ID, err)
+			}
+		}
+
+		event := &models.VulnerabilityPostureEvent{
+			FindingID:             finding.ID,
+			PreviousState:         previousState,
+			State:                 posture.State,
+			Source:                posture.Source,
+			ObservedAt:            posture.ObservedAt,
+			Reason:                posture.Reason,
+			IntelligenceVersionID: posture.IntelligenceVersionID,
+			ConflictSources:       posture.ConflictSources,
+		}
+		if _, err := db.NewInsert().Model(event).Exec(ctx); err != nil {
+			return 0, fmt.Errorf("record posture event for finding %s: %w", finding.ID, err)
+		}
+		changed++
+	}
+
+	return changed, nil
+}
+
+func intelligenceKeyRequested(requestedKeys map[string]bool, finding models.Vulnerability) bool {
+	exactKey := intelligenceKeyString(intelligenceFindingKey{VulnID: finding.VulnID, PackageName: finding.PkgName})
+	wildcardKey := intelligenceKeyString(intelligenceFindingKey{VulnID: finding.VulnID})
+	return requestedKeys[exactKey] || requestedKeys[wildcardKey]
+}
+
+type evidenceCandidate struct {
+	record      models.VulnerabilityIntelligenceEvidence
+	specificity int
+}
+
+// latestEvidenceForFinding selects one current record per source. Feed
+// records take precedence over scan snapshots, and package-specific records
+// take precedence over wildcard records. This allows a newer independent feed
+// to update an old finding without losing source conflicts.
+func latestEvidenceForFinding(exact, wildcard []models.VulnerabilityIntelligenceEvidence) []models.VulnerabilityIntelligenceEvidence {
+	bySource := make(map[string]evidenceCandidate)
+	consider := func(records []models.VulnerabilityIntelligenceEvidence, specificity int) {
+		for _, record := range records {
+			source := canonicalIntelligenceSource(record.Source)
+			if source == "" {
+				continue
+			}
+			record.Source = source
+			candidate := evidenceCandidate{record: record, specificity: specificity}
+			current, ok := bySource[source]
+			if !ok || evidenceCandidatePreferred(candidate, current) {
+				bySource[source] = candidate
+			}
+		}
+	}
+
+	consider(wildcard, 0)
+	consider(exact, 1)
+
+	result := make([]models.VulnerabilityIntelligenceEvidence, 0, len(bySource))
+	for _, candidate := range bySource {
+		result = append(result, candidate.record)
+	}
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].Source < result[j].Source
+	})
+	return result
+}
+
+func evidenceCandidatePreferred(left, right evidenceCandidate) bool {
+	leftFeed := strings.EqualFold(left.record.EvidenceKind, "feed")
+	rightFeed := strings.EqualFold(right.record.EvidenceKind, "feed")
+	if leftFeed != rightFeed {
+		return leftFeed
+	}
+	if left.specificity != right.specificity {
+		return left.specificity > right.specificity
+	}
+	return intelligenceEvidenceIsNewer(left.record, right.record)
+}
+
+func intelligenceEvidenceIsNewer(left, right models.VulnerabilityIntelligenceEvidence) bool {
+	if left.ObservedAt.After(right.ObservedAt) {
+		return true
+	}
+	if left.ObservedAt.Before(right.ObservedAt) {
+		return false
+	}
+	if left.CreatedAt.After(right.CreatedAt) {
+		return true
+	}
+	return left.CreatedAt.Equal(right.CreatedAt) && left.ID.String() > right.ID.String()
+}
+
+func derivePosture(finding models.Vulnerability, latest []models.VulnerabilityIntelligenceEvidence, versionNames map[uuid.UUID]string) models.VulnerabilityPosture {
+	posture := models.VulnerabilityPosture{
+		FindingID:       finding.ID,
+		ScanID:          finding.ScanID,
+		CVEState:        models.IntelligenceCVEStateUnknown,
+		Severity:        models.SeverityUnknown,
+		AffectedRanges:  []models.JSONObject{},
+		FixedVersions:   []string{},
+		ExploitSignals:  []models.JSONObject{},
+		ConflictSources: []string{},
+	}
+
+	sources := make([]string, 0, len(latest))
+	for _, record := range latest {
+		sources = append(sources, record.Source)
+	}
+	posture.Source = strings.Join(sources, ",")
+
+	if len(latest) > 1 && intelligenceEvidenceConflicts(latest) {
+		posture.State = models.PostureStateNeedsRescan
+		posture.Reason = "Conflicting intelligence sources require validation before posture can be derived."
+		posture.ConflictSources = append([]string(nil), sources...)
+		for _, record := range latest {
+			if record.ObservedAt.After(posture.ObservedAt) {
+				posture.ObservedAt = record.ObservedAt
+			}
+		}
+		return posture
+	}
+
+	representative := latest[0]
+	posture.CVEState = representative.CVEState
+	posture.Severity = representative.Severity
+	posture.CVSSScore = representative.CVSSScore
+	posture.CVSSVector = representative.CVSSVector
+	posture.AffectedRanges = cloneJSONObjectSlice(representative.AffectedRanges)
+	posture.FixedVersions = append([]string{}, representative.FixedVersions...)
+	posture.ExploitSignals = cloneJSONObjectSlice(representative.ExploitSignals)
+	posture.ObservedAt = representative.ObservedAt
+	posture.IntelligenceVersionID = uuidPointer(representative.IntelligenceVersionID)
+	posture.IntelligenceVersion = versionNames[representative.IntelligenceVersionID]
+
+	posture.State, posture.Reason = derivePostureState(finding, representative)
+	if len(latest) > 1 {
+		posture.Reason = fmt.Sprintf("Sources %s agree: %s", posture.Source, posture.Reason)
+		posture.IntelligenceVersionID = nil
+		posture.IntelligenceVersion = ""
+		for _, record := range latest[1:] {
+			if record.ObservedAt.After(posture.ObservedAt) {
+				posture.ObservedAt = record.ObservedAt
+			}
+		}
+	}
+	return posture
+}
+
+func derivePostureState(finding models.Vulnerability, evidence models.VulnerabilityIntelligenceEvidence) (string, string) {
+	source := strings.TrimSpace(evidence.Source)
+	if source == "" {
+		source = "the intelligence feed"
+	}
+
+	switch strings.ToLower(strings.TrimSpace(evidence.CVEState)) {
+	case "":
+		return models.PostureStateNeedsRescan, "Intelligence applicability is unknown; rescan required."
+	case models.IntelligenceCVEStateUnknown:
+		return models.PostureStateNeedsRescan, fmt.Sprintf("%s did not provide applicability information; rescan required.", source)
+	case models.IntelligenceCVEStateDisputed:
+		return models.PostureStateDisputed, fmt.Sprintf("%s reports that the vulnerability is disputed.", source)
+	case models.IntelligenceCVEStateRejected:
+		return models.PostureStateRejected, fmt.Sprintf("%s reports that the vulnerability is rejected.", source)
+	case models.IntelligenceCVEStateNotAffected:
+		return models.PostureStateNotAffected, fmt.Sprintf("%s explicitly reports that this package is not affected.", source)
+	case models.IntelligenceCVEStateAffected:
+		// A scanner finding with a fixed version is still affected at the
+		// installed version, but the current posture should make remediation
+		// available without rewriting the scan-time result.
+		if len(evidence.FixedVersions) > 0 {
+			return models.PostureStateFixAvailable, fmt.Sprintf("%s reports fixed version(s): %s.", source, strings.Join(evidence.FixedVersions, ", "))
+		}
+		currentRank := severityRank(finding.Severity)
+		latestRank := severityRank(evidence.Severity)
+		if latestRank > currentRank || (latestRank == currentRank && evidence.CVSSScore > finding.CVSSScore) {
+			return models.PostureStateSeverityIncreased, fmt.Sprintf("%s increased the assessed severity to %s.", source, evidence.Severity)
+		}
+		if latestRank < currentRank || (latestRank == currentRank && evidence.CVSSScore > 0 && evidence.CVSSScore < finding.CVSSScore) {
+			return models.PostureStateSeverityReduced, fmt.Sprintf("%s reduced the assessed severity to %s.", source, evidence.Severity)
+		}
+		return models.PostureStateUnchanged, fmt.Sprintf("%s did not change the assessed severity or remediation state.", source)
+	default:
+		return models.PostureStateNeedsRescan, fmt.Sprintf("%s returned an unrecognized applicability state; rescan required.", source)
+	}
+}
+
+func intelligenceEvidenceConflicts(records []models.VulnerabilityIntelligenceEvidence) bool {
+	if len(records) < 2 {
+		return false
+	}
+	base := records[0]
+	for _, record := range records[1:] {
+		if base.CVEState != record.CVEState ||
+			base.Severity != record.Severity ||
+			base.CVSSScore != record.CVSSScore ||
+			base.CVSSVector != record.CVSSVector ||
+			!equalJSONObjectSlices(base.AffectedRanges, record.AffectedRanges) ||
+			!equalStringSets(base.FixedVersions, record.FixedVersions) ||
+			!equalJSONObjectSlices(base.ExploitSignals, record.ExploitSignals) {
+			return true
+		}
+	}
+	return false
+}
+
+func equalStrings(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for i := range left {
+		if left[i] != right[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func equalStringSets(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	leftCopy := append([]string{}, left...)
+	rightCopy := append([]string{}, right...)
+	sort.Strings(leftCopy)
+	sort.Strings(rightCopy)
+	return equalStrings(leftCopy, rightCopy)
+}
+
+func equalJSONObjectSlices(left, right []models.JSONObject) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for i := range left {
+		if !reflect.DeepEqual(left[i], right[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func postureChanged(existing, next models.VulnerabilityPosture) bool {
+	return existing.State != next.State ||
+		existing.CVEState != next.CVEState ||
+		existing.Severity != next.Severity ||
+		existing.CVSSScore != next.CVSSScore ||
+		existing.CVSSVector != next.CVSSVector ||
+		!equalJSONObjectSlices(existing.AffectedRanges, next.AffectedRanges) ||
+		!equalStringSets(existing.FixedVersions, next.FixedVersions) ||
+		!equalJSONObjectSlices(existing.ExploitSignals, next.ExploitSignals) ||
+		existing.Source != next.Source ||
+		!existing.ObservedAt.Equal(next.ObservedAt) ||
+		existing.IntelligenceVersion != next.IntelligenceVersion ||
+		!equalUUIDPointers(existing.IntelligenceVersionID, next.IntelligenceVersionID) ||
+		!equalStrings(existing.ConflictSources, next.ConflictSources)
+}
+
+func equalUUIDPointers(left, right *uuid.UUID) bool {
+	if left == nil || right == nil {
+		return left == nil && right == nil
+	}
+	return *left == *right
+}
+
+func uuidPointer(value uuid.UUID) *uuid.UUID {
+	if value == uuid.Nil {
+		return nil
+	}
+	copy := value
+	return &copy
+}
+
+const maxIntelligenceIngestRecords = 10000
+
+// IngestIntelligence persists a source feed version and recalculates current
+// postures for matching historical findings. It never updates the original
+// vulnerability row or the scan's compliance result.
+func IngestIntelligence(ctx context.Context, db *bun.DB, request IntelligenceIngestRequest) (IntelligenceIngestResult, error) {
+	result := IntelligenceIngestResult{RecordsReceived: len(request.Records)}
+	request, err := normalizeIntelligenceIngestRequest(request)
+	if err != nil {
+		return result, err
+	}
+
+	descriptor := intelligenceSnapshotDescriptor{
+		Source:         request.Source,
+		Version:        request.Version,
+		FeedObservedAt: request.FeedObservedAt,
+		Metadata:       request.Metadata,
+	}
+	keys := make([]intelligenceFindingKey, 0, len(request.Records))
+	seenKeys := make(map[string]bool, len(request.Records))
+	for _, record := range request.Records {
+		key := intelligenceFindingKey{VulnID: record.VulnID, PackageName: record.PackageName}
+		keyString := intelligenceKeyString(key)
+		if !seenKeys[keyString] {
+			seenKeys[keyString] = true
+			keys = append(keys, key)
+		}
+	}
+
+	if db == nil {
+		return result, fmt.Errorf("database is required")
+	}
+
+	err = db.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
+		version, err := ensureIntelligenceVersion(ctx, tx, descriptor)
+		if err != nil {
+			return err
+		}
+		result.Version = version
+
+		evidence := make([]models.VulnerabilityIntelligenceEvidence, 0, len(request.Records))
+		for _, record := range request.Records {
+			observedAt := time.Now().UTC()
+			if record.ObservedAt != nil {
+				observedAt = *record.ObservedAt
+			}
+			evidence = append(evidence, models.VulnerabilityIntelligenceEvidence{
+				FindingID:             nil,
+				IntelligenceVersionID: version.ID,
+				VulnID:                record.VulnID,
+				PackageName:           record.PackageName,
+				InstalledVersion:      record.InstalledVersion,
+				RecordKey:             feedEvidenceRecordKey(record.VulnID, record.PackageName),
+				EvidenceKind:          "feed",
+				Source:                record.Source,
+				ObservedAt:            observedAt,
+				CVEState:              record.CVEState,
+				Severity:              record.Severity,
+				CVSSScore:             record.CVSSScore,
+				CVSSVector:            record.CVSSVector,
+				AffectedRanges:        record.AffectedRanges,
+				FixedVersions:         record.FixedVersions,
+				ExploitSignals:        record.ExploitSignals,
+				RawEvidence:           record.RawEvidence,
+			})
+		}
+
+		insertResult, err := tx.NewInsert().Model(&evidence).
+			On("CONFLICT (intelligence_version_id, source, record_key) DO NOTHING").
+			Exec(ctx)
+		if err != nil {
+			return fmt.Errorf("store intelligence feed records: %w", err)
+		}
+		if rows, rowsErr := insertResult.RowsAffected(); rowsErr == nil {
+			result.RecordsInserted = int(rows)
+		} else {
+			result.RecordsInserted = len(evidence)
+		}
+
+		changed, err := refreshPostures(ctx, tx, keys)
+		if err != nil {
+			return err
+		}
+		result.PosturesChanged = changed
+		return nil
+	})
+	if err != nil {
+		return IntelligenceIngestResult{RecordsReceived: result.RecordsReceived}, err
+	}
+	return result, nil
+}
+
+func normalizeIntelligenceIngestRequest(request IntelligenceIngestRequest) (IntelligenceIngestRequest, error) {
+	request.Source = canonicalIntelligenceSource(request.Source)
+	request.Version = strings.TrimSpace(request.Version)
+	if request.Source == "" {
+		return request, intelligenceValidationError("source is required")
+	}
+	if request.Version == "" {
+		return request, intelligenceValidationError("version is required")
+	}
+	if len(request.Records) == 0 {
+		return request, intelligenceValidationError("at least one intelligence record is required")
+	}
+	if len(request.Records) > maxIntelligenceIngestRecords {
+		return request, intelligenceValidationError(fmt.Sprintf("records cannot exceed %d items", maxIntelligenceIngestRecords))
+	}
+	if request.FeedObservedAt == nil {
+		now := time.Now().UTC()
+		request.FeedObservedAt = &now
+	} else {
+		observedAt := request.FeedObservedAt.UTC()
+		request.FeedObservedAt = &observedAt
+	}
+	if request.Metadata == nil {
+		request.Metadata = models.JSONObject{}
+	}
+
+	seen := make(map[string]bool, len(request.Records))
+	for i := range request.Records {
+		record := &request.Records[i]
+		record.VulnID = strings.TrimSpace(record.VulnID)
+		if record.VulnID == "" {
+			return request, intelligenceValidationError(fmt.Sprintf("records[%d].vuln_id is required", i))
+		}
+		record.PackageName = strings.TrimSpace(record.PackageName)
+		record.InstalledVersion = strings.TrimSpace(record.InstalledVersion)
+		record.Source = canonicalIntelligenceSource(record.Source)
+		if record.Source == "" {
+			record.Source = request.Source
+		}
+		record.CVEState = normalizeIntelligenceCVEState(record.CVEState)
+		record.Severity = normalizeSeverity(record.Severity)
+		record.CVSSVector = strings.TrimSpace(record.CVSSVector)
+		if record.CVSSScore < 0 || record.CVSSScore > 10 {
+			return request, intelligenceValidationError(fmt.Sprintf("records[%d].cvss_score must be between 0 and 10", i))
+		}
+		if record.ObservedAt == nil {
+			observedAt := *request.FeedObservedAt
+			record.ObservedAt = &observedAt
+		} else {
+			observedAt := record.ObservedAt.UTC()
+			record.ObservedAt = &observedAt
+		}
+		record.AffectedRanges = normalizeJSONObjectSlice(record.AffectedRanges)
+		record.FixedVersions = normalizeStringSlice(record.FixedVersions)
+		record.ExploitSignals = normalizeJSONObjectSlice(record.ExploitSignals)
+		if record.RawEvidence == nil {
+			record.RawEvidence = models.JSONObject{}
+		}
+
+		key := record.Source + "\x00" + record.VulnID + "\x00" + record.PackageName
+		if seen[key] {
+			return request, intelligenceValidationError(fmt.Sprintf("records[%d] duplicates source, vuln_id, and package_name", i))
+		}
+		seen[key] = true
+	}
+	return request, nil
+}
+
+func intelligenceValidationError(message string) error {
+	return &IntelligenceValidationError{Message: message}
+}
+
+func normalizeIntelligenceCVEState(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	value = strings.ReplaceAll(value, "-", "_")
+	value = strings.ReplaceAll(value, " ", "_")
+	switch value {
+	case models.IntelligenceCVEStateAffected,
+		models.IntelligenceCVEStateDisputed,
+		models.IntelligenceCVEStateRejected,
+		models.IntelligenceCVEStateNotAffected:
+		return value
+	case "notaffected", "unaffected":
+		return models.IntelligenceCVEStateNotAffected
+	default:
+		return models.IntelligenceCVEStateUnknown
+	}
+}
+
+func normalizeStringSlice(values []string) []string {
+	result := make([]string, 0, len(values))
+	seen := make(map[string]bool, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" || seen[value] {
+			continue
+		}
+		seen[value] = true
+		result = append(result, value)
+	}
+	return result
+}
+
+func normalizeJSONObjectSlice(values []models.JSONObject) []models.JSONObject {
+	result := make([]models.JSONObject, 0, len(values))
+	for _, value := range values {
+		if value == nil {
+			result = append(result, models.JSONObject{})
+			continue
+		}
+		result = append(result, value)
+	}
+	return result
+}
+
+func cloneJSONObjectSlice(values []models.JSONObject) []models.JSONObject {
+	result := make([]models.JSONObject, 0, len(values))
+	result = append(result, values...)
+	return result
+}
+
+func feedEvidenceRecordKey(vulnID, packageName string) string {
+	return "feed:" + vulnID + "\x00" + packageName
+}
+
+// AttachVulnerabilityIntelligence adds the immutable scan-time evidence and
+// latest derived posture to API response models.
+func AttachVulnerabilityIntelligence(ctx context.Context, db *bun.DB, vulnerabilities []models.Vulnerability) error {
+	if len(vulnerabilities) == 0 {
+		return nil
+	}
+
+	findingIDs := make([]uuid.UUID, 0, len(vulnerabilities))
+	for _, vulnerability := range vulnerabilities {
+		if vulnerability.ID != uuid.Nil {
+			findingIDs = append(findingIDs, vulnerability.ID)
+		}
+	}
+	if len(findingIDs) == 0 {
+		return nil
+	}
+
+	var evidence []models.VulnerabilityIntelligenceEvidence
+	if err := db.NewSelect().Model(&evidence).
+		Where("finding_id IN (?)", bun.In(findingIDs)).
+		OrderExpr("observed_at ASC, created_at ASC").
+		Scan(ctx); err != nil {
+		return fmt.Errorf("load scan-time intelligence: %w", err)
+	}
+	byFinding := make(map[uuid.UUID][]models.VulnerabilityIntelligenceEvidence, len(findingIDs))
+	for _, record := range evidence {
+		if record.FindingID == nil {
+			continue
+		}
+		byFinding[*record.FindingID] = append(byFinding[*record.FindingID], record)
+	}
+
+	var postures []models.VulnerabilityPosture
+	if err := db.NewSelect().Model(&postures).Where("finding_id IN (?)", bun.In(findingIDs)).Scan(ctx); err != nil {
+		return fmt.Errorf("load current vulnerability postures: %w", err)
+	}
+	postureByFinding := make(map[uuid.UUID]*models.VulnerabilityPosture, len(postures))
+	for i := range postures {
+		postureByFinding[postures[i].FindingID] = &postures[i]
+	}
+
+	for i := range vulnerabilities {
+		vulnerabilities[i].ScanTimeIntelligence = byFinding[vulnerabilities[i].ID]
+		vulnerabilities[i].CurrentPosture = postureByFinding[vulnerabilities[i].ID]
+	}
+	return nil
+}
+
+// LoadScanIntelligenceVersions loads the feed snapshots associated with a scan.
+func LoadScanIntelligenceVersions(ctx context.Context, db *bun.DB, scanID uuid.UUID) ([]models.VulnerabilityIntelligenceVersion, error) {
+	var versions []models.VulnerabilityIntelligenceVersion
+	if err := db.NewSelect().
+		TableExpr("vulnerability_intelligence_versions AS v").
+		ColumnExpr("v.*").
+		Join("JOIN scan_intelligence_versions AS siv ON siv.intelligence_version_id = v.id").
+		Where("siv.scan_id = ?", scanID).
+		OrderExpr("v.source ASC, v.version ASC").
+		Scan(ctx, &versions); err != nil {
+		return nil, fmt.Errorf("load scan intelligence versions: %w", err)
+	}
+	return versions, nil
+}
+
+// BackfillVulnerabilityIntelligence asynchronously captures evidence for
+// historical scans after an additive migration. It is safe to retry because
+// scan/version and finding/version/source writes are idempotent.
+func BackfillVulnerabilityIntelligence(db *bun.DB) {
+	ctx := context.Background()
+	for {
+		var scanIDs []uuid.UUID
+		if err := db.NewSelect().
+			TableExpr("scans AS s").
+			ColumnExpr("s.id").
+			Where("NOT EXISTS (SELECT 1 FROM scan_intelligence_versions siv WHERE siv.scan_id = s.id)").
+			OrderExpr("s.created_at ASC, s.id ASC").
+			Limit(100).
+			Scan(ctx, &scanIDs); err != nil {
+			logrus.Warnf("Intelligence backfill: failed to find historical scans: %v", err)
+			return
+		}
+		if len(scanIDs) == 0 {
+			return
+		}
+
+		completed := 0
+		for _, scanID := range scanIDs {
+			scan := &models.Scan{}
+			if err := db.NewSelect().Model(scan).Where("id = ?", scanID).Scan(ctx); err != nil {
+				logrus.Warnf("Intelligence backfill: failed to load scan %s: %v", scanID, err)
+				continue
+			}
+			if err := RecordIntelligenceSnapshot(ctx, db, scan); err != nil {
+				logrus.Warnf("Intelligence backfill: failed for scan %s: %v", scanID, err)
+				continue
+			}
+			completed++
+		}
+		if completed == 0 {
+			return
+		}
+	}
+}

--- a/services/backend/scanner/intelligence_test.go
+++ b/services/backend/scanner/intelligence_test.go
@@ -1,0 +1,277 @@
+package scanner
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"justscan-backend/pkg/models"
+
+	"github.com/google/uuid"
+)
+
+func TestDerivePostureState(t *testing.T) {
+	tests := []struct {
+		name          string
+		finding       models.Vulnerability
+		evidence      models.VulnerabilityIntelligenceEvidence
+		wantState     string
+		wantReasonHas string
+	}{
+		{
+			name: "fixed version is actionable",
+			finding: models.Vulnerability{
+				Severity:  models.SeverityHigh,
+				CVSSScore: 7.5,
+			},
+			evidence: models.VulnerabilityIntelligenceEvidence{
+				Source:        "NVD",
+				CVEState:      models.IntelligenceCVEStateAffected,
+				Severity:      models.SeverityHigh,
+				FixedVersions: []string{"1.2.4"},
+				ObservedAt:    time.Now(),
+			},
+			wantState:     models.PostureStateFixAvailable,
+			wantReasonHas: "1.2.4",
+		},
+		{
+			name: "severity increase is separate from scan finding",
+			finding: models.Vulnerability{
+				Severity:  models.SeverityMedium,
+				CVSSScore: 5.0,
+			},
+			evidence: models.VulnerabilityIntelligenceEvidence{
+				Source:     "NVD",
+				CVEState:   models.IntelligenceCVEStateAffected,
+				Severity:   models.SeverityHigh,
+				CVSSScore:  8.1,
+				ObservedAt: time.Now(),
+			},
+			wantState:     models.PostureStateSeverityIncreased,
+			wantReasonHas: "NVD",
+		},
+		{
+			name: "unknown applicability requires rescan",
+			finding: models.Vulnerability{
+				Severity:  models.SeverityHigh,
+				CVSSScore: 8.1,
+			},
+			evidence: models.VulnerabilityIntelligenceEvidence{
+				Source:     "OSV",
+				CVEState:   models.IntelligenceCVEStateUnknown,
+				Severity:   models.SeverityUnknown,
+				ObservedAt: time.Now(),
+			},
+			wantState:     models.PostureStateNeedsRescan,
+			wantReasonHas: "rescan",
+		},
+		{
+			name: "explicit not affected can be represented",
+			finding: models.Vulnerability{
+				Severity: models.SeverityHigh,
+			},
+			evidence: models.VulnerabilityIntelligenceEvidence{
+				Source:     "vendor",
+				CVEState:   models.IntelligenceCVEStateNotAffected,
+				Severity:   models.SeverityUnknown,
+				ObservedAt: time.Now(),
+			},
+			wantState:     models.PostureStateNotAffected,
+			wantReasonHas: "explicitly",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			state, reason := derivePostureState(tt.finding, tt.evidence)
+			if state != tt.wantState {
+				t.Fatalf("state = %q, want %q", state, tt.wantState)
+			}
+			if !strings.Contains(strings.ToLower(reason), strings.ToLower(tt.wantReasonHas)) {
+				t.Fatalf("reason = %q, want it to contain %q", reason, tt.wantReasonHas)
+			}
+		})
+	}
+}
+
+func TestDerivePostureStoresConflictingSources(t *testing.T) {
+	findingID := uuid.New()
+	scanID := uuid.New()
+	finding := models.Vulnerability{
+		ID:       findingID,
+		ScanID:   scanID,
+		Severity: models.SeverityHigh,
+	}
+	latest := []models.VulnerabilityIntelligenceEvidence{
+		{
+			IntelligenceVersionID: uuid.New(),
+			Source:                "NVD",
+			CVEState:              models.IntelligenceCVEStateAffected,
+			Severity:              models.SeverityHigh,
+			CVSSScore:             7.5,
+			ObservedAt:            time.Date(2026, 8, 1, 10, 0, 0, 0, time.UTC),
+		},
+		{
+			IntelligenceVersionID: uuid.New(),
+			Source:                "OSV",
+			CVEState:              models.IntelligenceCVEStateAffected,
+			Severity:              models.SeverityMedium,
+			CVSSScore:             5.0,
+			ObservedAt:            time.Date(2026, 8, 1, 10, 0, 1, 0, time.UTC),
+		},
+	}
+
+	posture := derivePosture(finding, latest, map[uuid.UUID]string{})
+	if posture.State != models.PostureStateNeedsRescan {
+		t.Fatalf("state = %q, want %q", posture.State, models.PostureStateNeedsRescan)
+	}
+	if len(posture.ConflictSources) != 2 || posture.ConflictSources[0] != "NVD" || posture.ConflictSources[1] != "OSV" {
+		t.Fatalf("conflict sources = %#v, want [NVD OSV]", posture.ConflictSources)
+	}
+	if posture.Severity != models.SeverityUnknown || posture.CVSSScore != 0 {
+		t.Fatalf("conflicting posture selected a score: severity=%q score=%v", posture.Severity, posture.CVSSScore)
+	}
+}
+
+func TestIntelligenceDescriptorUsesFeedVersion(t *testing.T) {
+	updatedAt := time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
+	scan := &models.Scan{
+		ID:                      uuid.New(),
+		ScanProvider:            models.ScanProviderTrivy,
+		TrivyVersion:            "0.61.0",
+		TrivyVulnDBUpdatedAt:    &updatedAt,
+		TrivyVulnDBDownloadedAt: &updatedAt,
+	}
+
+	descriptor := intelligenceDescriptorForScan(scan)
+	if descriptor.Source != models.IntelligenceSourceTrivy {
+		t.Fatalf("source = %q, want %q", descriptor.Source, models.IntelligenceSourceTrivy)
+	}
+	if descriptor.Version != "vuln-db:2026-07-30T12:00:00Z" {
+		t.Fatalf("version = %q, want feed timestamp version", descriptor.Version)
+	}
+	if descriptor.FeedObservedAt == nil || !descriptor.FeedObservedAt.Equal(updatedAt) {
+		t.Fatalf("feed observed at = %v, want %v", descriptor.FeedObservedAt, updatedAt)
+	}
+}
+
+func TestNormalizeIntelligenceIngestRequest(t *testing.T) {
+	feedObservedAt := time.Date(2026, 8, 1, 12, 0, 0, 0, time.FixedZone("CEST", 2*60*60))
+	request, err := normalizeIntelligenceIngestRequest(IntelligenceIngestRequest{
+		Source:         " NVD ",
+		Version:        " 2026-08-01 ",
+		FeedObservedAt: &feedObservedAt,
+		Records: []IntelligenceIngestRecord{{
+			VulnID:        "CVE-2026-0001",
+			CVEState:      "not affected",
+			Severity:      "critical",
+			CVSSScore:     9.8,
+			FixedVersions: []string{" 1.2.4 ", "1.2.4", ""},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("normalize request: %v", err)
+	}
+	if request.Source != "nvd" || request.Version != "2026-08-01" {
+		t.Fatalf("normalized descriptor = %q/%q", request.Source, request.Version)
+	}
+	record := request.Records[0]
+	if record.CVEState != models.IntelligenceCVEStateNotAffected {
+		t.Fatalf("cve state = %q, want %q", record.CVEState, models.IntelligenceCVEStateNotAffected)
+	}
+	if record.Severity != models.SeverityCritical {
+		t.Fatalf("severity = %q, want %q", record.Severity, models.SeverityCritical)
+	}
+	if len(record.FixedVersions) != 1 || record.FixedVersions[0] != "1.2.4" {
+		t.Fatalf("fixed versions = %#v", record.FixedVersions)
+	}
+	if record.ObservedAt == nil || !record.ObservedAt.Equal(feedObservedAt.UTC()) {
+		t.Fatalf("observed at = %v, want %v", record.ObservedAt, feedObservedAt.UTC())
+	}
+}
+
+func TestNormalizeIntelligenceIngestRequestUnknownApplicabilityRequiresRescan(t *testing.T) {
+	request, err := normalizeIntelligenceIngestRequest(IntelligenceIngestRequest{
+		Source:  "osv",
+		Version: "feed-1",
+		Records: []IntelligenceIngestRecord{{
+			VulnID:   "CVE-2026-0002",
+			CVEState: "",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("normalize request: %v", err)
+	}
+	if request.Records[0].CVEState != models.IntelligenceCVEStateUnknown {
+		t.Fatalf("cve state = %q, want unknown", request.Records[0].CVEState)
+	}
+	state, _ := derivePostureState(models.Vulnerability{}, models.VulnerabilityIntelligenceEvidence{
+		Source:   request.Records[0].Source,
+		CVEState: request.Records[0].CVEState,
+	})
+	if state != models.PostureStateNeedsRescan {
+		t.Fatalf("state = %q, want %q", state, models.PostureStateNeedsRescan)
+	}
+}
+
+func TestLatestEvidenceForFindingPrefersFeedAndPackageSpecificRecords(t *testing.T) {
+	oldScan := models.VulnerabilityIntelligenceEvidence{
+		Source:       "NVD",
+		EvidenceKind: "scan",
+		CVEState:     models.IntelligenceCVEStateAffected,
+		Severity:     models.SeverityMedium,
+		ObservedAt:   time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC),
+	}
+	wildcardFeed := models.VulnerabilityIntelligenceEvidence{
+		Source:        "nvd",
+		EvidenceKind:  "feed",
+		CVEState:      models.IntelligenceCVEStateAffected,
+		Severity:      models.SeverityHigh,
+		FixedVersions: []string{"2.0.0"},
+		ObservedAt:    time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC),
+	}
+	exactFeed := wildcardFeed
+	exactFeed.Severity = models.SeverityCritical
+	exactFeed.FixedVersions = []string{"2.1.0"}
+
+	latest := latestEvidenceForFinding(
+		[]models.VulnerabilityIntelligenceEvidence{exactFeed},
+		[]models.VulnerabilityIntelligenceEvidence{oldScan, wildcardFeed},
+	)
+	if len(latest) != 1 {
+		t.Fatalf("latest evidence count = %d, want 1", len(latest))
+	}
+	if latest[0].Source != "nvd" || latest[0].EvidenceKind != "feed" || latest[0].Severity != models.SeverityCritical {
+		t.Fatalf("selected evidence = %#v", latest[0])
+	}
+}
+
+func TestDerivePostureCarriesFeedEvidenceFields(t *testing.T) {
+	finding := models.Vulnerability{
+		ID:       uuid.New(),
+		ScanID:   uuid.New(),
+		Severity: models.SeverityMedium,
+	}
+	ranges := []models.JSONObject{{"introduced": "1.0.0", "fixed": "1.2.0"}}
+	exploits := []models.JSONObject{{"type": "known_exploit", "available": true}}
+	posture := derivePosture(finding, []models.VulnerabilityIntelligenceEvidence{{
+		IntelligenceVersionID: uuid.New(),
+		Source:                "nvd",
+		CVEState:              models.IntelligenceCVEStateAffected,
+		Severity:              models.SeverityHigh,
+		CVSSScore:             8.2,
+		AffectedRanges:        ranges,
+		FixedVersions:         []string{"1.2.0"},
+		ExploitSignals:        exploits,
+		ObservedAt:            time.Now().UTC(),
+	}}, map[uuid.UUID]string{})
+	if posture.CVEState != models.IntelligenceCVEStateAffected {
+		t.Fatalf("cve state = %q", posture.CVEState)
+	}
+	if len(posture.AffectedRanges) != 1 || len(posture.ExploitSignals) != 1 {
+		t.Fatalf("posture evidence fields = ranges %#v exploits %#v", posture.AffectedRanges, posture.ExploitSignals)
+	}
+	if posture.State != models.PostureStateFixAvailable {
+		t.Fatalf("state = %q, want %q", posture.State, models.PostureStateFixAvailable)
+	}
+}

--- a/services/backend/scanner/worker.go
+++ b/services/backend/scanner/worker.go
@@ -130,8 +130,13 @@ func InitWorker(db *bun.DB) {
 		}()
 	}
 
-	// Backfill vuln_kb from existing vulnerabilities (best-effort, runs once in background)
-	go backfillKB(db)
+	// Backfill the KB before capturing historical intelligence so existing
+	// exploit signals are available to the first evidence snapshot. Both jobs
+	// are idempotent and safe to retry on the next startup.
+	go func() {
+		backfillKB(db)
+		BackfillVulnerabilityIntelligence(db)
+	}()
 }
 
 // EnqueueScan queues a scan job. The scan row must already exist in the DB with status=pending.
@@ -471,6 +476,12 @@ func processScan(job ScanJob, cacheDir string) {
 		Where("id = ?", scanID).Exec(context.Background()); err != nil {
 		log.Errorf("Worker: failed to mark scan %s as completed: %v", scanID, err)
 		return
+	}
+	if err := RecordIntelligenceSnapshot(context.Background(), db, scan); err != nil {
+		log.Warnf("Worker: intelligence snapshot failed for scan %s (non-fatal): %v", scanID, err)
+		recordScanStepOutput(context.Background(), db, scanID, fmt.Sprintf("Scan-time intelligence snapshot failed, but the scan result remains available: %v", err))
+	} else {
+		recordScanStepOutput(context.Background(), db, scanID, "Stored scan-time vulnerability intelligence and refreshed current posture.")
 	}
 	if err := setScanStep(context.Background(), db, scan, models.ScanStepCompleted); err != nil {
 		log.Errorf("Worker: failed to record completed step for scan %s: %v", scanID, err)

--- a/services/backend/scanner/xray.go
+++ b/services/backend/scanner/xray.go
@@ -598,6 +598,12 @@ func processXrayScan(ctx context.Context, db *bun.DB, scan *models.Scan) error {
 		Exec(ctx); err != nil {
 		return fmt.Errorf("failed to mark xray scan as completed: %w", err)
 	}
+	if err := RecordIntelligenceSnapshot(ctx, db, scan); err != nil {
+		log.Warnf("Xray: intelligence snapshot failed for scan %s (non-fatal): %v", scan.ID, err)
+		recordScanStepOutput(ctx, db, scan.ID, fmt.Sprintf("Scan-time intelligence snapshot failed, but the Xray result remains available: %v", err))
+	} else {
+		recordScanStepOutput(ctx, db, scan.ID, "Stored scan-time vulnerability intelligence and refreshed current posture.")
+	}
 	if err := setScanStep(ctx, db, scan, models.ScanStepCompleted); err != nil {
 		return err
 	}

--- a/services/docs/content/docs/scan-and-analyze/findings-and-sbom.mdx
+++ b/services/docs/content/docs/scan-and-analyze/findings-and-sbom.mdx
@@ -16,3 +16,11 @@ The dependency tree and graph are generated only from relationships supplied by 
 Use **CycloneDX** to download the retained source document. The authenticated scan page and token-shared result page expose the same package evidence; a public result does not expose this expanded investigation surface.
 
 Use suppressions only for accepted risk; document the decision with a comment and review it regularly. A suppression is not a scanner fix and should not hide an unresolved operational error. See [audit and governance](/organize-and-govern/audit-and-governance) for an evidence handoff checklist.
+
+## Living vulnerability intelligence
+
+Completed scans retain the scanner result as immutable scan-time evidence. The authenticated vulnerability response also exposes `scan_time_intelligence` and the separately derived `current_posture`; the scan response lists the `intelligence_versions` used for its feed snapshots. A newer feed can therefore update posture for an older finding without changing its original severity, finding data, or compliance verdict.
+
+Posture changes include the source, observation time, intelligence version, and reason. Conflicting source evidence is retained and surfaced as `needs_rescan`; unknown applicability is never treated as `not_affected`. Historical scans are backfilled asynchronously after the additive schema migration.
+
+Administrators can add an independent normalized feed snapshot with `POST /api/v1/admin/vulnerability-intelligence`. The request supplies a source, immutable version, and records containing CVE state, CVSS data, affected ranges, fixed versions, exploit signals, and raw source evidence. A record with an empty `package_name` applies to all packages carrying that vulnerability. Replaying the same source/version/record is idempotent; newly inserted records immediately re-evaluate matching historical findings and append posture events without rewriting scan data.


### PR DESCRIPTION
## Summary
- add additive schema and immutable source evidence for scan-time intelligence and current posture
- re-evaluate historical findings from independently ingested feed versions, including wildcard package applicability
- expose scan-time evidence, current posture, posture events, feed metadata, and the privileged ingestion API
- preserve source conflicts and route unknown applicability to `needs_rescan`

## Validation
- `env GOCACHE=/tmp/justscan-go-cache go test -count=1 ./...`
- `git diff --check`

This replacement PR contains only the Issue #298 implementation; the unrelated Node-version change remains in its original branch/PR.

Closes #298