### PR TITLE
Add guided notification rule conditions

### DIFF
--- a/services/backend/handlers/admins/notifications.go
+++ b/services/backend/handlers/admins/notifications.go
@@ -251,7 +251,7 @@ func isAllowedChannelType(channelType string) bool {
 
 func isAllowedNotificationEvent(event string) bool {
 	switch event {
-	case models.NotificationEventScanComplete, models.NotificationEventScanFailed, models.NotificationEventComplianceFailed:
+	case models.NotificationEventScanComplete, models.NotificationEventScanFailed, models.NotificationEventComplianceFailed, models.NotificationEventIntelligencePolicyImpact:
 		return true
 	default:
 		return false

--- a/services/backend/handlers/admins/notifications_test.go
+++ b/services/backend/handlers/admins/notifications_test.go
@@ -1,0 +1,16 @@
+package admins
+
+import (
+	"testing"
+
+	"justscan-backend/pkg/models"
+)
+
+func TestAdminNotificationEventValidationIncludesIntelligenceImpact(t *testing.T) {
+	if !isAllowedNotificationEvent(models.NotificationEventIntelligencePolicyImpact) {
+		t.Fatal("intelligence policy impact should be an allowed notification event")
+	}
+	if isAllowedNotificationEvent("unknown_event") {
+		t.Fatal("unknown notification events should remain rejected")
+	}
+}

--- a/services/backend/handlers/notifications/condition_options.go
+++ b/services/backend/handlers/notifications/condition_options.go
@@ -1,0 +1,495 @@
+package notifications
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"justscan-backend/functions/authz"
+	"justscan-backend/pkg/models"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/uptrace/bun"
+)
+
+// NotificationConditionOption is deliberately separate from the persisted
+// predicate type: labels and descriptions are presentation data and must not
+// leak into notification rule JSON.
+type NotificationConditionOption struct {
+	Value       string `json:"value"`
+	Label       string `json:"label"`
+	Description string `json:"description,omitempty"`
+	Group       string `json:"group,omitempty"`
+}
+
+type notificationConditionOptionContext struct {
+	scope            Scope
+	userID           uuid.UUID
+	isAdmin          bool
+	accessibleOrgIDs []uuid.UUID
+	orgID            uuid.UUID
+}
+
+var dynamicNotificationConditionFields = map[string]struct{}{
+	"user_id":          {},
+	"org_id":           {},
+	"policy_id":        {},
+	"policy_name":      {},
+	"tag":              {},
+	"image_ref":        {},
+	"xray_policy_name": {},
+	"xray_watch_name":  {},
+}
+
+// ListConditionOptions returns searchable values for condition fields whose
+// values come from scoped resources. Finite values are intentionally kept in
+// the editor catalog so they do not require a database round trip.
+func ListConditionOptions(c *gin.Context, db *bun.DB, scope Scope) {
+	field := strings.ToLower(strings.TrimSpace(c.Query("field")))
+	if _, ok := dynamicNotificationConditionFields[field]; !ok {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "unsupported condition option field"})
+		return
+	}
+
+	optionContext, ok := resolveNotificationConditionOptionContext(c, db, scope)
+	if !ok {
+		return
+	}
+
+	limit := normalizeLimit(c.DefaultQuery("limit", "50"), 50, 100)
+	query := strings.TrimSpace(c.Query("q"))
+	if len(query) > 200 {
+		query = query[:200]
+	}
+
+	options, err := loadNotificationConditionOptions(c, db, optionContext, field, query, limit)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to load condition options"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": options})
+}
+
+func resolveNotificationConditionOptionContext(c *gin.Context, db *bun.DB, scope Scope) (notificationConditionOptionContext, bool) {
+	result := notificationConditionOptionContext{scope: scope}
+
+	switch scope.Type {
+	case models.NotificationScopeSystem:
+		// The admin middleware owns this authorization boundary. System values
+		// are therefore allowed to include all persisted resources.
+		result.isAdmin = true
+		return result, true
+	case models.NotificationScopeOrg:
+		orgID, err := uuid.Parse(scope.Ref)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid organization scope"})
+			return notificationConditionOptionContext{}, false
+		}
+		userID, isAdmin, ok := authz.RequireRequestUser(c, db)
+		if !ok {
+			return notificationConditionOptionContext{}, false
+		}
+		result.orgID = orgID
+		result.userID = userID
+		result.isAdmin = isAdmin
+		return result, true
+	case models.NotificationScopeUser:
+		requestedUserID, err := uuid.Parse(scope.Ref)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid user scope"})
+			return notificationConditionOptionContext{}, false
+		}
+		userID, isAdmin, ok := authz.RequireRequestUser(c, db)
+		if !ok {
+			return notificationConditionOptionContext{}, false
+		}
+		if userID != requestedUserID && !isAdmin {
+			c.JSON(http.StatusForbidden, gin.H{"error": "insufficient notification scope"})
+			return notificationConditionOptionContext{}, false
+		}
+		accessibleOrgIDs, err := authz.ListAccessibleOrgIDs(c.Request.Context(), db, userID, isAdmin)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to resolve organization access"})
+			return notificationConditionOptionContext{}, false
+		}
+		result.userID = userID
+		result.isAdmin = isAdmin
+		result.accessibleOrgIDs = accessibleOrgIDs
+		return result, true
+	default:
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid notification scope"})
+		return notificationConditionOptionContext{}, false
+	}
+}
+
+func loadNotificationConditionOptions(
+	c *gin.Context,
+	db *bun.DB,
+	optionContext notificationConditionOptionContext,
+	field string,
+	query string,
+	limit int,
+) ([]NotificationConditionOption, error) {
+	switch field {
+	case "user_id":
+		return loadNotificationUserOptions(c, db, optionContext, query, limit)
+	case "org_id":
+		return loadNotificationOrgOptions(c, db, optionContext, query, limit)
+	case "policy_id", "policy_name":
+		return loadNotificationPolicyOptions(c, db, optionContext, field, query, limit)
+	case "tag":
+		return loadNotificationTagOptions(c, db, optionContext, query, limit)
+	case "image_ref":
+		return loadNotificationImageOptions(c, db, optionContext, query, limit)
+	case "xray_policy_name", "xray_watch_name":
+		return loadNotificationXrayOptions(c, db, optionContext, field, query, limit)
+	default:
+		return nil, fmt.Errorf("unsupported condition option field %q", field)
+	}
+}
+
+func loadNotificationUserOptions(
+	c *gin.Context,
+	db *bun.DB,
+	optionContext notificationConditionOptionContext,
+	query string,
+	limit int,
+) ([]NotificationConditionOption, error) {
+	where := "1 = 1"
+	args := make([]interface{}, 0)
+	join := ""
+	switch optionContext.scope.Type {
+	case models.NotificationScopeOrg:
+		where = "om.org_id = ?"
+		args = append(args, optionContext.orgID)
+	case models.NotificationScopeUser:
+		if !optionContext.isAdmin {
+			clauses := []string{"u.id = ?"}
+			args = append(args, optionContext.userID)
+			if len(optionContext.accessibleOrgIDs) > 0 {
+				join = "LEFT JOIN org_members om ON om.user_id = u.id"
+				clauses = append(clauses, "om.org_id IN (?)")
+				args = append(args, bun.In(optionContext.accessibleOrgIDs))
+			}
+			where = "(" + strings.Join(clauses, " OR ") + ")"
+		}
+	}
+
+	if optionContext.scope.Type == models.NotificationScopeOrg {
+		join = "JOIN org_members om ON om.user_id = u.id"
+	}
+	search, searchArgs := notificationOptionSearch(query, "u.username", "u.email", "u.id::text")
+	where, args = appendNotificationOptionSearch(where, args, search, searchArgs)
+
+	sql := fmt.Sprintf(`
+		SELECT DISTINCT
+			u.id::text AS value,
+			COALESCE(NULLIF(u.username, ''), NULLIF(u.email, ''), u.id::text) AS label,
+			COALESCE(u.email, '') AS description,
+			'Users' AS group_name
+		FROM users u
+		%s
+		WHERE %s
+		ORDER BY label ASC
+		LIMIT ?`, join, where)
+	args = append(args, limit)
+	return scanNotificationConditionOptions(c, db, sql, args...)
+}
+
+func loadNotificationOrgOptions(
+	c *gin.Context,
+	db *bun.DB,
+	optionContext notificationConditionOptionContext,
+	query string,
+	limit int,
+) ([]NotificationConditionOption, error) {
+	where := "1 = 1"
+	args := make([]interface{}, 0)
+	switch optionContext.scope.Type {
+	case models.NotificationScopeOrg:
+		where = "o.id = ?"
+		args = append(args, optionContext.orgID)
+	case models.NotificationScopeUser:
+		if !optionContext.isAdmin {
+			if len(optionContext.accessibleOrgIDs) == 0 {
+				where = "1 = 0"
+			} else {
+				where = "o.id IN (?)"
+				args = append(args, bun.In(optionContext.accessibleOrgIDs))
+			}
+		}
+	}
+	search, searchArgs := notificationOptionSearch(query, "o.name", "o.description", "o.id::text")
+	where, args = appendNotificationOptionSearch(where, args, search, searchArgs)
+
+	sql := fmt.Sprintf(`
+		SELECT
+			o.id::text AS value,
+			o.name AS label,
+			COALESCE(o.description, '') AS description,
+			'Organizations' AS group_name
+		FROM orgs o
+		WHERE %s
+		ORDER BY label ASC
+		LIMIT ?`, where)
+	args = append(args, limit)
+	return scanNotificationConditionOptions(c, db, sql, args...)
+}
+
+func loadNotificationPolicyOptions(
+	c *gin.Context,
+	db *bun.DB,
+	optionContext notificationConditionOptionContext,
+	field string,
+	query string,
+	limit int,
+) ([]NotificationConditionOption, error) {
+	where := "1 = 1"
+	args := make([]interface{}, 0)
+	switch optionContext.scope.Type {
+	case models.NotificationScopeOrg:
+		where = "p.org_id = ?"
+		args = append(args, optionContext.orgID)
+	case models.NotificationScopeUser:
+		if !optionContext.isAdmin {
+			if len(optionContext.accessibleOrgIDs) == 0 {
+				where = "1 = 0"
+			} else {
+				where = "p.org_id IN (?)"
+				args = append(args, bun.In(optionContext.accessibleOrgIDs))
+			}
+		}
+	}
+	search, searchArgs := notificationOptionSearch(query, "p.name", "p.id::text", "o.name")
+	where, args = appendNotificationOptionSearch(where, args, search, searchArgs)
+	value := "p.id::text"
+	if field == "policy_name" {
+		value = "p.name"
+	}
+
+	sql := fmt.Sprintf(`
+		SELECT
+			%s AS value,
+			p.name AS label,
+			COALESCE(o.name, '') AS description,
+			'Policies' AS group_name
+		FROM org_policies p
+		JOIN orgs o ON o.id = p.org_id
+		WHERE %s
+		ORDER BY label ASC
+		LIMIT ?`, value, where)
+	args = append(args, limit)
+	return scanNotificationConditionOptions(c, db, sql, args...)
+}
+
+func loadNotificationTagOptions(
+	c *gin.Context,
+	db *bun.DB,
+	optionContext notificationConditionOptionContext,
+	query string,
+	limit int,
+) ([]NotificationConditionOption, error) {
+	where := "1 = 1"
+	args := make([]interface{}, 0)
+	if !optionContext.isAdmin && optionContext.scope.Type != models.NotificationScopeSystem {
+		clauses := []string{"t.owner_type = ?"}
+		args = append(args, models.OwnerTypeSystem)
+		if optionContext.scope.Type == models.NotificationScopeOrg {
+			clauses = append(clauses,
+				"t.owner_user_id = ?",
+				"t.owner_org_id = ?",
+			)
+			args = append(args, optionContext.userID, optionContext.orgID)
+			clauses = append(clauses,
+				"EXISTS (SELECT 1 FROM org_tags shared WHERE shared.tag_id = t.id AND shared.org_id = ?)",
+			)
+			args = append(args, optionContext.orgID)
+		} else {
+			clauses = append(clauses, "t.owner_user_id = ?")
+			args = append(args, optionContext.userID)
+			if len(optionContext.accessibleOrgIDs) > 0 {
+				clauses = append(clauses,
+					"t.owner_org_id IN (?)",
+					"EXISTS (SELECT 1 FROM org_tags shared WHERE shared.tag_id = t.id AND shared.org_id IN (?))",
+				)
+				args = append(args, bun.In(optionContext.accessibleOrgIDs), bun.In(optionContext.accessibleOrgIDs))
+			}
+		}
+		where = "(" + strings.Join(clauses, " OR ") + ")"
+	}
+	search, searchArgs := notificationOptionSearch(query, "t.name", "t.id::text")
+	where, args = appendNotificationOptionSearch(where, args, search, searchArgs)
+
+	sql := fmt.Sprintf(`
+		SELECT DISTINCT
+			t.name AS value,
+			t.name AS label,
+			'' AS description,
+			'Tags' AS group_name
+		FROM tags t
+		WHERE %s
+		ORDER BY label ASC
+		LIMIT ?`, where)
+	args = append(args, limit)
+	return scanNotificationConditionOptions(c, db, sql, args...)
+}
+
+func loadNotificationImageOptions(
+	c *gin.Context,
+	db *bun.DB,
+	optionContext notificationConditionOptionContext,
+	query string,
+	limit int,
+) ([]NotificationConditionOption, error) {
+	visibility, visibilityArgs := notificationScanVisibilityClause(optionContext, "s")
+	search, searchArgs := notificationOptionSearch(query, "image_options.value")
+	where := "value <> ''"
+	args := append([]interface{}{}, visibilityArgs...)
+	if search != "" {
+		where, args = appendNotificationOptionSearch(where, args, search, searchArgs)
+	}
+
+	sql := fmt.Sprintf(`
+		SELECT value, value AS label, '' AS description, 'Scanned images' AS group_name
+		FROM (
+			SELECT DISTINCT CONCAT_WS(':', NULLIF(s.image_name, ''), NULLIF(s.image_tag, '')) AS value
+			FROM scans s
+			WHERE %s
+		) AS image_options
+		WHERE %s
+		ORDER BY label ASC
+		LIMIT ?`, visibility, where)
+	args = append(args, limit)
+	return scanNotificationConditionOptions(c, db, sql, args...)
+}
+
+func loadNotificationXrayOptions(
+	c *gin.Context,
+	db *bun.DB,
+	optionContext notificationConditionOptionContext,
+	field string,
+	query string,
+	limit int,
+) ([]NotificationConditionOption, error) {
+	visibility, visibilityArgs := notificationScanVisibilityClause(optionContext, "s")
+	var valueQueries string
+	switch field {
+	case "xray_watch_name":
+		valueQueries = fmt.Sprintf(`
+			SELECT NULLIF(v.xray_watch_name, '') AS value
+			FROM vulnerabilities v
+			JOIN scans s ON s.id = v.scan_id
+			WHERE %s
+			UNION ALL
+			SELECT NULLIF(w.watch_name, '') AS value
+			FROM vulnerabilities v
+			JOIN scans s ON s.id = v.scan_id
+			CROSS JOIN LATERAL jsonb_array_elements_text(COALESCE(v.xray_watch_names, '[]'::jsonb)) AS w(watch_name)
+			WHERE %s`, visibility, visibility)
+	case "xray_policy_name":
+		valueQueries = fmt.Sprintf(`
+			SELECT NULLIF(policy.policy->>'policy', '') AS value
+			FROM vulnerabilities v
+			JOIN scans s ON s.id = v.scan_id
+			CROSS JOIN LATERAL jsonb_array_elements(COALESCE(v.xray_matched_policies, '[]'::jsonb)) AS policy(policy)
+			WHERE %s
+			UNION ALL
+			SELECT NULLIF(policy.policy->>'policy', '') AS value
+			FROM vulnerabilities v
+			JOIN scans s ON s.id = v.scan_id
+			CROSS JOIN LATERAL jsonb_array_elements(COALESCE(v.xray_watch_policy_matches, '[]'::jsonb)) AS policy(policy)
+			WHERE %s`, visibility, visibility)
+	default:
+		return nil, fmt.Errorf("unsupported Xray condition option field %q", field)
+	}
+
+	where := "value IS NOT NULL"
+	search, searchArgs := notificationOptionSearch(query, "xray_options.value")
+	args := make([]interface{}, 0, len(visibilityArgs)*2+len(searchArgs)+1)
+	args = append(args, visibilityArgs...)
+	args = append(args, visibilityArgs...)
+	if search != "" {
+		where, args = appendNotificationOptionSearch(where, args, search, searchArgs)
+	}
+
+	sql := fmt.Sprintf(`
+		SELECT DISTINCT value, value AS label, '' AS description, 'Xray values' AS group_name
+		FROM (%s) AS xray_options
+		WHERE %s
+		ORDER BY label ASC
+		LIMIT ?`, valueQueries, where)
+	args = append(args, limit)
+	return scanNotificationConditionOptions(c, db, sql, args...)
+}
+
+func notificationScanVisibilityClause(optionContext notificationConditionOptionContext, alias string) (string, []interface{}) {
+	if optionContext.isAdmin || optionContext.scope.Type == models.NotificationScopeSystem {
+		return "1 = 1", nil
+	}
+	if optionContext.scope.Type == models.NotificationScopeOrg {
+		return fmt.Sprintf("(%s.owner_org_id = ? OR EXISTS (SELECT 1 FROM org_scans os WHERE os.scan_id = %s.id AND os.org_id = ?))", alias, alias), []interface{}{optionContext.orgID, optionContext.orgID}
+	}
+
+	clauses := []string{
+		fmt.Sprintf("%s.user_id = ?", alias),
+		fmt.Sprintf("%s.owner_user_id = ?", alias),
+	}
+	args := []interface{}{optionContext.userID, optionContext.userID}
+	if len(optionContext.accessibleOrgIDs) > 0 {
+		clauses = append(clauses,
+			fmt.Sprintf("%s.owner_org_id IN (?)", alias),
+			fmt.Sprintf("EXISTS (SELECT 1 FROM org_scans os WHERE os.scan_id = %s.id AND os.org_id IN (?))", alias),
+		)
+		args = append(args, bun.In(optionContext.accessibleOrgIDs), bun.In(optionContext.accessibleOrgIDs))
+	}
+	return "(" + strings.Join(clauses, " OR ") + ")", args
+}
+
+func notificationOptionSearch(query string, expressions ...string) (string, []interface{}) {
+	query = strings.TrimSpace(query)
+	if query == "" || len(expressions) == 0 {
+		return "", nil
+	}
+	pattern := "%" + query + "%"
+	parts := make([]string, 0, len(expressions))
+	args := make([]interface{}, 0, len(expressions))
+	for _, expression := range expressions {
+		parts = append(parts, expression+" ILIKE ?")
+		args = append(args, pattern)
+	}
+	return "(" + strings.Join(parts, " OR ") + ")", args
+}
+
+func appendNotificationOptionSearch(where string, args []interface{}, search string, searchArgs []interface{}) (string, []interface{}) {
+	if search == "" {
+		return where, args
+	}
+	return where + " AND " + search, append(args, searchArgs...)
+}
+
+func scanNotificationConditionOptions(c *gin.Context, db *bun.DB, query string, args ...interface{}) ([]NotificationConditionOption, error) {
+	var rows []struct {
+		Value       string `bun:"value"`
+		Label       string `bun:"label"`
+		Description string `bun:"description"`
+		Group       string `bun:"group_name"`
+	}
+	if err := db.NewRaw(query, args...).Scan(c.Request.Context(), &rows); err != nil {
+		return nil, err
+	}
+	options := make([]NotificationConditionOption, 0, len(rows))
+	for _, row := range rows {
+		value := strings.TrimSpace(row.Value)
+		if value == "" {
+			continue
+		}
+		options = append(options, NotificationConditionOption{
+			Value:       value,
+			Label:       strings.TrimSpace(row.Label),
+			Description: strings.TrimSpace(row.Description),
+			Group:       strings.TrimSpace(row.Group),
+		})
+	}
+	return options, nil
+}

--- a/services/backend/handlers/notifications/condition_options_test.go
+++ b/services/backend/handlers/notifications/condition_options_test.go
@@ -1,0 +1,176 @@
+package notifications
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"justscan-backend/middlewares"
+	"justscan-backend/pkg/models"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/uptrace/bun"
+	"github.com/uptrace/bun/dialect/pgdialect"
+)
+
+func TestNotificationConditionOptionScopeVisibility(t *testing.T) {
+	userID := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	orgID := uuid.MustParse("22222222-2222-2222-2222-222222222222")
+
+	tests := []struct {
+		name           string
+		optionCtx      notificationConditionOptionContext
+		mustContain    []string
+		mustNotContain []string
+	}{
+		{
+			name: "personal scope includes owned and accessible organization scans",
+			optionCtx: notificationConditionOptionContext{
+				scope:            UserScope(userID),
+				userID:           userID,
+				accessibleOrgIDs: []uuid.UUID{orgID},
+			},
+			mustContain: []string{"s.user_id = ?", "s.owner_user_id = ?", "s.owner_org_id IN (?)", "org_scans"},
+		},
+		{
+			name: "organization scope includes owned and shared scans",
+			optionCtx: notificationConditionOptionContext{
+				scope: OrgScope(orgID),
+				orgID: orgID,
+			},
+			mustContain: []string{"s.owner_org_id = ?", "os.org_id = ?"},
+		},
+		{
+			name: "system scope is unrestricted only for the system context",
+			optionCtx: notificationConditionOptionContext{
+				scope:   SystemScope(),
+				isAdmin: true,
+			},
+			mustContain:    []string{"1 = 1"},
+			mustNotContain: []string{"owner_org_id", "org_scans"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			clause, args := notificationScanVisibilityClause(test.optionCtx, "s")
+			for _, expected := range test.mustContain {
+				if !strings.Contains(clause, expected) {
+					t.Fatalf("visibility clause %q does not contain %q", clause, expected)
+				}
+			}
+			for _, unexpected := range test.mustNotContain {
+				if strings.Contains(clause, unexpected) {
+					t.Fatalf("visibility clause %q unexpectedly contains %q", clause, unexpected)
+				}
+			}
+			if test.optionCtx.scope.Type == models.NotificationScopeSystem && len(args) != 0 {
+				t.Fatalf("system scope should not require query arguments, got %v", args)
+			}
+		})
+	}
+}
+
+func TestNotificationConditionOptionSearch(t *testing.T) {
+	clause, args := notificationOptionSearch("prod", "name", "id::text")
+	if clause != "(name ILIKE ? OR id::text ILIKE ?)" {
+		t.Fatalf("search clause = %q", clause)
+	}
+	if len(args) != 2 || args[0] != "%prod%" || args[1] != "%prod%" {
+		t.Fatalf("search args = %#v", args)
+	}
+}
+
+func TestNotificationConditionOptionLookupScopes(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	orgID := uuid.MustParse("22222222-2222-2222-2222-222222222222")
+	userID := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+
+	tests := []struct {
+		name       string
+		scope      Scope
+		setUser    bool
+		setup      func(sqlmock.Sqlmock)
+		wantStatus int
+	}{
+		{
+			name:  "system",
+			scope: SystemScope(),
+			setup: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery(`(?s).*`).
+					WillReturnRows(sqlmock.NewRows([]string{"value", "label", "description", "group_name"}).AddRow(orgID.String(), "Acme", "", "Organizations"))
+			},
+			wantStatus: 200,
+		},
+		{
+			name:    "organization",
+			scope:   OrgScope(orgID),
+			setUser: true,
+			setup: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery(`(?s).*`).
+					WillReturnRows(sqlmock.NewRows([]string{"value", "label", "description", "group_name"}).AddRow(orgID.String(), "Acme", "", "Organizations"))
+			},
+			wantStatus: 200,
+		},
+		{
+			name:    "personal",
+			scope:   UserScope(userID),
+			setUser: true,
+			setup: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery(`(?s).*`).
+					WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(orgID))
+				mock.ExpectQuery(`(?s).*`).
+					WillReturnRows(sqlmock.NewRows([]string{"value", "label", "description", "group_name"}).AddRow(orgID.String(), "Acme", "", "Organizations"))
+			},
+			wantStatus: 200,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			db, mock, closeDB := newConditionOptionsMockDB(t)
+			defer closeDB()
+			test.setup(mock)
+
+			request := httptest.NewRequest("GET", "/notifications/condition-options?field=org_id&limit=5", nil)
+			response := httptest.NewRecorder()
+			context, _ := gin.CreateTestContext(response)
+			context.Request = request
+			if test.setUser {
+				context.Set(middlewares.AuthContextUserIDKey, userID)
+				context.Set(middlewares.AuthContextIsAdminKey, false)
+			}
+
+			ListConditionOptions(context, db, test.scope)
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Fatalf("mock expectations: %v; body=%s", err, response.Body.String())
+			}
+			if response.Code != test.wantStatus {
+				t.Fatalf("status = %d, want %d; body=%s", response.Code, test.wantStatus, response.Body.String())
+			}
+		})
+	}
+}
+
+func TestNotificationEventValidationIncludesIntelligenceImpact(t *testing.T) {
+	if !isAllowedNotificationEvent(models.NotificationEventIntelligencePolicyImpact) {
+		t.Fatal("intelligence policy impact should be an allowed notification event")
+	}
+	if isAllowedNotificationEvent("unknown_event") {
+		t.Fatal("unknown notification events should remain rejected")
+	}
+}
+
+func newConditionOptionsMockDB(t *testing.T) (*bun.DB, sqlmock.Sqlmock, func()) {
+	t.Helper()
+	sqlDB, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create sqlmock database: %v", err)
+	}
+	db := bun.NewDB(sqlDB, pgdialect.New())
+	return db, mock, func() {
+		_ = db.Close()
+	}
+}

--- a/services/backend/handlers/notifications/notifications.go
+++ b/services/backend/handlers/notifications/notifications.go
@@ -484,6 +484,8 @@ func isAllowedNotificationEvent(event string) bool {
 	switch event {
 	case models.NotificationEventScanComplete, models.NotificationEventScanFailed, models.NotificationEventComplianceFailed:
 		return true
+	case models.NotificationEventIntelligencePolicyImpact:
+		return true
 	default:
 		return false
 	}

--- a/services/backend/notifications/rules_test.go
+++ b/services/backend/notifications/rules_test.go
@@ -115,3 +115,53 @@ func TestRuleMatchesIntelligenceImpactConditions(t *testing.T) {
 		t.Fatal("expected different intelligence impact not to match")
 	}
 }
+
+func TestRuleMatchesGuidedEnumBooleanAndNumericConditions(t *testing.T) {
+	rule := models.NotificationRule{
+		Enabled: true,
+		Conditions: models.JSONObject{
+			"op": "all",
+			"conditions": []models.JSONObject{
+				{"field": "scan_status", "operator": "eq", "value": "completed"},
+				{"field": "xray_blocked", "operator": "eq", "value": true},
+				{"field": "critical_count", "operator": "gte", "value": 2},
+			},
+		},
+	}
+
+	payload := Payload{Status: "completed", XrayBlocked: true, CriticalCount: 3}
+	if !ruleMatches(rule, payload) {
+		t.Fatal("expected enum, boolean, and numeric conditions to match")
+	}
+
+	payload.XrayBlocked = false
+	if ruleMatches(rule, payload) {
+		t.Fatal("expected boolean condition to reject a non-matching payload")
+	}
+}
+
+func TestRuleMatchesMultiValueConditions(t *testing.T) {
+	rule := models.NotificationRule{
+		Enabled: true,
+		Conditions: models.JSONObject{
+			"op": "all",
+			"conditions": []models.JSONObject{
+				{"field": "event_type", "operator": "in", "value": []string{"scan_complete", "scan_failed"}},
+				{"field": "tag", "operator": "in", "value": []string{"production", "release"}},
+			},
+		},
+	}
+
+	payload := Payload{
+		Event: models.NotificationEventScanFailed,
+		Tags:  []string{"production"},
+	}
+	if !ruleMatches(rule, payload) {
+		t.Fatal("expected multi-value conditions to match")
+	}
+
+	payload.Tags = []string{"development"}
+	if ruleMatches(rule, payload) {
+		t.Fatal("expected multi-value condition to reject a missing value")
+	}
+}

--- a/services/backend/router/admin.go
+++ b/services/backend/router/admin.go
@@ -127,6 +127,9 @@ func Admin(router *gin.RouterGroup, db *bun.DB) {
 		admin.GET("/notifications/rules", func(c *gin.Context) {
 			notificationhandlers.ListRules(c, db, notificationhandlers.SystemScope())
 		})
+		admin.GET("/notifications/condition-options", func(c *gin.Context) {
+			notificationhandlers.ListConditionOptions(c, db, notificationhandlers.SystemScope())
+		})
 		admin.POST("/notifications/rules", func(c *gin.Context) {
 			notificationhandlers.CreateRule(c, db, notificationhandlers.SystemScope())
 		})

--- a/services/backend/router/org.go
+++ b/services/backend/router/org.go
@@ -101,6 +101,13 @@ func Orgs(router *gin.RouterGroup, db *bun.DB) {
 			}
 			notificationhandlers.ListRules(c, db, scope)
 		})
+		r.GET("/:id/notifications/condition-options", func(c *gin.Context) {
+			scope, ok := notificationhandlers.RequireOrgViewerScope(c, db)
+			if !ok {
+				return
+			}
+			notificationhandlers.ListConditionOptions(c, db, scope)
+		})
 		r.POST("/:id/notifications/rules", func(c *gin.Context) {
 			scope, ok := notificationhandlers.RequireOrgAdminScope(c, db)
 			if !ok {

--- a/services/backend/router/user.go
+++ b/services/backend/router/user.go
@@ -89,6 +89,13 @@ func User(router *gin.RouterGroup, db *bun.DB) {
 			}
 			notificationhandlers.ListRules(c, db, scope)
 		})
+		user.GET("/notifications/condition-options", func(c *gin.Context) {
+			scope, ok := notificationhandlers.RequireUserScope(c)
+			if !ok {
+				return
+			}
+			notificationhandlers.ListConditionOptions(c, db, scope)
+		})
 		user.POST("/notifications/rules", func(c *gin.Context) {
 			scope, ok := notificationhandlers.RequireUserScope(c)
 			if !ok {

--- a/services/docs/content/docs/organize-and-govern/notifications-and-status-pages.mdx
+++ b/services/docs/content/docs/organize-and-govern/notifications-and-status-pages.mdx
@@ -7,6 +7,14 @@ Create notification channels and rules at the personal or organization level, th
 
 Status pages expose a controlled set of image health signals. Choose the intended visibility, select the targets, set freshness expectations, and share or transfer the page using the same ownership controls as other resources.
 
+## Guided notification rule conditions
+
+The rule editor uses a guided value control for each condition. Event types, scan providers, scan statuses, severities, compliance and intelligence statuses, and boolean values are selected from known options. CVSS scores and finding counts use numeric inputs.
+
+Conditions that refer to resources—such as users, organizations, policies, tags, images, and Xray policies or watches—provide searchable suggestions. Suggestions are limited to values visible in the current personal, organization, or system notification scope. The stored value remains the resource ID when the condition uses an ID field; the label is only there to make the choice understandable.
+
+Use `contains`, `matches`, or `matches_any` where offered when a partial or pattern value is intentional. Those operators allow custom entry for pattern-capable fields. Existing values that are no longer available in the current scope are shown as flagged saved legacy values and are preserved until you replace them.
+
 ## Git repository sources
 
 A status page can also follow one or more Git repositories. This is useful for GitOps deployments where image tags or digests change frequently: JustScan uses the non-excluded image inventory from each repository’s latest completed or partial discovery run, so new references appear automatically and removed references stop appearing.

--- a/services/frontend/components/notifications/condition-catalog.ts
+++ b/services/frontend/components/notifications/condition-catalog.ts
@@ -1,0 +1,437 @@
+import type {
+  NotificationConditionOption as ApiNotificationConditionOption,
+  NotificationConditionPredicate,
+} from '@/lib/api';
+
+export type ConditionValue = string | string[];
+
+export type ConditionOption = ApiNotificationConditionOption & {
+  legacy?: boolean;
+};
+
+export const eventTypeOptions: ConditionOption[] = [
+  { value: 'scan_complete', label: 'Scan complete' },
+  { value: 'scan_failed', label: 'Scan failed' },
+  { value: 'compliance_failed', label: 'Compliance failed' },
+  { value: 'intelligence_policy_impact', label: 'CVE intelligence policy impact' },
+];
+
+const scanProviderOptions: ConditionOption[] = [
+  { value: 'trivy', label: 'Trivy' },
+  { value: 'artifactory_xray', label: 'Artifactory Xray' },
+];
+
+const scanStatusOptions: ConditionOption[] = [
+  { value: 'pending', label: 'Pending' },
+  { value: 'running', label: 'Running' },
+  { value: 'completed', label: 'Completed' },
+  { value: 'failed', label: 'Failed' },
+  { value: 'cancelled', label: 'Cancelled' },
+];
+
+const severityOptions: ConditionOption[] = [
+  { value: 'UNKNOWN', label: 'Unknown' },
+  { value: 'LOW', label: 'Low' },
+  { value: 'MEDIUM', label: 'Medium' },
+  { value: 'HIGH', label: 'High' },
+  { value: 'CRITICAL', label: 'Critical' },
+];
+
+const complianceStatusOptions: ConditionOption[] = [
+  { value: 'pass', label: 'Pass' },
+  { value: 'fail', label: 'Fail' },
+  { value: 'needs_validation', label: 'Needs validation' },
+  { value: 'mixed', label: 'Mixed' },
+];
+
+const intelligenceImpactOptions: ConditionOption[] = [
+  { value: 'resolved', label: 'Resolved' },
+  { value: 'new_failure', label: 'New failure' },
+  { value: 'still_failed', label: 'Still failed' },
+  { value: 'needs_validation', label: 'Needs validation' },
+];
+
+const booleanOptions: ConditionOption[] = [
+  { value: 'true', label: 'Yes' },
+  { value: 'false', label: 'No' },
+];
+
+export const conditionFieldOptions = [
+  'event_type',
+  'user_id',
+  'org_id',
+  'image_ref',
+  'scan_provider',
+  'scan_status',
+  'highest_severity',
+  'highest_cvss',
+  'critical_count',
+  'high_count',
+  'medium_count',
+  'low_count',
+  'unknown_count',
+  'suppressed_count',
+  'compliance_failed',
+  'compliance_status',
+  'policy_id',
+  'policy_name',
+  'intelligence_impact',
+  'historical_compliance_status',
+  'current_compliance_status',
+  'xray_blocked',
+  'xray_policy_name',
+  'xray_watch_name',
+  'tag',
+] as const;
+
+export type ConditionField = (typeof conditionFieldOptions)[number];
+export type ConditionKind = 'enum' | 'dynamic' | 'pattern' | 'numeric' | 'boolean' | 'severity';
+
+export const conditionFieldLabels: Record<ConditionField, string> = {
+  event_type: 'Event type',
+  user_id: 'User',
+  org_id: 'Organization',
+  image_ref: 'Image reference',
+  scan_provider: 'Scan provider',
+  scan_status: 'Scan status',
+  highest_severity: 'Highest severity',
+  highest_cvss: 'Highest CVSS',
+  critical_count: 'Critical findings',
+  high_count: 'High findings',
+  medium_count: 'Medium findings',
+  low_count: 'Low findings',
+  unknown_count: 'Unknown findings',
+  suppressed_count: 'Suppressed findings',
+  compliance_failed: 'Compliance failed',
+  compliance_status: 'Compliance status',
+  policy_id: 'Policy ID',
+  policy_name: 'Policy name',
+  intelligence_impact: 'Intelligence impact',
+  historical_compliance_status: 'Historical compliance status',
+  current_compliance_status: 'Current compliance status',
+  xray_blocked: 'Blocked by Xray',
+  xray_policy_name: 'Xray policy name',
+  xray_watch_name: 'Xray watch name',
+  tag: 'Tag',
+};
+
+export const operatorLabels: Record<string, string> = {
+  eq: 'is',
+  neq: 'is not',
+  contains: 'contains',
+  in: 'is one of',
+  matches: 'matches pattern',
+  matches_any: 'matches any pattern',
+  gte: 'is at least',
+  gt: 'is greater than',
+  lte: 'is at most',
+  lt: 'is less than',
+  gte_severity: 'is at least severity',
+};
+
+const operatorOptionsByKind: Record<ConditionKind, string[]> = {
+  enum: ['eq', 'neq', 'in'],
+  dynamic: ['eq', 'neq', 'in'],
+  pattern: ['eq', 'neq', 'contains', 'in', 'matches_any'],
+  numeric: ['eq', 'gte', 'gt', 'lte', 'lt'],
+  boolean: ['eq'],
+  severity: ['eq', 'gte_severity'],
+};
+
+type ConditionDefinition = {
+  label: string;
+  kind: ConditionKind;
+  operators?: string[];
+  defaultOperator?: string;
+  options?: ConditionOption[];
+  placeholder?: string;
+  description?: string;
+  defaultValue: string;
+};
+
+const definitions: Record<ConditionField, ConditionDefinition> = {
+  event_type: {
+    label: conditionFieldLabels.event_type,
+    kind: 'enum',
+    options: eventTypeOptions,
+    defaultValue: eventTypeOptions[0].value,
+  },
+  user_id: {
+    label: conditionFieldLabels.user_id,
+    kind: 'dynamic',
+    placeholder: 'Search users',
+    description: 'Only users visible in this notification scope are suggested.',
+    defaultValue: '',
+  },
+  org_id: {
+    label: conditionFieldLabels.org_id,
+    kind: 'dynamic',
+    placeholder: 'Search organizations',
+    description: 'Only organizations visible in this notification scope are suggested.',
+    defaultValue: '',
+  },
+  image_ref: {
+    label: conditionFieldLabels.image_ref,
+    kind: 'pattern',
+    operators: ['eq', 'contains', 'matches', 'matches_any'],
+    placeholder: 'Search images or type a pattern',
+    description: 'Use contains or a pattern operator for an image not in the suggestions.',
+    defaultValue: '',
+  },
+  scan_provider: {
+    label: conditionFieldLabels.scan_provider,
+    kind: 'enum',
+    options: scanProviderOptions,
+    defaultValue: scanProviderOptions[0].value,
+  },
+  scan_status: {
+    label: conditionFieldLabels.scan_status,
+    kind: 'enum',
+    options: scanStatusOptions,
+    defaultValue: scanStatusOptions[0].value,
+  },
+  highest_severity: {
+    label: conditionFieldLabels.highest_severity,
+    kind: 'severity',
+    options: severityOptions,
+    defaultValue: 'HIGH',
+  },
+  highest_cvss: {
+    label: conditionFieldLabels.highest_cvss,
+    kind: 'numeric',
+    defaultOperator: 'gte',
+    placeholder: '7.0',
+    description: 'Enter a CVSS score from 0 to 10.',
+    defaultValue: '7',
+  },
+  critical_count: {
+    label: conditionFieldLabels.critical_count,
+    kind: 'numeric',
+    placeholder: '1',
+    defaultValue: '0',
+  },
+  high_count: {
+    label: conditionFieldLabels.high_count,
+    kind: 'numeric',
+    placeholder: '5',
+    defaultValue: '0',
+  },
+  medium_count: {
+    label: conditionFieldLabels.medium_count,
+    kind: 'numeric',
+    placeholder: '10',
+    defaultValue: '0',
+  },
+  low_count: {
+    label: conditionFieldLabels.low_count,
+    kind: 'numeric',
+    placeholder: '20',
+    defaultValue: '0',
+  },
+  unknown_count: {
+    label: conditionFieldLabels.unknown_count,
+    kind: 'numeric',
+    placeholder: '0',
+    defaultValue: '0',
+  },
+  suppressed_count: {
+    label: conditionFieldLabels.suppressed_count,
+    kind: 'numeric',
+    placeholder: '0',
+    defaultValue: '0',
+  },
+  compliance_failed: {
+    label: conditionFieldLabels.compliance_failed,
+    kind: 'boolean',
+    options: booleanOptions,
+    defaultValue: 'true',
+  },
+  compliance_status: {
+    label: conditionFieldLabels.compliance_status,
+    kind: 'enum',
+    options: complianceStatusOptions,
+    defaultValue: 'fail',
+  },
+  policy_id: {
+    label: conditionFieldLabels.policy_id,
+    kind: 'dynamic',
+    placeholder: 'Search policies by name or ID',
+    description: 'Policy IDs are stored in the rule; names are shown to help you choose.',
+    defaultValue: '',
+  },
+  policy_name: {
+    label: conditionFieldLabels.policy_name,
+    kind: 'pattern',
+    placeholder: 'Search policies or type a name',
+    description: 'Use contains for a partial policy name.',
+    defaultValue: '',
+  },
+  intelligence_impact: {
+    label: conditionFieldLabels.intelligence_impact,
+    kind: 'enum',
+    options: intelligenceImpactOptions,
+    defaultValue: intelligenceImpactOptions[0].value,
+  },
+  historical_compliance_status: {
+    label: conditionFieldLabels.historical_compliance_status,
+    kind: 'enum',
+    options: complianceStatusOptions,
+    defaultValue: 'fail',
+  },
+  current_compliance_status: {
+    label: conditionFieldLabels.current_compliance_status,
+    kind: 'enum',
+    options: complianceStatusOptions,
+    defaultValue: 'fail',
+  },
+  xray_blocked: {
+    label: conditionFieldLabels.xray_blocked,
+    kind: 'boolean',
+    options: booleanOptions,
+    defaultValue: 'true',
+  },
+  xray_policy_name: {
+    label: conditionFieldLabels.xray_policy_name,
+    kind: 'pattern',
+    placeholder: 'Search Xray policies or type a pattern',
+    description: 'Use contains or a pattern operator for values not in the suggestions.',
+    defaultValue: '',
+  },
+  xray_watch_name: {
+    label: conditionFieldLabels.xray_watch_name,
+    kind: 'pattern',
+    placeholder: 'Search Xray watches or type a pattern',
+    description: 'Use contains or a pattern operator for values not in the suggestions.',
+    defaultValue: '',
+  },
+  tag: {
+    label: conditionFieldLabels.tag,
+    kind: 'pattern',
+    placeholder: 'Search tags or type a partial name',
+    description: 'Only tags visible in this notification scope are suggested.',
+    defaultValue: '',
+  },
+};
+
+export function getConditionDefinition(field: string): ConditionDefinition {
+  return (
+    definitions[field as ConditionField] ?? {
+      label: field,
+      kind: 'pattern',
+      options: [],
+      placeholder: 'Saved legacy value',
+      defaultValue: '',
+    }
+  );
+}
+
+export function getOperatorOptions(field: string, currentOperator?: string) {
+  const definition = getConditionDefinition(field);
+  const options = [...(definition.operators ?? operatorOptionsByKind[definition.kind])];
+  if (currentOperator && !options.includes(currentOperator)) {
+    options.push(currentOperator);
+  }
+  return options;
+}
+
+export function getDefaultOperator(field: string) {
+  const definition = getConditionDefinition(field);
+  const options = getOperatorOptions(field);
+  return definition.defaultOperator && options.includes(definition.defaultOperator)
+    ? definition.defaultOperator
+    : (options[0] ?? 'eq');
+}
+
+export function getDefaultConditionValue(field: string): ConditionValue {
+  return getConditionDefinition(field).defaultValue;
+}
+
+export function isMultiValueOperator(operator: string) {
+  return operator === 'in' || operator === 'matches_any';
+}
+
+export function allowsCustomConditionValue(field: string, operator: string) {
+  const kind = getConditionDefinition(field).kind;
+  return (
+    (kind === 'pattern' || kind === 'dynamic') &&
+    (operator === 'contains' || operator === 'matches' || operator === 'matches_any')
+  );
+}
+
+export function normalizeConditionValue(operator: string, value: ConditionValue): ConditionValue {
+  if (isMultiValueOperator(operator)) {
+    if (Array.isArray(value)) return value;
+    return value
+      .split(',')
+      .map((item) => item.trim())
+      .filter(Boolean);
+  }
+  return Array.isArray(value) ? (value[0] ?? '') : value;
+}
+
+export function conditionValueIsEmpty(value: ConditionValue) {
+  return Array.isArray(value) ? value.length === 0 : value.trim() === '';
+}
+
+export function parseConditionValue(
+  field: string,
+  operator: string,
+  value: ConditionValue
+): NotificationConditionPredicate['value'] {
+  const normalized = normalizeConditionValue(operator, value);
+  if (isMultiValueOperator(operator)) {
+    return Array.isArray(normalized)
+      ? normalized.map((item) => item.trim()).filter(Boolean)
+      : normalized
+          .split(',')
+          .map((item) => item.trim())
+          .filter(Boolean);
+  }
+
+  const trimmed = String(normalized).trim();
+  if (getConditionDefinition(field).kind === 'boolean') {
+    return trimmed === 'true';
+  }
+  if (getConditionDefinition(field).kind === 'numeric') {
+    return trimmed === '' ? '' : Number(trimmed);
+  }
+  return trimmed;
+}
+
+export function formatConditionValue(
+  value: NotificationConditionPredicate['value'] | ConditionValue
+) {
+  return Array.isArray(value) ? value.join(', ') : String(value);
+}
+
+export function conditionOptionLabel(field: string, value: string, options: ConditionOption[]) {
+  const option = options.find((item) => item.value === value);
+  return option?.label ?? value;
+}
+
+export function mergeConditionOptions(
+  field: string,
+  options: ConditionOption[],
+  value: ConditionValue
+) {
+  const definitionOptions = getConditionDefinition(field).options ?? [];
+  const merged = [...definitionOptions, ...options];
+  const seen = new Set<string>();
+  const result = merged.filter((option) => {
+    if (seen.has(option.value)) return false;
+    seen.add(option.value);
+    return true;
+  });
+  const values = Array.isArray(value) ? value : [value];
+  for (const savedValue of values) {
+    if (!savedValue || seen.has(savedValue)) continue;
+    result.push({
+      value: savedValue,
+      label: `Saved legacy value: ${savedValue}`,
+      description: 'This value is no longer available in the current scope.',
+      legacy: true,
+    });
+    seen.add(savedValue);
+  }
+  return result;
+}

--- a/services/frontend/components/notifications/condition-value-control.tsx
+++ b/services/frontend/components/notifications/condition-value-control.tsx
@@ -1,0 +1,333 @@
+'use client';
+
+import { FormField } from '@/components/ui/form-field';
+import {
+  fieldDescriptionClassName,
+  fieldLabelClassName,
+  heroFieldClassName,
+  heroSelectTriggerClassName,
+} from '@/components/ui/form-styles';
+import type { ConditionOption, ConditionValue } from '@/components/notifications/condition-catalog';
+import {
+  allowsCustomConditionValue,
+  conditionOptionLabel,
+  getConditionDefinition,
+  isMultiValueOperator,
+  mergeConditionOptions,
+  normalizeConditionValue,
+} from '@/components/notifications/condition-catalog';
+import { ComboBox, Input, Label, ListBox, Select, Tag, TagGroup } from '@heroui/react';
+import type { Key } from '@heroui/react';
+import { useEffect, useMemo, useState } from 'react';
+
+type ConditionValueControlProps = {
+  field: string;
+  operator: string;
+  value: ConditionValue;
+  options: ConditionOption[];
+  isLoading?: boolean;
+  onChange: (value: ConditionValue) => void;
+  onLookup: (query: string) => void;
+};
+
+const selectedLabelClassName = 'truncate text-sm';
+
+function optionText(option: ConditionOption) {
+  return option.legacy ? `⚠ ${option.label}` : option.label;
+}
+
+function OptionContent({ option }: { option: ConditionOption }) {
+  return (
+    <div className="min-w-0">
+      <div className={option.legacy ? 'truncate text-warning' : 'truncate'}>
+        {optionText(option)}
+      </div>
+      {option.description ? (
+        <div className="truncate text-xs text-muted">{option.description}</div>
+      ) : null}
+    </div>
+  );
+}
+
+function StaticConditionValueControl({
+  field,
+  operator,
+  value,
+  options,
+  onChange,
+}: Omit<ConditionValueControlProps, 'isLoading' | 'onLookup'>) {
+  const definition = getConditionDefinition(field);
+  const multi = isMultiValueOperator(operator);
+  const normalizedValue = normalizeConditionValue(operator, value);
+  const selectedValues = Array.isArray(normalizedValue) ? normalizedValue : [normalizedValue];
+
+  return (
+    <Select
+      aria-label={definition.label}
+      selectionMode={multi ? 'multiple' : 'single'}
+      value={multi ? selectedValues : (selectedValues[0] ?? '')}
+      onChange={(nextValue) => {
+        const values = Array.isArray(nextValue)
+          ? nextValue.map(String)
+          : nextValue == null
+            ? []
+            : [String(nextValue)];
+        onChange(multi ? values : (values[0] ?? ''));
+      }}
+      variant="primary"
+    >
+      <Select.Trigger className={heroSelectTriggerClassName}>
+        <span
+          className={selectedValues.length > 0 ? selectedLabelClassName : 'truncate text-muted'}
+        >
+          {selectedValues.length > 0
+            ? selectedValues.map((item) => conditionOptionLabel(field, item, options)).join(', ')
+            : 'Select a value'}
+        </span>
+        <Select.Indicator />
+      </Select.Trigger>
+      <Select.Popover>
+        <ListBox selectionMode={multi ? 'multiple' : 'single'}>
+          {options.map((option) => (
+            <ListBox.Item key={option.value} id={option.value} textValue={option.label}>
+              <OptionContent option={option} />
+              <ListBox.ItemIndicator />
+            </ListBox.Item>
+          ))}
+        </ListBox>
+      </Select.Popover>
+    </Select>
+  );
+}
+
+function NumericConditionValueControl({
+  field,
+  value,
+  onChange,
+}: Pick<ConditionValueControlProps, 'field' | 'value' | 'onChange'>) {
+  const definition = getConditionDefinition(field);
+  const stringValue = Array.isArray(value) ? (value[0] ?? '') : value;
+  return (
+    <FormField
+      aria-label={definition.label}
+      label={definition.label}
+      hideLabel
+      type="number"
+      min={field === 'highest_cvss' ? 0 : 0}
+      max={field === 'highest_cvss' ? 10 : undefined}
+      step={field === 'highest_cvss' ? '0.1' : '1'}
+      value={stringValue}
+      onChange={(event) => onChange(event.target.value)}
+      placeholder={definition.placeholder}
+      description={definition.description}
+      variant="primary"
+    />
+  );
+}
+
+function DynamicSingleValueControl({
+  field,
+  operator,
+  value,
+  options,
+  isLoading,
+  onChange,
+  onLookup,
+}: ConditionValueControlProps) {
+  const definition = getConditionDefinition(field);
+  const allowsCustom = allowsCustomConditionValue(field, operator);
+  const stringValue = Array.isArray(value) ? (value[0] ?? '') : value;
+  const selectedOption = options.find((option) => option.value === stringValue);
+  const [inputValue, setInputValue] = useState(selectedOption?.label ?? stringValue);
+  const displayInputValue =
+    inputValue === stringValue ? (selectedOption?.label ?? stringValue) : inputValue;
+
+  useEffect(() => {
+    onLookup('');
+  }, [onLookup]);
+
+  return (
+    <ComboBox
+      aria-label={definition.label}
+      allowsCustomValue={allowsCustom}
+      allowsEmptyCollection
+      inputValue={displayInputValue}
+      selectedKey={stringValue || null}
+      onInputChange={(nextInput) => {
+        setInputValue(nextInput);
+        onLookup(nextInput);
+        if (allowsCustom) onChange(nextInput);
+      }}
+      onSelectionChange={(key) => {
+        if (key == null) return;
+        const selectedValue = String(key);
+        const selected = options.find((option) => option.value === selectedValue);
+        onChange(selectedValue);
+        setInputValue(selected?.label ?? selectedValue);
+      }}
+    >
+      <Label className={fieldLabelClassName}>{definition.label}</Label>
+      <ComboBox.InputGroup>
+        <Input className={heroFieldClassName} placeholder={definition.placeholder} />
+        <ComboBox.Trigger />
+      </ComboBox.InputGroup>
+      {definition.description ? (
+        <div className={fieldDescriptionClassName}>
+          {definition.description}
+          {isLoading ? ' Loading suggestions…' : ''}
+        </div>
+      ) : isLoading ? (
+        <div className={fieldDescriptionClassName}>Loading suggestions…</div>
+      ) : null}
+      <ComboBox.Popover>
+        <ListBox
+          renderEmptyState={() => (
+            <div className="px-3 py-2 text-sm text-muted">No matching values.</div>
+          )}
+        >
+          {options.map((option) => (
+            <ListBox.Item key={option.value} id={option.value} textValue={option.label}>
+              <OptionContent option={option} />
+              <ListBox.ItemIndicator />
+            </ListBox.Item>
+          ))}
+        </ListBox>
+      </ComboBox.Popover>
+    </ComboBox>
+  );
+}
+
+function DynamicMultiValueControl({
+  field,
+  operator,
+  value,
+  options,
+  isLoading,
+  onChange,
+  onLookup,
+}: ConditionValueControlProps) {
+  const definition = getConditionDefinition(field);
+  const allowsCustom = allowsCustomConditionValue(field, operator);
+  const selectedValues = useMemo(() => {
+    const normalizedValue = normalizeConditionValue(operator, value);
+    return Array.isArray(normalizedValue) ? normalizedValue : [];
+  }, [operator, value]);
+  const tagItems = useMemo(
+    () => selectedValues.map((selectedValue) => ({ id: selectedValue, value: selectedValue })),
+    [selectedValues]
+  );
+  const [inputValue, setInputValue] = useState('');
+  const availableOptions = useMemo(
+    () => options.filter((option) => !selectedValues.includes(option.value)),
+    [options, selectedValues]
+  );
+
+  useEffect(() => {
+    onLookup('');
+  }, [onLookup]);
+
+  const addValue = (nextValue: string | Key | null) => {
+    if (nextValue == null) return;
+    const trimmed = String(nextValue).trim();
+    if (!trimmed || selectedValues.includes(trimmed)) return;
+    onChange([...selectedValues, trimmed]);
+    setInputValue('');
+    onLookup('');
+  };
+
+  return (
+    <div className="space-y-2">
+      <TagGroup
+        aria-label={`${definition.label} selected values`}
+        selectionMode="none"
+        onRemove={(keys) => onChange(selectedValues.filter((item) => !keys.has(item)))}
+      >
+        <TagGroup.List
+          items={tagItems}
+          renderEmptyState={() => (
+            <span className="text-xs text-muted">No values selected yet.</span>
+          )}
+          className="gap-1.5"
+        >
+          {(tagItem) => {
+            const option = options.find((item) => item.value === tagItem.value);
+            return (
+              <Tag key={tagItem.id} id={tagItem.id} textValue={tagItem.value} variant="surface">
+                {option?.legacy ? '⚠ ' : ''}
+                {option?.label ?? tagItem.value}
+              </Tag>
+            );
+          }}
+        </TagGroup.List>
+      </TagGroup>
+
+      <ComboBox
+        aria-label={`Add ${definition.label}`}
+        allowsCustomValue={allowsCustom}
+        allowsEmptyCollection
+        inputValue={inputValue}
+        selectedKey={null}
+        onInputChange={(nextInput) => {
+          setInputValue(nextInput);
+          onLookup(nextInput);
+        }}
+        onSelectionChange={(key) => addValue(key)}
+      >
+        <Label className="sr-only">Add {definition.label}</Label>
+        <ComboBox.InputGroup>
+          <Input
+            className={heroFieldClassName}
+            placeholder={definition.placeholder ?? 'Search and add values'}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter' && allowsCustom && inputValue.trim()) {
+                event.preventDefault();
+                addValue(inputValue);
+              }
+            }}
+          />
+          <ComboBox.Trigger />
+        </ComboBox.InputGroup>
+        <div className={fieldDescriptionClassName}>
+          {allowsCustom
+            ? 'Choose a suggestion or press Enter to add a custom pattern.'
+            : 'Choose one or more suggestions.'}
+          {isLoading ? ' Loading suggestions…' : ''}
+        </div>
+        <ComboBox.Popover>
+          <ListBox
+            renderEmptyState={() => (
+              <div className="px-3 py-2 text-sm text-muted">No matching values.</div>
+            )}
+          >
+            {availableOptions.map((option) => (
+              <ListBox.Item key={option.value} id={option.value} textValue={option.label}>
+                <OptionContent option={option} />
+                <ListBox.ItemIndicator />
+              </ListBox.Item>
+            ))}
+          </ListBox>
+        </ComboBox.Popover>
+      </ComboBox>
+    </div>
+  );
+}
+
+export function ConditionValueControl(props: ConditionValueControlProps) {
+  const definition = getConditionDefinition(props.field);
+  const options = mergeConditionOptions(props.field, props.options, props.value);
+
+  if (definition.kind === 'numeric') {
+    return <NumericConditionValueControl {...props} />;
+  }
+  if (
+    definition.kind === 'enum' ||
+    definition.kind === 'boolean' ||
+    definition.kind === 'severity'
+  ) {
+    return <StaticConditionValueControl {...props} options={options} />;
+  }
+  if (isMultiValueOperator(props.operator)) {
+    return <DynamicMultiValueControl {...props} options={options} />;
+  }
+  return <DynamicSingleValueControl {...props} options={options} />;
+}

--- a/services/frontend/components/notifications/notification-manager.tsx
+++ b/services/frontend/components/notifications/notification-manager.tsx
@@ -4,10 +4,27 @@ import { useConfirmDialog } from '@/components/confirm-dialog';
 import { StatusAlert } from '@/components/ui/form-alert';
 import { FormField } from '@/components/ui/form-field';
 import { heroSelectTriggerClassName, heroTextAreaClassName } from '@/components/ui/form-styles';
+import {
+  conditionFieldLabels,
+  conditionFieldOptions,
+  conditionValueIsEmpty,
+  eventTypeOptions,
+  formatConditionValue,
+  getConditionDefinition,
+  getDefaultConditionValue,
+  getDefaultOperator,
+  getOperatorOptions,
+  normalizeConditionValue,
+  operatorLabels,
+  parseConditionValue,
+  type ConditionValue,
+} from '@/components/notifications/condition-catalog';
+import { ConditionValueControl } from '@/components/notifications/condition-value-control';
 import { RowActionsMenu } from '@/components/ui/row-actions-menu';
 import type {
   NotificationChannel,
   NotificationConditionGroup,
+  NotificationConditionOption,
   NotificationConditionPredicate,
   NotificationDelivery,
   NotificationQueueJob,
@@ -19,6 +36,7 @@ import {
   deleteScopedNotificationChannel,
   deleteScopedNotificationRule,
   listScopedNotificationChannels,
+  listScopedNotificationConditionOptions,
   listScopedNotificationDeliveries,
   listScopedNotificationQueue,
   listScopedNotificationRules,
@@ -47,7 +65,7 @@ import {
   Refresh01Icon,
   Setting07Icon,
 } from 'hugeicons-react';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 const channelTypeOptions: Array<{ value: NotificationChannel['type']; label: string }> = [
   { value: 'discord', label: 'Discord' },
@@ -57,123 +75,6 @@ const channelTypeOptions: Array<{ value: NotificationChannel['type']; label: str
   { value: 'email', label: 'Email' },
   { value: 'telegram', label: 'Telegram' },
 ];
-
-const eventTypeOptions = [
-  { value: 'scan_complete', label: 'Scan complete' },
-  { value: 'scan_failed', label: 'Scan failed' },
-  { value: 'compliance_failed', label: 'Compliance failed' },
-  { value: 'intelligence_policy_impact', label: 'CVE intelligence policy impact' },
-];
-
-const conditionFieldOptions = [
-  'event_type',
-  'user_id',
-  'org_id',
-  'image_ref',
-  'scan_provider',
-  'scan_status',
-  'highest_severity',
-  'highest_cvss',
-  'critical_count',
-  'high_count',
-  'medium_count',
-  'low_count',
-  'unknown_count',
-  'suppressed_count',
-  'compliance_failed',
-  'compliance_status',
-  'policy_id',
-  'policy_name',
-  'intelligence_impact',
-  'historical_compliance_status',
-  'current_compliance_status',
-  'xray_blocked',
-  'xray_policy_name',
-  'xray_watch_name',
-  'tag',
-] as const;
-
-const conditionFieldLabels: Record<(typeof conditionFieldOptions)[number], string> = {
-  event_type: 'Event type',
-  user_id: 'User',
-  org_id: 'Organization',
-  image_ref: 'Image reference',
-  scan_provider: 'Scan provider',
-  scan_status: 'Scan status',
-  highest_severity: 'Highest severity',
-  highest_cvss: 'Highest CVSS',
-  critical_count: 'Critical findings',
-  high_count: 'High findings',
-  medium_count: 'Medium findings',
-  low_count: 'Low findings',
-  unknown_count: 'Unknown findings',
-  suppressed_count: 'Suppressed findings',
-  compliance_failed: 'Compliance failed',
-  compliance_status: 'Compliance status',
-  policy_id: 'Policy ID',
-  policy_name: 'Policy name',
-  intelligence_impact: 'Intelligence impact',
-  historical_compliance_status: 'Historical compliance status',
-  current_compliance_status: 'Current compliance status',
-  xray_blocked: 'Blocked by Xray',
-  xray_policy_name: 'Xray policy name',
-  xray_watch_name: 'Xray watch name',
-  tag: 'Tag',
-};
-
-const conditionFieldKinds: Record<
-  (typeof conditionFieldOptions)[number],
-  'enum' | 'text' | 'pattern' | 'numeric' | 'boolean' | 'severity'
-> = {
-  event_type: 'enum',
-  user_id: 'text',
-  org_id: 'text',
-  image_ref: 'pattern',
-  scan_provider: 'enum',
-  scan_status: 'enum',
-  highest_severity: 'severity',
-  highest_cvss: 'numeric',
-  critical_count: 'numeric',
-  high_count: 'numeric',
-  medium_count: 'numeric',
-  low_count: 'numeric',
-  unknown_count: 'numeric',
-  suppressed_count: 'numeric',
-  compliance_failed: 'boolean',
-  compliance_status: 'enum',
-  policy_id: 'text',
-  policy_name: 'text',
-  intelligence_impact: 'enum',
-  historical_compliance_status: 'enum',
-  current_compliance_status: 'enum',
-  xray_blocked: 'boolean',
-  xray_policy_name: 'text',
-  xray_watch_name: 'text',
-  tag: 'text',
-};
-
-const operatorOptionsByKind = {
-  enum: ['eq', 'neq', 'in'],
-  text: ['eq', 'neq', 'contains', 'in'],
-  pattern: ['eq', 'contains', 'matches', 'matches_any'],
-  numeric: ['eq', 'gte', 'gt', 'lte', 'lt'],
-  boolean: ['eq'],
-  severity: ['eq', 'gte_severity'],
-} as const;
-
-const operatorLabels: Record<string, string> = {
-  eq: 'is',
-  neq: 'is not',
-  contains: 'contains',
-  in: 'is one of',
-  matches: 'matches pattern',
-  matches_any: 'matches any pattern',
-  gte: 'is at least',
-  gt: 'is greater than',
-  lte: 'is at most',
-  lt: 'is less than',
-  gte_severity: 'is at least severity',
-};
 
 const deliveryModeLabels: Record<'immediate' | 'digest', string> = {
   immediate: 'Immediate',
@@ -185,33 +86,7 @@ const groupOpLabels: Record<'all' | 'any', string> = {
   any: 'Match any condition',
 };
 
-const conditionValuePlaceholders: Record<string, string> = {
-  event_type: 'scan_complete',
-  user_id: 'user UUID',
-  org_id: '550e8400-e29b-41d4-a716-446655440000',
-  image_ref: 'ghcr.io/acme/api:*',
-  scan_provider: 'trivy',
-  scan_status: 'completed',
-  highest_severity: 'HIGH',
-  highest_cvss: '7',
-  critical_count: '1',
-  high_count: '5',
-  medium_count: '10',
-  low_count: '20',
-  unknown_count: '0',
-  suppressed_count: '0',
-  compliance_failed: 'true',
-  compliance_status: 'fail',
-  policy_id: '7b4f5bb9-0d9b-4d4f-beb3-91d2f90ed4e4',
-  policy_name: 'Critical Runtime Policy',
-  intelligence_impact: 'resolved',
-  historical_compliance_status: 'fail',
-  current_compliance_status: 'needs_validation',
-  xray_blocked: 'true',
-  xray_policy_name: 'Production Block Policy',
-  xray_watch_name: 'prod-cluster',
-  tag: 'production',
-};
+const noopConditionLookup = () => {};
 
 type NotificationManagerProps = {
   basePath: string;
@@ -247,7 +122,7 @@ type RuleFormState = {
   delivery_mode: 'immediate' | 'digest';
   digest_window_minutes: string;
   op: 'all' | 'any';
-  conditions: Array<{ id: string; field: string; operator: string; value: string }>;
+  conditions: Array<{ id: string; field: string; operator: string; value: ConditionValue }>;
 };
 
 function emptyChannelForm(): ChannelFormState {
@@ -278,12 +153,17 @@ function emptyRuleForm(): RuleFormState {
     delivery_mode: 'immediate',
     digest_window_minutes: '15',
     op: 'all',
-    conditions: [{ id: crypto.randomUUID(), field: 'highest_cvss', operator: 'gte', value: '7' }],
+    conditions: [createCondition('highest_cvss')],
   };
 }
 
-function formatConditionValue(value: NotificationConditionPredicate['value']) {
-  return Array.isArray(value) ? value.join(', ') : String(value);
+function createCondition(field = 'highest_cvss') {
+  return {
+    id: crypto.randomUUID(),
+    field,
+    operator: getDefaultOperator(field),
+    value: getDefaultConditionValue(field),
+  };
 }
 
 function decodeRuleConditions(group?: NotificationConditionGroup | null) {
@@ -294,28 +174,8 @@ function decodeRuleConditions(group?: NotificationConditionGroup | null) {
     id: crypto.randomUUID(),
     field: condition.field,
     operator: condition.operator,
-    value: formatConditionValue(condition.value),
+    value: Array.isArray(condition.value) ? condition.value.map(String) : String(condition.value),
   }));
-}
-
-function parseConditionValue(
-  operator: string,
-  rawValue: string
-): string | number | boolean | string[] {
-  const trimmed = rawValue.trim();
-  if (operator === 'in' || operator === 'matches_any') {
-    return trimmed
-      .split(',')
-      .map((value) => value.trim())
-      .filter(Boolean);
-  }
-  if (trimmed === 'true' || trimmed === 'false') {
-    return trimmed === 'true';
-  }
-  if (trimmed !== '' && !Number.isNaN(Number(trimmed))) {
-    return Number(trimmed);
-  }
-  return trimmed;
 }
 
 function parseHeaders(rawHeaders: string) {
@@ -330,20 +190,12 @@ function parseHeaders(rawHeaders: string) {
   return headers;
 }
 
-function getOperatorOptions(field: string) {
-  const kind = conditionFieldKinds[field as keyof typeof conditionFieldKinds] ?? 'text';
-  return operatorOptionsByKind[kind];
-}
-
-function getDefaultOperator(field: string) {
-  const options = getOperatorOptions(field);
-  return options[0] ?? 'eq';
-}
-
 function summarizeRule(rule: NotificationRule, channels: NotificationChannel[]) {
   const channelNames = rule.channel_ids
-    .map((channelId) => channels.find((channel) => channel.id === channelId)?.name)
-    .filter(Boolean)
+    .flatMap((channelId) => {
+      const name = channels.find((channel) => channel.id === channelId)?.name;
+      return name ? [name] : [];
+    })
     .join(', ');
   const conditions =
     rule.conditions?.conditions
@@ -370,8 +222,13 @@ export function NotificationManager({
   const [feedback, setFeedback] = useState<{ type: 'success' | 'error'; text: string } | null>(
     null
   );
-  const [channelForm, setChannelForm] = useState<ChannelFormState>(emptyChannelForm());
-  const [ruleForm, setRuleForm] = useState<RuleFormState>(emptyRuleForm());
+  const [channelForm, setChannelForm] = useState<ChannelFormState>(() => emptyChannelForm());
+  const [ruleForm, setRuleForm] = useState<RuleFormState>(() => emptyRuleForm());
+  const [conditionOptions, setConditionOptions] = useState<
+    Record<string, NotificationConditionOption[]>
+  >({});
+  const [conditionOptionLoading, setConditionOptionLoading] = useState<Record<string, boolean>>({});
+  const conditionLookupRequest = useRef<Record<string, number>>({});
 
   const channelModal = useOverlayState();
   const ruleModal = useOverlayState();
@@ -400,6 +257,31 @@ export function NotificationManager({
 
   useEffect(() => deferEffect(load), [load]);
 
+  const loadConditionOptions = useCallback(
+    async (field: string, query = '') => {
+      const definition = getConditionDefinition(field);
+      if (definition.kind !== 'dynamic' && definition.kind !== 'pattern') return;
+
+      const requestID = (conditionLookupRequest.current[field] ?? 0) + 1;
+      conditionLookupRequest.current[field] = requestID;
+      setConditionOptionLoading((current) => ({ ...current, [field]: true }));
+      try {
+        const options = await listScopedNotificationConditionOptions(basePath, field, query);
+        if (conditionLookupRequest.current[field] === requestID) {
+          setConditionOptions((current) => ({ ...current, [field]: options }));
+        }
+      } catch {
+        // Suggestions are an enhancement; a saved legacy value or a custom
+        // pattern must remain editable when the lookup is unavailable.
+      } finally {
+        if (conditionLookupRequest.current[field] === requestID) {
+          setConditionOptionLoading((current) => ({ ...current, [field]: false }));
+        }
+      }
+    },
+    [basePath]
+  );
+
   const channelNames = useMemo(
     () => Object.fromEntries(channels.map((channel) => [channel.id, channel.name])),
     [channels]
@@ -415,6 +297,18 @@ export function NotificationManager({
         conditionFieldOptions.map((field) => [field, conditionFieldLabels[field]])
       ),
     []
+  );
+  const conditionLookupHandlers = useMemo(
+    () =>
+      Object.fromEntries(
+        conditionFieldOptions.map((field) => [
+          field,
+          (query: string) => {
+            void loadConditionOptions(field, query);
+          },
+        ])
+      ) as Record<string, (query: string) => void>,
+    [loadConditionOptions]
   );
 
   function openCreateChannel() {
@@ -530,13 +424,22 @@ export function NotificationManager({
         ruleForm.delivery_mode === 'digest' ? Number(ruleForm.digest_window_minutes) || 15 : 0,
       conditions: {
         op: ruleForm.op,
-        conditions: ruleForm.conditions
-          .filter((condition) => condition.field.trim() && condition.operator.trim())
-          .map<NotificationConditionPredicate>((condition) => ({
-            field: condition.field.trim(),
-            operator: condition.operator.trim(),
-            value: parseConditionValue(condition.operator, condition.value),
-          })),
+        conditions: ruleForm.conditions.flatMap<NotificationConditionPredicate>((condition) => {
+          if (
+            !condition.field.trim() ||
+            !condition.operator.trim() ||
+            conditionValueIsEmpty(condition.value)
+          ) {
+            return [];
+          }
+          return [
+            {
+              field: condition.field.trim(),
+              operator: condition.operator.trim(),
+              value: parseConditionValue(condition.field, condition.operator, condition.value),
+            },
+          ];
+        }),
       },
     };
 
@@ -1406,24 +1309,39 @@ export function NotificationManager({
                     </Select.Popover>
                   </Select>
 
+                  <div className="space-y-2">
+                    <div>
+                      <p className="text-sm font-medium">Conditions</p>
+                      <p className="text-xs text-muted">
+                        Choose known values from guided lists. Resource fields search values visible
+                        in this scope, while pattern operators can accept a custom value.
+                      </p>
+                    </div>
+                  </div>
+
                   <div className="space-y-3">
                     {ruleForm.conditions.map((condition, index) => (
                       <Card key={condition.id} variant="secondary">
-                        <Card.Content className="grid gap-3 lg:grid-cols-[1.1fr_1fr_1.2fr_auto]">
+                        <Card.Content className="grid gap-3 lg:grid-cols-[1.1fr_1fr_minmax(14rem,1.5fr)_auto]">
                           <Select
                             value={condition.field}
                             onChange={(value) =>
                               setRuleForm((current) => ({
                                 ...current,
-                                conditions: current.conditions.map((item, itemIndex) =>
-                                  itemIndex === index
-                                    ? {
-                                        ...item,
-                                        field: String(value),
-                                        operator: getDefaultOperator(String(value)),
-                                      }
-                                    : item
-                                ),
+                                conditions: current.conditions.map((item, itemIndex) => {
+                                  if (itemIndex !== index) return item;
+                                  const nextField = String(value);
+                                  const nextOperator = getDefaultOperator(nextField);
+                                  return {
+                                    ...item,
+                                    field: nextField,
+                                    operator: nextOperator,
+                                    value: normalizeConditionValue(
+                                      nextOperator,
+                                      getDefaultConditionValue(nextField)
+                                    ),
+                                  };
+                                }),
                               }))
                             }
                             variant="primary"
@@ -1457,7 +1375,13 @@ export function NotificationManager({
                               setRuleForm((current) => ({
                                 ...current,
                                 conditions: current.conditions.map((item, itemIndex) =>
-                                  itemIndex === index ? { ...item, operator: String(value) } : item
+                                  itemIndex === index
+                                    ? {
+                                        ...item,
+                                        operator: String(value),
+                                        value: normalizeConditionValue(String(value), item.value),
+                                      }
+                                    : item
                                 ),
                               }))
                             }
@@ -1472,39 +1396,40 @@ export function NotificationManager({
                             </Select.Trigger>
                             <Select.Popover>
                               <ListBox>
-                                {getOperatorOptions(condition.field).map((operator) => (
-                                  <ListBox.Item
-                                    key={operator}
-                                    id={operator}
-                                    textValue={operatorLabels[operator]}
-                                  >
-                                    {operatorLabels[operator]}
-                                    <ListBox.ItemIndicator />
-                                  </ListBox.Item>
-                                ))}
+                                {getOperatorOptions(condition.field, condition.operator).map(
+                                  (operator) => (
+                                    <ListBox.Item
+                                      key={operator}
+                                      id={operator}
+                                      textValue={operatorLabels[operator]}
+                                    >
+                                      {operatorLabels[operator]}
+                                      <ListBox.ItemIndicator />
+                                    </ListBox.Item>
+                                  )
+                                )}
                               </ListBox>
                             </Select.Popover>
                           </Select>
 
-                          <FormField
-                            label="Value"
-                            hideLabel
+                          <ConditionValueControl
+                            key={`${condition.id}-${condition.field}`}
+                            field={condition.field}
+                            operator={condition.operator}
                             value={condition.value}
-                            onChange={(event) =>
+                            options={conditionOptions[condition.field] ?? []}
+                            isLoading={conditionOptionLoading[condition.field] ?? false}
+                            onLookup={
+                              conditionLookupHandlers[condition.field] ?? noopConditionLookup
+                            }
+                            onChange={(value) =>
                               setRuleForm((current) => ({
                                 ...current,
                                 conditions: current.conditions.map((item, itemIndex) =>
-                                  itemIndex === index
-                                    ? { ...item, value: event.target.value }
-                                    : item
+                                  itemIndex === index ? { ...item, value } : item
                                 ),
                               }))
                             }
-                            placeholder={
-                              conditionValuePlaceholders[condition.field] ??
-                              'Value or comma-separated values'
-                            }
-                            variant="primary"
                           />
 
                           <div className="flex items-center justify-end">
@@ -1533,15 +1458,7 @@ export function NotificationManager({
                       onPress={() =>
                         setRuleForm((current) => ({
                           ...current,
-                          conditions: [
-                            ...current.conditions,
-                            {
-                              id: crypto.randomUUID(),
-                              field: 'highest_cvss',
-                              operator: 'gte',
-                              value: '7',
-                            },
-                          ],
+                          conditions: [...current.conditions, createCondition()],
                         }))
                       }
                     >

--- a/services/frontend/lib/api/notifications.ts
+++ b/services/frontend/lib/api/notifications.ts
@@ -1,13 +1,31 @@
 import { req } from './core';
 import type {
   NotificationChannel,
+  NotificationConditionOption,
   NotificationDelivery,
   NotificationQueueJob,
   NotificationRule,
 } from './types/admin';
 
+export const listScopedNotificationConditionOptions = (
+  basePath: string,
+  field: string,
+  query = ''
+) => {
+  const params = new URLSearchParams({ field });
+  if (query.trim()) {
+    params.set('q', query.trim());
+  }
+  return req<{ data: NotificationConditionOption[] }>(
+    'GET',
+    `${basePath}/condition-options?${params.toString()}`
+  ).then((result) => result.data ?? []);
+};
+
 export const listScopedNotificationChannels = (basePath: string) =>
-  req<{ data: NotificationChannel[] }>('GET', `${basePath}/channels`).then((result) => result.data ?? []);
+  req<{ data: NotificationChannel[] }>('GET', `${basePath}/channels`).then(
+    (result) => result.data ?? []
+  );
 
 export const createScopedNotificationChannel = (
   basePath: string,
@@ -42,10 +60,14 @@ export const deleteScopedNotificationRule = (basePath: string, id: string) =>
   req<{ result: string }>('DELETE', `${basePath}/rules/${id}`);
 
 export const listScopedNotificationDeliveries = (basePath: string, limit = 25) =>
-  req<{ data: NotificationDelivery[] }>('GET', `${basePath}/deliveries?limit=${limit}`).then((result) => result.data ?? []);
+  req<{ data: NotificationDelivery[] }>('GET', `${basePath}/deliveries?limit=${limit}`).then(
+    (result) => result.data ?? []
+  );
 
 export const listScopedNotificationQueue = (basePath: string, limit = 50) =>
-  req<{ data: NotificationQueueJob[] }>('GET', `${basePath}/queue?limit=${limit}`).then((result) => result.data ?? []);
+  req<{ data: NotificationQueueJob[] }>('GET', `${basePath}/queue?limit=${limit}`).then(
+    (result) => result.data ?? []
+  );
 
 export const retryScopedNotificationQueueJob = (basePath: string, jobId: string) =>
   req<{ result: string }>('POST', `${basePath}/queue/${jobId}/retry`);

--- a/services/frontend/lib/api/types/admin.ts
+++ b/services/frontend/lib/api/types/admin.ts
@@ -45,6 +45,13 @@ export interface AuditLog {
   role?: string;
 }
 
+export interface NotificationConditionOption {
+  value: string;
+  label: string;
+  description?: string;
+  group?: string;
+}
+
 export interface APIRequestLogFilters {
   method?: string;
   path?: string;


### PR DESCRIPTION
## Summary

- Replace free-form notification condition values with typed HeroUI selectors, numeric inputs, searchable resource lookups, multi-value chips, and pattern-aware entry.
- Add a read-only, scope-authorized condition-options API for personal, organization, and system notification scopes.
- Preserve existing rule JSON values, including saved legacy values and numeric/boolean/multi-value serialization.
- Allow `intelligence_policy_impact` in both notification validation paths.
- Document the guided condition builder and lookup behavior.

## Why

Finite condition values such as event type, scan provider, statuses, severities, compliance/intelligence states, and booleans should be selected instead of guessed. Dynamic resources now provide human-readable labels while storing their IDs or existing rule values unchanged.

## Validation

- `cd services/backend && go test ./...`
- `cd services/frontend && pnpm lint`
- `cd services/frontend && pnpm exec next build --webpack`
- Documentation formatting and internal link checks
- Live notification editor verification for guided selectors, CVSS defaults, searchable values, and pattern operators

The default Turbopack `pnpm build` remains blocked by the sandbox's process/port restriction; the webpack production build passes.