### PR TITLE
Fix post-scan intelligence cleanup and archive upload recovery

### DIFF
--- a/deploy/docker-compose/docker-compose.yml
+++ b/deploy/docker-compose/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       - ./backend-config.yaml:/etc/justscan/config.yaml
       - backend_data:/app/data
     healthcheck:
-      test: ["CMD-SHELL", "wget -qO- http://localhost:8080/api/v1/health || exit 1"]
+      test: ["CMD-SHELL", "wget -qO- http://localhost:8080/api/v1/readyz || exit 1"]
       interval: 15s
       timeout: 5s
       retries: 5

--- a/deploy/helm/justscan/templates/backend/deployment.yaml
+++ b/deploy/helm/justscan/templates/backend/deployment.yaml
@@ -106,7 +106,7 @@ spec:
 
           livenessProbe:
             httpGet:
-              path: /api/v1/health
+              path: /api/v1/livez
               port: http
             initialDelaySeconds: 20
             periodSeconds: 30
@@ -114,7 +114,7 @@ spec:
 
           readinessProbe:
             httpGet:
-              path: /api/v1/health
+              path: /api/v1/readyz
               port: http
             initialDelaySeconds: 10
             periodSeconds: 15

--- a/services/backend/compliance/intelligence_summary.go
+++ b/services/backend/compliance/intelligence_summary.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	vulnerabilityintelligence "justscan-backend/functions/vulnerabilityintelligence"
 	"justscan-backend/pkg/models"
 
 	"github.com/google/uuid"
@@ -34,7 +35,7 @@ func LoadIntelligenceSummaries(
 	}
 
 	rows := make([]summaryRow, 0, len(scanIDs))
-	postScanChange := "(p.change_event_id IS NOT NULL OR (s.completed_at IS NOT NULL AND p.observed_at > s.completed_at))"
+	postScanChange := vulnerabilityintelligence.PostScanChangeCondition("p", "s")
 	query := db.NewSelect().
 		TableExpr("vulnerabilities AS v").
 		ColumnExpr("v.scan_id").

--- a/services/backend/config/resolver.go
+++ b/services/backend/config/resolver.go
@@ -22,6 +22,7 @@ type SettingResolver struct {
 
 type cachedSetting struct {
 	value     string
+	found     bool
 	expiresAt time.Time
 }
 
@@ -50,7 +51,10 @@ func GetResolver() *SettingResolver {
 // GetString returns the string value for key, falling back to fallback if no DB
 // override exists.
 func (r *SettingResolver) GetString(key, fallback string) string {
-	if v, ok := r.fromCache(key); ok {
+	if v, found, hit := r.fromCache(key); hit {
+		if !found {
+			return fallback
+		}
 		return v
 	}
 	val, found := r.fromDB(key)
@@ -58,6 +62,27 @@ func (r *SettingResolver) GetString(key, fallback string) string {
 		return fallback
 	}
 	return val
+}
+
+// GetStringAny returns the first explicitly persisted value for keys in order.
+// It lets runtime callers prefer a canonical key while still honouring a
+// legacy key during a setting rename.
+func (r *SettingResolver) GetStringAny(keys []string, fallback string) string {
+	for _, key := range keys {
+		if key == "" {
+			continue
+		}
+		if value, found, hit := r.fromCache(key); hit {
+			if found {
+				return value
+			}
+			continue
+		}
+		if value, found := r.fromDB(key); found {
+			return value
+		}
+	}
+	return fallback
 }
 
 // GetBool returns the bool value for key, falling back to fallback.
@@ -70,9 +95,29 @@ func (r *SettingResolver) GetBool(key string, fallback bool) bool {
 	return v
 }
 
+// GetBoolAny is the boolean counterpart to GetStringAny.
+func (r *SettingResolver) GetBoolAny(keys []string, fallback bool) bool {
+	s := r.GetStringAny(keys, strconv.FormatBool(fallback))
+	v, err := strconv.ParseBool(s)
+	if err != nil {
+		return fallback
+	}
+	return v
+}
+
 // GetInt returns the int value for key, falling back to fallback.
 func (r *SettingResolver) GetInt(key string, fallback int) int {
 	s := r.GetString(key, strconv.Itoa(fallback))
+	v, err := strconv.Atoi(s)
+	if err != nil {
+		return fallback
+	}
+	return v
+}
+
+// GetIntAny is the integer counterpart to GetStringAny.
+func (r *SettingResolver) GetIntAny(keys []string, fallback int) int {
+	s := r.GetStringAny(keys, strconv.Itoa(fallback))
 	v, err := strconv.Atoi(s)
 	if err != nil {
 		return fallback
@@ -109,14 +154,14 @@ func (r *SettingResolver) Invalidate(key string) {
 }
 
 // fromCache returns a cached value if it exists and has not expired.
-func (r *SettingResolver) fromCache(key string) (string, bool) {
+func (r *SettingResolver) fromCache(key string) (string, bool, bool) {
 	r.mu.RLock()
 	entry, ok := r.cache[key]
 	r.mu.RUnlock()
 	if ok && time.Now().Before(entry.expiresAt) {
-		return entry.value, true
+		return entry.value, entry.found, true
 	}
-	return "", false
+	return "", false, false
 }
 
 // fromDB fetches a value from the database and populates the cache.
@@ -126,12 +171,12 @@ func (r *SettingResolver) fromDB(key string) (string, bool) {
 	if err != nil {
 		// Key not in DB — cache a sentinel so we don't hammer the DB for missing keys.
 		r.mu.Lock()
-		r.cache[key] = cachedSetting{value: "", expiresAt: time.Now().Add(r.ttl)}
+		r.cache[key] = cachedSetting{value: "", found: false, expiresAt: time.Now().Add(r.ttl)}
 		r.mu.Unlock()
 		return "", false
 	}
 	r.mu.Lock()
-	r.cache[key] = cachedSetting{value: value, expiresAt: time.Now().Add(r.ttl)}
+	r.cache[key] = cachedSetting{value: value, found: true, expiresAt: time.Now().Add(r.ttl)}
 	r.mu.Unlock()
 	log.Debugf("setting resolved from DB: %s = %s", key, value)
 	return value, true

--- a/services/backend/config/resolver_test.go
+++ b/services/backend/config/resolver_test.go
@@ -1,0 +1,41 @@
+package config
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSettingResolverCachesMissingKeys(t *testing.T) {
+	resolver := &SettingResolver{
+		cache: map[string]cachedSetting{
+			"scanner.missing": {
+				found:     false,
+				expiresAt: time.Now().Add(time.Minute),
+			},
+		},
+	}
+
+	if got := resolver.GetString("scanner.missing", "fallback"); got != "fallback" {
+		t.Fatalf("GetString() = %q, want fallback", got)
+	}
+}
+
+func TestSettingResolverAliasSkipsCachedMissingKey(t *testing.T) {
+	resolver := &SettingResolver{
+		cache: map[string]cachedSetting{
+			"scanner.command_timeout_seconds": {
+				found:     false,
+				expiresAt: time.Now().Add(time.Minute),
+			},
+			"scanner.timeout_seconds": {
+				value:     "900",
+				found:     true,
+				expiresAt: time.Now().Add(time.Minute),
+			},
+		},
+	}
+
+	if got := resolver.GetIntAny([]string{"scanner.command_timeout_seconds", "scanner.timeout_seconds"}, 300); got != 900 {
+		t.Fatalf("GetIntAny() = %d, want 900", got)
+	}
+}

--- a/services/backend/database/migrations/101_clear_confirmed_intelligence_postures.go
+++ b/services/backend/database/migrations/101_clear_confirmed_intelligence_postures.go
@@ -1,0 +1,32 @@
+package migrations
+
+import (
+	"context"
+	"fmt"
+
+	vulnerabilityintelligence "justscan-backend/functions/vulnerabilityintelligence"
+
+	"github.com/uptrace/bun"
+)
+
+// Remove derived postures that were already known when their scan completed.
+// They can be rebuilt from immutable evidence if newer intelligence arrives.
+func init() {
+	Migrations.MustRegister(func(ctx context.Context, db *bun.DB) error {
+		condition := vulnerabilityintelligence.PostScanChangeCondition("p", "s")
+		if _, err := db.NewRaw(`
+			DELETE FROM vulnerability_postures AS p
+			USING scans AS s
+			WHERE p.scan_id = s.id
+			  AND s.completed_at IS NOT NULL
+			  AND NOT (` + condition + `)
+		`).Exec(ctx); err != nil {
+			return fmt.Errorf("clear CVE postures already confirmed by a scan: %w", err)
+		}
+		return nil
+	}, func(context.Context, *bun.DB) error {
+		// Vulnerability postures are derived from immutable evidence; there is no
+		// safe reason to recreate stale rows during rollback.
+		return nil
+	})
+}

--- a/services/backend/database/migrations/103_remove_scan_collections_repair.go
+++ b/services/backend/database/migrations/103_remove_scan_collections_repair.go
@@ -7,6 +7,10 @@ import (
 	"github.com/uptrace/bun"
 )
 
+// Migration 103 repairs installations that were affected by the historical
+// duplicate 79 migration identifier.  The old migration may already have
+// removed some or all of this schema; every statement is therefore
+// deliberately idempotent.
 func init() {
 	Migrations.MustRegister(func(ctx context.Context, db *bun.DB) error {
 		for _, statement := range []string{
@@ -15,11 +19,11 @@ func init() {
 			`ALTER TABLE watchlist_items DROP COLUMN IF EXISTS collection_ids`,
 		} {
 			if _, err := db.NewRaw(statement).Exec(ctx); err != nil {
-				return fmt.Errorf("migration 79 remove scan collections: %w", err)
+				return fmt.Errorf("migration 103 remove scan collections repair: %w", err)
 			}
 		}
 		return nil
 	}, func(context.Context, *bun.DB) error {
-		return fmt.Errorf("migration 79 cannot restore removed scan collections")
+		return fmt.Errorf("migration 103 cannot restore removed scan collections")
 	})
 }

--- a/services/backend/database/migrations/104_mcp_interactions_repair.go
+++ b/services/backend/database/migrations/104_mcp_interactions_repair.go
@@ -7,8 +7,9 @@ import (
 	"github.com/uptrace/bun"
 )
 
-// Migration 101 stores metadata-only MCP tool interaction events for admin
-// analytics. Raw prompts, arguments, tokens, and outputs are never persisted.
+// Migration 104 repairs installations where the historical duplicate 101
+// identifier marked only one of the two migrations.  IF NOT EXISTS keeps this
+// safe when the MCP table was already created by the old migration.
 func init() {
 	Migrations.MustRegister(func(ctx context.Context, db *bun.DB) error {
 		_, err := db.NewRaw(`
@@ -26,7 +27,7 @@ CREATE TABLE IF NOT EXISTS mcp_interactions (
     created_at TIMESTAMPTZ NOT NULL DEFAULT now()
 )`).Exec(ctx)
 		if err != nil {
-			return fmt.Errorf("migration 101 mcp interactions table: %w", err)
+			return fmt.Errorf("migration 104 mcp interactions table repair: %w", err)
 		}
 		for _, statement := range []string{
 			`CREATE INDEX IF NOT EXISTS idx_mcp_interactions_created_at ON mcp_interactions(created_at DESC)`,
@@ -34,14 +35,15 @@ CREATE TABLE IF NOT EXISTS mcp_interactions (
 			`CREATE INDEX IF NOT EXISTS idx_mcp_interactions_user_created_at ON mcp_interactions(user_id, created_at DESC)`,
 		} {
 			if _, err := db.NewRaw(statement).Exec(ctx); err != nil {
-				return fmt.Errorf("migration 101 mcp interactions index: %w", err)
+				return fmt.Errorf("migration 104 mcp interactions index repair: %w", err)
 			}
 		}
 		return nil
-	}, func(ctx context.Context, db *bun.DB) error {
-		if _, err := db.NewRaw(`DROP TABLE IF EXISTS mcp_interactions`).Exec(ctx); err != nil {
-			return fmt.Errorf("rollback migration 101 mcp interactions: %w", err)
-		}
+	}, func(context.Context, *bun.DB) error {
+		// The table may have been created by the legacy 101 migration before
+		// this repair ran. Dropping it during rollback could destroy production
+		// interaction history, and there is no safe way to distinguish ownership
+		// of the pre-existing table. Leave the idempotently repaired schema intact.
 		return nil
 	})
 }

--- a/services/backend/database/migrations/105_clear_confirmed_intelligence_postures_repair.go
+++ b/services/backend/database/migrations/105_clear_confirmed_intelligence_postures_repair.go
@@ -9,8 +9,10 @@ import (
 	"github.com/uptrace/bun"
 )
 
-// Remove derived postures that were already known when their scan completed.
-// They can be rebuilt from immutable evidence if newer intelligence arrives.
+// Migration 105 removes derived postures that were already known when their
+// scan completed. The historical migration used the duplicate identifier 101;
+// this predicate is intentionally safe to replay so either legacy branch is
+// repaired without relying on an ambiguous migration row.
 func init() {
 	Migrations.MustRegister(func(ctx context.Context, db *bun.DB) error {
 		condition := vulnerabilityintelligence.PostScanChangeCondition("p", "s")

--- a/services/backend/database/migrations/106_archive_upload_scan_id.go
+++ b/services/backend/database/migrations/106_archive_upload_scan_id.go
@@ -1,0 +1,30 @@
+package migrations
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/uptrace/bun"
+)
+
+// Migration 106 adds the durable completion key to archive upload sessions
+// created before resumable completion became retry-safe.
+func init() {
+	Migrations.MustRegister(func(ctx context.Context, db *bun.DB) error {
+		for _, statement := range []string{
+			`ALTER TABLE archive_upload_sessions ADD COLUMN IF NOT EXISTS scan_id UUID NULL REFERENCES scans(id) ON DELETE SET NULL`,
+			`CREATE UNIQUE INDEX IF NOT EXISTS idx_archive_upload_sessions_scan_id ON archive_upload_sessions(scan_id) WHERE scan_id IS NOT NULL`,
+		} {
+			if _, err := db.NewRaw(statement).Exec(ctx); err != nil {
+				return fmt.Errorf("migration 106 archive upload scan id: %w", err)
+			}
+		}
+		return nil
+	}, func(context.Context, *bun.DB) error {
+		// Migration 80 includes this column for fresh installs, so dropping it
+		// during a rollback would leave a database marked through 80 with a schema
+		// that no longer matches migration 80. It may also contain durable scan
+		// completion keys; leave the repair intact rather than risking data loss.
+		return nil
+	})
+}

--- a/services/backend/database/migrations/107_remove_pipeline_verdict_config_repair.go
+++ b/services/backend/database/migrations/107_remove_pipeline_verdict_config_repair.go
@@ -1,0 +1,33 @@
+package migrations
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/uptrace/bun"
+)
+
+// Migration 107 repairs the other side of the historical duplicate 79
+// identifier. A legacy bun_migrations row does not tell us which 79 function
+// ran, so this idempotent schema reconciliation guarantees that the removed
+// pipeline verdict column is absent without replaying any data migration.
+func init() {
+	Migrations.MustRegister(func(ctx context.Context, db *bun.DB) error {
+		exists, err := db.NewSelect().Table("information_schema.tables").
+			Where("table_name = ?", "pipeline_scan_requests").Exists(ctx)
+		if err != nil {
+			return fmt.Errorf("migration 107 inspect pipeline scan requests: %w", err)
+		}
+		if !exists {
+			return nil
+		}
+		if _, err := db.NewRaw(`ALTER TABLE pipeline_scan_requests DROP COLUMN IF EXISTS verdict_config`).Exec(ctx); err != nil {
+			return fmt.Errorf("migration 107 remove pipeline verdict config repair: %w", err)
+		}
+		return nil
+	}, func(context.Context, *bun.DB) error {
+		// The column was intentionally removed and its old values cannot be
+		// reconstructed safely during rollback.
+		return nil
+	})
+}

--- a/services/backend/database/migrations/80_archive_upload_sessions.go
+++ b/services/backend/database/migrations/80_archive_upload_sessions.go
@@ -14,6 +14,7 @@ func init() {
 				id UUID PRIMARY KEY,
 				org_id UUID NOT NULL REFERENCES orgs(id) ON DELETE CASCADE,
 				user_id UUID NULL REFERENCES users(id) ON DELETE SET NULL,
+				scan_id UUID NULL REFERENCES scans(id) ON DELETE SET NULL,
 				filename TEXT NOT NULL,
 				image_name TEXT NOT NULL DEFAULT '',
 				image_tag TEXT NOT NULL DEFAULT '',
@@ -28,6 +29,7 @@ func init() {
 			)`,
 			`CREATE INDEX IF NOT EXISTS idx_archive_upload_sessions_org_status ON archive_upload_sessions(org_id, status)`,
 			`CREATE INDEX IF NOT EXISTS idx_archive_upload_sessions_expires_at ON archive_upload_sessions(expires_at)`,
+			`CREATE UNIQUE INDEX IF NOT EXISTS idx_archive_upload_sessions_scan_id ON archive_upload_sessions(scan_id) WHERE scan_id IS NOT NULL`,
 		}
 		for _, statement := range statements {
 			if _, err := db.NewRaw(statement).Exec(ctx); err != nil {

--- a/services/backend/database/migrations/pipeline_scan_initiators_test.go
+++ b/services/backend/database/migrations/pipeline_scan_initiators_test.go
@@ -10,3 +10,13 @@ func TestPipelineScanInitiatorMigrationIsRegistered(t *testing.T) {
 	}
 	t.Fatal("migration 78 is not registered")
 }
+
+func TestMigrationNamesAreUnique(t *testing.T) {
+	seen := make(map[string]string)
+	for _, migration := range Migrations.Sorted() {
+		if previous, ok := seen[migration.Name]; ok {
+			t.Fatalf("migration name %q is registered by both %s and %s", migration.Name, previous, migration)
+		}
+		seen[migration.Name] = migration.String()
+	}
+}

--- a/services/backend/functions/vulnerabilityintelligence/post_scan.go
+++ b/services/backend/functions/vulnerabilityintelligence/post_scan.go
@@ -1,0 +1,22 @@
+package vulnerabilityintelligence
+
+import "fmt"
+
+// PostScanChangeCondition returns the SQL predicate used to decide whether a
+// posture represents intelligence learned after a scan completed. Change
+// events are compared by their ingestion time so a later confirmation scan
+// clears an older event even when the provider's observed_at value is older.
+// Aliases are internal constants supplied by callers, never request values.
+func PostScanChangeCondition(postureAlias, scanAlias string) string {
+	return fmt.Sprintf(`(
+		(%[1]s.change_event_id IS NOT NULL AND EXISTS (
+			SELECT 1
+			FROM vulnerability_intelligence_change_events AS intelligence_change
+			WHERE intelligence_change.id = %[1]s.change_event_id
+			  AND %[2]s.completed_at IS NOT NULL
+			  AND intelligence_change.created_at > %[2]s.completed_at
+		))
+		OR
+		(%[1]s.change_event_id IS NULL AND %[2]s.completed_at IS NOT NULL AND %[1]s.observed_at > %[2]s.completed_at)
+	)`, postureAlias, scanAlias)
+}

--- a/services/backend/functions/vulnerabilityintelligence/post_scan_test.go
+++ b/services/backend/functions/vulnerabilityintelligence/post_scan_test.go
@@ -1,0 +1,22 @@
+package vulnerabilityintelligence
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestPostScanChangeConditionComparesChangeIngestionToCompletion(t *testing.T) {
+	condition := PostScanChangeCondition("posture", "scan")
+	for _, expected := range []string{
+		"intelligence_change.id = posture.change_event_id",
+		"intelligence_change.created_at > scan.completed_at",
+		"posture.observed_at > scan.completed_at",
+	} {
+		if !strings.Contains(condition, expected) {
+			t.Fatalf("post-scan condition missing %q: %s", expected, condition)
+		}
+	}
+	if strings.Contains(condition, "posture.change_event_id IS NOT NULL OR") {
+		t.Fatalf("a change event ID alone must not remain pending forever: %s", condition)
+	}
+}

--- a/services/backend/handlers/admins/settings.go
+++ b/services/backend/handlers/admins/settings.go
@@ -48,6 +48,19 @@ func GetSettings(c *gin.Context, db *bun.DB) {
 	for _, s := range settings {
 		result[s.Key] = s.Value
 	}
+	// `timeout_seconds` was the original admin API key. Keep returning it as
+	// an alias while persistence uses the canonical command_timeout_seconds
+	// name consumed by scanner processes.
+	if value, ok := result["scanner.command_timeout_seconds"]; ok {
+		if _, exists := result["scanner.timeout_seconds"]; !exists {
+			result["scanner.timeout_seconds"] = value
+		}
+	}
+	if value, ok := result["scanner.timeout_seconds"]; ok {
+		if _, exists := result["scanner.command_timeout_seconds"]; !exists {
+			result["scanner.command_timeout_seconds"] = value
+		}
+	}
 	c.JSON(http.StatusOK, result)
 }
 
@@ -190,6 +203,7 @@ func UpdateScannerSettings(c *gin.Context, db *bun.DB) {
 		EnableGrype               *bool `json:"enable_grype"`
 		Concurrency               *int  `json:"concurrency"`
 		TimeoutSeconds            *int  `json:"timeout_seconds"`
+		CommandTimeoutSeconds     *int  `json:"command_timeout_seconds"`
 		DBMaxAgeHours             *int  `json:"db_max_age_hours"`
 		EnableOSVJavaAugmentation *bool `json:"enable_osv_java_augmentation"`
 	}
@@ -217,10 +231,23 @@ func UpdateScannerSettings(c *gin.Context, db *bun.DB) {
 		}
 		settings["scanner.concurrency"] = strconv.Itoa(*req.Concurrency)
 	}
-	if req.TimeoutSeconds != nil {
-		settings["scanner.timeout_seconds"] = strconv.Itoa(*req.TimeoutSeconds)
+	timeoutSeconds := req.TimeoutSeconds
+	if req.CommandTimeoutSeconds != nil {
+		// Accept the canonical name as well as the original admin API field.
+		timeoutSeconds = req.CommandTimeoutSeconds
+	}
+	if timeoutSeconds != nil {
+		if *timeoutSeconds < 1 {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "timeout_seconds must be >= 1"})
+			return
+		}
+		settings["scanner.command_timeout_seconds"] = strconv.Itoa(*timeoutSeconds)
 	}
 	if req.DBMaxAgeHours != nil {
+		if *req.DBMaxAgeHours < 1 {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "db_max_age_hours must be >= 1"})
+			return
+		}
 		settings["scanner.db_max_age_hours"] = strconv.Itoa(*req.DBMaxAgeHours)
 	}
 	if req.EnableOSVJavaAugmentation != nil {
@@ -232,7 +259,21 @@ func UpdateScannerSettings(c *gin.Context, db *bun.DB) {
 			return
 		}
 	}
-	c.JSON(http.StatusOK, gin.H{"updated": settings})
+	restartRequired := make([]string, 0, 1)
+	if req.Concurrency != nil {
+		// Worker goroutines are intentionally fixed at process start. This is
+		// explicit so an operator knows a concurrency change takes effect on
+		// the next backend restart instead of believing capacity changed live.
+		restartRequired = append(restartRequired, "concurrency")
+	}
+	c.JSON(http.StatusOK, gin.H{
+		"updated":          settings,
+		"restart_required": restartRequired,
+		"live_applies": []string{
+			"enable_trivy", "enable_grype", "command_timeout_seconds",
+			"db_max_age_hours", "enable_osv_java_augmentation",
+		},
+	})
 }
 
 // UpdateAuthSettings updates DB-backed authentication settings.

--- a/services/backend/handlers/dashboard/stats.go
+++ b/services/backend/handlers/dashboard/stats.go
@@ -8,6 +8,7 @@ import (
 
 	"justscan-backend/compliance"
 	"justscan-backend/functions/authz"
+	vulnerabilityintelligence "justscan-backend/functions/vulnerabilityintelligence"
 	"justscan-backend/pkg/models"
 
 	"github.com/gin-gonic/gin"
@@ -116,8 +117,8 @@ func GetStats(db *bun.DB) gin.HandlerFunc {
 			result.Operations.OrgPolicyFailCount = policyCounts.orgPolicyFailed
 		}
 		if intelligenceCounts, intelligenceErr := loadIntelligenceIssueCounts(c, ctx, db, userID, isAdmin, accessibleOrgIDs); intelligenceErr == nil {
-			result.Operations.IntelligenceChangedCount = intelligenceCounts.changed
-			result.Operations.IntelligencePendingCount = intelligenceCounts.pending
+			result.Operations.IntelligenceChangedCount = intelligenceCounts.Changed
+			result.Operations.IntelligencePendingCount = intelligenceCounts.Pending
 		}
 
 		// Severity totals across scans with finalized findings.
@@ -313,8 +314,8 @@ type dashboardPolicyIssueCounts struct {
 }
 
 type dashboardIntelligenceIssueCounts struct {
-	changed int
-	pending int
+	Changed int `bun:"changed"`
+	Pending int `bun:"pending"`
 }
 
 func loadIntelligenceIssueCounts(
@@ -326,7 +327,7 @@ func loadIntelligenceIssueCounts(
 	accessibleOrgIDs []uuid.UUID,
 ) (dashboardIntelligenceIssueCounts, error) {
 	var counts dashboardIntelligenceIssueCounts
-	postScanChange := "(p.change_event_id IS NOT NULL OR (s.completed_at IS NOT NULL AND p.observed_at > s.completed_at))"
+	postScanChange := vulnerabilityintelligence.PostScanChangeCondition("p", "s")
 	query := db.NewSelect().
 		TableExpr("vulnerabilities AS v").
 		ColumnExpr("COUNT(DISTINCT v.scan_id) FILTER (WHERE p.state IS NOT NULL AND p.state <> ? AND "+postScanChange+") AS changed", models.PostureStateUnchanged).

--- a/services/backend/handlers/dashboard/stats_test.go
+++ b/services/backend/handlers/dashboard/stats_test.go
@@ -1,9 +1,17 @@
 package dashboard
 
 import (
+	"context"
+	"net/http/httptest"
 	"testing"
 
 	"justscan-backend/pkg/models"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/uptrace/bun"
+	"github.com/uptrace/bun/dialect/pgdialect"
 )
 
 func TestIsBlockedByXrayPolicyStatus(t *testing.T) {
@@ -47,5 +55,31 @@ func TestSummarizeActiveXrayScansUsesQueuedFallback(t *testing.T) {
 	}
 	if steps[models.ScanStepQueued] != 1 {
 		t.Fatalf("expected queued fallback step count of 1, got %d", steps[models.ScanStepQueued])
+	}
+}
+
+func TestLoadIntelligenceIssueCountsScansAggregateColumns(t *testing.T) {
+	sqldb, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create mock database: %v", err)
+	}
+	defer sqldb.Close()
+	db := bun.NewDB(sqldb, pgdialect.New())
+	defer db.Close()
+
+	mock.ExpectQuery("SELECT").WillReturnRows(
+		sqlmock.NewRows([]string{"changed", "pending"}).AddRow(4, 3),
+	)
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request = httptest.NewRequest("GET", "/api/v1/dashboard/stats", nil)
+	counts, err := loadIntelligenceIssueCounts(c, context.Background(), db, uuid.Nil, true, nil)
+	if err != nil {
+		t.Fatalf("load intelligence counts: %v", err)
+	}
+	if counts.Changed != 4 || counts.Pending != 3 {
+		t.Fatalf("intelligence counts = changed %d pending %d, want 4/3", counts.Changed, counts.Pending)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/services/backend/handlers/scans/archive_uploads.go
+++ b/services/backend/handlers/scans/archive_uploads.go
@@ -137,34 +137,35 @@ func UploadArchiveUploadChunk(db *bun.DB) gin.HandlerFunc {
 			if session.Status != models.ArchiveUploadStatusActive || time.Now().After(session.ExpiresAt) {
 				return errUploadSessionUnavailable
 			}
+			if !isArchiveUploadPath(session.ID, session.ArchivePath) {
+				return errors.New("invalid upload archive path")
+			}
+			// Filesystem writes cannot participate in the database transaction. If
+			// the process crashed (or the offset update failed) after appending a
+			// chunk, reconcile the file back to the durable database offset before
+			// accepting a retry. This prevents the same chunk from being appended
+			// twice.
+			if err := reconcileArchiveUploadFile(session); err != nil {
+				return err
+			}
 			if offset != session.UploadedSize {
 				currentOffset = session.UploadedSize
 				return errUploadOffsetMismatch
 			}
-			if !isArchiveUploadPath(session.ID, session.ArchivePath) {
-				return errors.New("invalid upload archive path")
-			}
-			file, err := os.OpenFile(session.ArchivePath, os.O_WRONLY|os.O_APPEND, 0o600)
+			newOffset, err := appendArchiveUploadChunk(session, c.Request.Body)
 			if err != nil {
 				return err
 			}
-			written, copyErr := io.Copy(file, io.LimitReader(c.Request.Body, archiveUploadChunkBytes+1))
-			closeErr := file.Close()
-			if copyErr != nil {
-				return copyErr
-			}
-			if closeErr != nil {
-				return closeErr
-			}
-			if written == 0 || written > archiveUploadChunkBytes {
-				return errors.New("upload chunk must be between 1 byte and 8 MiB")
-			}
-			newOffset := session.UploadedSize + written
 			if newOffset > maxUploadedArchiveBytes || (session.ExpectedSize > 0 && newOffset > session.ExpectedSize) {
+				_ = truncateArchiveUploadFile(session.ArchivePath, session.UploadedSize)
 				return errors.New("uploaded archive exceeds the 5 GB limit")
 			}
 			if _, err := tx.NewUpdate().Model((*models.ArchiveUploadSession)(nil)).
 				Set("uploaded_size = ?", newOffset).Where("id = ?", session.ID).Exec(ctx); err != nil {
+				// Best-effort rollback closes the crash window for ordinary DB
+				// errors; reconcileArchiveUploadFile remains the recovery path if
+				// the process dies before this truncation runs.
+				_ = truncateArchiveUploadFile(session.ArchivePath, session.UploadedSize)
 				return err
 			}
 			currentOffset = newOffset
@@ -177,6 +178,9 @@ func UploadArchiveUploadChunk(db *bun.DB) gin.HandlerFunc {
 				c.JSON(http.StatusConflict, gin.H{"error": "upload offset does not match", "upload_offset": currentOffset})
 			case errors.Is(err, errUploadSessionUnavailable):
 				c.JSON(http.StatusConflict, gin.H{"error": "upload session is expired or already completed"})
+			case errors.Is(err, errUploadArchiveFileMismatch):
+				c.Header("Upload-Offset", strconv.FormatInt(currentOffset, 10))
+				c.JSON(http.StatusConflict, gin.H{"error": "upload archive file does not match its recorded offset", "upload_offset": currentOffset})
 			case errors.Is(err, sql.ErrNoRows):
 				c.JSON(http.StatusNotFound, gin.H{"error": "upload session not found"})
 			default:
@@ -200,61 +204,34 @@ func CompleteArchiveUploadSession(db *bun.DB) gin.HandlerFunc {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid upload session ID"})
 			return
 		}
-		session := &models.ArchiveUploadSession{}
-		if err := db.NewSelect().Model(session).Where("id = ? AND org_id = ?", sessionID, orgID).Scan(c.Request.Context()); err != nil {
-			c.JSON(http.StatusNotFound, gin.H{"error": "upload session not found"})
-			return
-		}
-		if session.Status != models.ArchiveUploadStatusActive || time.Now().After(session.ExpiresAt) {
-			c.JSON(http.StatusConflict, gin.H{"error": "upload session is expired or already completed"})
-			return
-		}
-		if session.UploadedSize == 0 || (session.ExpectedSize > 0 && session.UploadedSize != session.ExpectedSize) {
-			c.JSON(http.StatusConflict, gin.H{"error": "archive upload is incomplete", "upload_offset": session.UploadedSize})
-			return
-		}
-		if !isArchiveUploadPath(session.ID, session.ArchivePath) {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "invalid upload archive path"})
-			return
-		}
-		if info, err := os.Stat(session.ArchivePath); err != nil || info.Size() != session.UploadedSize {
-			c.JSON(http.StatusConflict, gin.H{"error": "archive upload is incomplete or unavailable"})
-			return
-		}
-
-		now := time.Now().UTC()
-		completed, err := db.NewUpdate().Model((*models.ArchiveUploadSession)(nil)).
-			Set("status = ?", models.ArchiveUploadStatusCompleted).
-			Set("completed_at = ?", now).
-			Where("id = ? AND status = ?", session.ID, models.ArchiveUploadStatusActive).
-			Exec(c.Request.Context())
+		session, err := claimArchiveUploadCompletion(c.Request.Context(), db, sessionID, orgID)
 		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to complete upload session"})
-			return
-		}
-		rows, err := completed.RowsAffected()
-		if err != nil || rows != 1 {
-			c.JSON(http.StatusConflict, gin.H{"error": "upload session is already being completed or has completed"})
+			switch {
+			case errors.Is(err, sql.ErrNoRows):
+				c.JSON(http.StatusNotFound, gin.H{"error": "upload session not found"})
+			case errors.Is(err, errUploadSessionIncomplete):
+				var currentOffset int64
+				if session != nil {
+					currentOffset = session.UploadedSize
+				}
+				c.JSON(http.StatusConflict, gin.H{"error": "archive upload is incomplete", "upload_offset": currentOffset})
+			case errors.Is(err, errUploadArchiveFileMismatch):
+				c.JSON(http.StatusConflict, gin.H{"error": "archive upload is incomplete or unavailable"})
+			case errors.Is(err, errUploadSessionUnavailable):
+				c.JSON(http.StatusConflict, gin.H{"error": "upload session is expired or unavailable"})
+			default:
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to complete upload session"})
+			}
 			return
 		}
 
 		initiatorTokenID, initiatorDescription, err := resolvePipelineInitiator(c, db, userID)
 		if err != nil {
-			_, _ = db.NewUpdate().Model((*models.ArchiveUploadSession)(nil)).
-				Set("status = ?", models.ArchiveUploadStatusActive).
-				Set("completed_at = NULL").
-				Where("id = ? AND status = ?", session.ID, models.ArchiveUploadStatusCompleted).
-				Exec(c.Request.Context())
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to resolve upload initiator"})
 			return
 		}
 		response, err := createScanFromArchive(c.Request.Context(), db, orgID, userID, session, initiatorTokenID, initiatorDescription)
 		if err != nil {
-			_, _ = db.NewUpdate().Model((*models.ArchiveUploadSession)(nil)).
-				Set("status = ?", models.ArchiveUploadStatusActive).
-				Set("completed_at = NULL").
-				Where("id = ? AND status = ?", session.ID, models.ArchiveUploadStatusCompleted).
-				Exec(c.Request.Context())
 			log.Errorf("CompleteArchiveUploadSession %s: %v", session.ID, err)
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to create scan from uploaded archive"})
 			return
@@ -265,9 +242,186 @@ func CompleteArchiveUploadSession(db *bun.DB) gin.HandlerFunc {
 }
 
 var (
-	errUploadOffsetMismatch     = errors.New("upload offset mismatch")
-	errUploadSessionUnavailable = errors.New("upload session unavailable")
+	errUploadOffsetMismatch      = errors.New("upload offset mismatch")
+	errUploadSessionUnavailable  = errors.New("upload session unavailable")
+	errUploadSessionIncomplete   = errors.New("upload session incomplete")
+	errUploadArchiveFileMismatch = errors.New("upload archive file mismatch")
 )
+
+// reconcileArchiveUploadFile makes the filesystem state agree with the
+// database offset before a new chunk is accepted. A file can be ahead when a
+// process dies after writing bytes but before committing uploaded_size.
+func reconcileArchiveUploadFile(session *models.ArchiveUploadSession) error {
+	if session == nil || !isArchiveUploadPath(session.ID, session.ArchivePath) {
+		return errors.New("invalid upload archive path")
+	}
+	info, err := os.Lstat(session.ArchivePath)
+	if err != nil {
+		return fmt.Errorf("stat upload archive: %w", err)
+	}
+	if !info.Mode().IsRegular() || info.Size() < session.UploadedSize {
+		return errUploadArchiveFileMismatch
+	}
+	if info.Size() == session.UploadedSize {
+		return nil
+	}
+	return truncateArchiveUploadFile(session.ArchivePath, session.UploadedSize)
+}
+
+func truncateArchiveUploadFile(path string, offset int64) error {
+	file, err := os.OpenFile(path, os.O_WRONLY, 0o600)
+	if err != nil {
+		return err
+	}
+	if err := file.Truncate(offset); err != nil {
+		_ = file.Close()
+		return err
+	}
+	if err := file.Sync(); err != nil {
+		_ = file.Close()
+		return err
+	}
+	return file.Close()
+}
+
+// appendArchiveUploadChunk writes a single chunk and returns the resulting
+// offset. Any body/file error restores the original file length immediately;
+// the offset reconciliation above remains the final protection for crashes
+// between this write and the database update.
+func appendArchiveUploadChunk(session *models.ArchiveUploadSession, body io.Reader) (int64, error) {
+	if session == nil || !isArchiveUploadPath(session.ID, session.ArchivePath) {
+		return 0, errors.New("invalid upload archive path")
+	}
+	startOffset := session.UploadedSize
+	file, err := os.OpenFile(session.ArchivePath, os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		return 0, err
+	}
+	rollback := func() {
+		if err := file.Truncate(startOffset); err != nil {
+			log.Warnf("failed to roll back partial archive upload %s: %v", session.ID, err)
+			return
+		}
+		if err := file.Sync(); err != nil {
+			log.Warnf("failed to sync rolled-back archive upload %s: %v", session.ID, err)
+		}
+	}
+	written, copyErr := io.Copy(file, io.LimitReader(body, archiveUploadChunkBytes+1))
+	if copyErr != nil || written == 0 || written > archiveUploadChunkBytes {
+		rollback()
+		_ = file.Close()
+		if copyErr != nil {
+			return 0, copyErr
+		}
+		return 0, errors.New("upload chunk must be between 1 byte and 8 MiB")
+	}
+	if err := file.Sync(); err != nil {
+		rollback()
+		_ = file.Close()
+		return 0, err
+	}
+	if err := file.Close(); err != nil {
+		return 0, err
+	}
+	return startOffset + written, nil
+}
+
+// claimArchiveUploadCompletion serializes completion and persists the scan ID
+// before any scan dispatch work. A retry therefore resumes the same scan even
+// if the process dies after this transaction commits.
+func claimArchiveUploadCompletion(ctx context.Context, db *bun.DB, sessionID, orgID uuid.UUID) (*models.ArchiveUploadSession, error) {
+	var result *models.ArchiveUploadSession
+	err := db.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
+		session := &models.ArchiveUploadSession{}
+		if err := tx.NewSelect().Model(session).
+			Where("id = ? AND org_id = ?", sessionID, orgID).
+			For("UPDATE").Scan(ctx); err != nil {
+			return err
+		}
+
+		if session.Status == models.ArchiveUploadStatusCompleted {
+			if session.ScanID == nil {
+				if err := recoverCompletedArchiveScanID(ctx, tx, session); err != nil {
+					return err
+				}
+			}
+			result = session
+			return nil
+		}
+		if session.Status != models.ArchiveUploadStatusActive || time.Now().After(session.ExpiresAt) {
+			return errUploadSessionUnavailable
+		}
+		if session.UploadedSize == 0 || (session.ExpectedSize > 0 && session.UploadedSize != session.ExpectedSize) {
+			result = session
+			return errUploadSessionIncomplete
+		}
+		if !isArchiveUploadPath(session.ID, session.ArchivePath) {
+			return errors.New("invalid upload archive path")
+		}
+		if err := reconcileArchiveUploadFile(session); err != nil {
+			return err
+		}
+		info, err := os.Lstat(session.ArchivePath)
+		if err != nil || !info.Mode().IsRegular() || info.Size() != session.UploadedSize {
+			return errUploadArchiveFileMismatch
+		}
+
+		scanID := uuid.New()
+		now := time.Now().UTC()
+		updated, err := tx.NewUpdate().Model((*models.ArchiveUploadSession)(nil)).
+			Set("status = ?", models.ArchiveUploadStatusCompleted).
+			Set("completed_at = ?", now).
+			Set("scan_id = ?", scanID).
+			Where("id = ? AND status = ?", session.ID, models.ArchiveUploadStatusActive).
+			Exec(ctx)
+		if err != nil {
+			return err
+		}
+		if rows, err := updated.RowsAffected(); err != nil {
+			return err
+		} else if rows != 1 {
+			return errUploadSessionUnavailable
+		}
+		session.ScanID = &scanID
+		session.Status = models.ArchiveUploadStatusCompleted
+		session.CompletedAt = &now
+		result = session
+		return nil
+	})
+	return result, err
+}
+
+// recoverCompletedArchiveScanID handles sessions completed by an older
+// server version before scan_id was persisted. It first reuses a matching
+// existing scan, then reserves a new deterministic ID for the retry.
+func recoverCompletedArchiveScanID(ctx context.Context, db bun.IDB, session *models.ArchiveUploadSession) error {
+	var scan models.Scan
+	err := db.NewSelect().Model(&scan).
+		Where("scan_source = ? AND image_location = ? AND owner_org_id = ?", models.ScanSourceUploadedArchive, session.ArchivePath, session.OrgID).
+		OrderExpr("created_at ASC, id ASC").
+		Limit(1).
+		Scan(ctx)
+	if err == nil {
+		session.ScanID = &scan.ID
+		_, err = db.NewUpdate().Model((*models.ArchiveUploadSession)(nil)).
+			Set("scan_id = ?", scan.ID).
+			Where("id = ? AND scan_id IS NULL", session.ID).
+			Exec(ctx)
+		return err
+	}
+	if !errors.Is(err, sql.ErrNoRows) {
+		return err
+	}
+	scanID := uuid.New()
+	if _, err := db.NewUpdate().Model((*models.ArchiveUploadSession)(nil)).
+		Set("scan_id = ?", scanID).
+		Where("id = ? AND scan_id IS NULL", session.ID).
+		Exec(ctx); err != nil {
+		return err
+	}
+	session.ScanID = &scanID
+	return nil
+}
 
 func requireArchiveUploadOrgScope(c *gin.Context, db *bun.DB) (uuid.UUID, uuid.UUID, bool) {
 	if !scanner.TrivyEnabled() {
@@ -295,27 +449,60 @@ func createScanFromArchive(ctx context.Context, db *bun.DB, orgID, userID uuid.U
 	if imageTag == "" {
 		imageTag = "local"
 	}
-	scan := &models.Scan{ID: uuid.New(), ImageName: imageName, ImageTag: imageTag, Platform: session.Platform, ScanProvider: models.ScanProviderTrivy, ScanSource: models.ScanSourceUploadedArchive, ImageLocation: session.ArchivePath, CurrentStep: models.ScanStepQueued, Status: models.ScanStatusPending, OwnerType: models.OwnerTypeOrg, OwnerOrgID: &orgID, CreatedAt: time.Now()}
+	scanID := uuid.New()
+	if session.ScanID != nil {
+		scanID = *session.ScanID
+	}
+	scan := &models.Scan{ID: scanID, ImageName: imageName, ImageTag: imageTag, Platform: session.Platform, ScanProvider: models.ScanProviderTrivy, ScanSource: models.ScanSourceUploadedArchive, ImageLocation: session.ArchivePath, CurrentStep: models.ScanStepQueued, Status: models.ScanStatusPending, OwnerType: models.OwnerTypeOrg, OwnerOrgID: &orgID, CreatedAt: time.Now()}
 	if userID != uuid.Nil {
 		scan.UserID = &userID
 	}
-	if _, err := db.NewInsert().Model(scan).Exec(ctx); err != nil {
+	inserted, err := db.NewInsert().Model(scan).On("CONFLICT (id) DO NOTHING").Exec(ctx)
+	if err != nil {
 		return uploadedArchiveScanResponse{}, err
+	}
+	insertedRows, err := inserted.RowsAffected()
+	if err != nil {
+		return uploadedArchiveScanResponse{}, err
+	}
+	if insertedRows == 0 {
+		// The completion transaction already reserved this ID and another
+		// request may have created the scan. Reuse the durable row instead of
+		// creating a second scan or dispatching the same job twice.
+		if err := db.NewSelect().Model(scan).Where("id = ?", scanID).Scan(ctx); err != nil {
+			return uploadedArchiveScanResponse{}, err
+		}
 	}
 	if err := EnsureOrgScanLink(ctx, db, orgID, scan.ID); err != nil {
 		return uploadedArchiveScanResponse{}, err
 	}
-	if err := pipelines.CreateScanRequest(ctx, db, scan.ID.String(), orgID.String(), pipelines.ScanCreateConfig{
-		Source:                    models.PipelineSourceJustScanCLI,
-		InitiatorTokenID:          initiatorTokenID,
-		InitiatorTokenDescription: initiatorDescription,
-	}); err != nil {
-		return uploadedArchiveScanResponse{}, err
+	var pipelineRequest models.PipelineScanRequest
+	pipelineErr := db.NewSelect().Model(&pipelineRequest).Where("scan_id = ?", scan.ID).Scan(ctx)
+	if errors.Is(pipelineErr, sql.ErrNoRows) {
+		if err := pipelines.CreateScanRequest(ctx, db, scan.ID.String(), orgID.String(), pipelines.ScanCreateConfig{
+			Source:                    models.PipelineSourceJustScanCLI,
+			InitiatorTokenID:          initiatorTokenID,
+			InitiatorTokenDescription: initiatorDescription,
+		}); err != nil {
+			// A concurrent completion may have inserted the unique request. Treat
+			// that race as success when the request is now present.
+			if loadErr := db.NewSelect().Model(&pipelineRequest).Where("scan_id = ?", scan.ID).Scan(ctx); loadErr != nil {
+				return uploadedArchiveScanResponse{}, err
+			}
+		}
+	} else if pipelineErr != nil {
+		return uploadedArchiveScanResponse{}, pipelineErr
 	}
-	if err := scanner.DispatchScan(ctx, db, scan, nil, session.Platform); err != nil {
-		log.Warnf("Create archive session scan dispatch failed for %s: %v", scan.ID, err)
-		if markErr := scanner.MarkScanFailed(ctx, db, scan.ID, err.Error()); markErr != nil {
-			return uploadedArchiveScanResponse{}, markErr
+	// If the process crashed after inserting the reserved scan but before
+	// dispatching it, a retry must enqueue the existing pending row. The worker
+	// claims pending rows atomically, so a concurrent retry cannot execute the
+	// same scan twice.
+	if insertedRows == 1 || (insertedRows == 0 && scan.Status == models.ScanStatusPending) {
+		if err := scanner.DispatchScan(ctx, db, scan, nil, session.Platform); err != nil {
+			log.Warnf("Create archive session scan dispatch failed for %s: %v", scan.ID, err)
+			if markErr := scanner.MarkScanFailed(ctx, db, scan.ID, err.Error()); markErr != nil {
+				return uploadedArchiveScanResponse{}, markErr
+			}
 		}
 	}
 	return uploadedArchiveScanResponse{ID: scan.ID, ImageName: scan.ImageName, ImageTag: scan.ImageTag, Status: scan.Status, CurrentStep: scan.CurrentStep}, nil
@@ -328,7 +515,83 @@ func archiveUploadDirectory(id uuid.UUID) string {
 func isArchiveUploadPath(id uuid.UUID, path string) bool {
 	directory := archiveUploadDirectory(id)
 	relative, err := filepath.Rel(directory, path)
-	return err == nil && relative != "." && !strings.HasPrefix(relative, ".."+string(filepath.Separator)) && !filepath.IsAbs(relative)
+	if err != nil || relative == "." || filepath.IsAbs(relative) || strings.HasPrefix(relative, ".."+string(filepath.Separator)) || relative == ".." {
+		return false
+	}
+	return !strings.Contains(relative, string(filepath.Separator)) && validateArchiveFilename(relative) == nil
+}
+
+// isControlledUploadedArchivePath accepts only an archive file directly under
+// a UUID-named directory in the application upload root. This is used when a
+// scan row is being deleted and its session ID is not available in the row.
+func isControlledUploadedArchivePath(path string) bool {
+	root := filepath.Join(os.TempDir(), "justscan", "uploads")
+	relative, err := filepath.Rel(root, filepath.Clean(path))
+	if err != nil || relative == "." || filepath.IsAbs(relative) {
+		return false
+	}
+	parts := strings.Split(relative, string(filepath.Separator))
+	if len(parts) != 2 {
+		return false
+	}
+	if _, err := uuid.Parse(parts[0]); err != nil {
+		return false
+	}
+	return validateArchiveFilename(parts[1]) == nil
+}
+
+// loadArchiveUploadSessionsForScans resolves resumable uploads before their
+// scan rows are deleted. The scan_id foreign key is intentionally nullable for
+// legacy sessions, so callers must capture the validated session path before
+// deleteScanRecords removes the link.
+func loadArchiveUploadSessionsForScans(ctx context.Context, db bun.IDB, scanIDs []uuid.UUID) ([]models.ArchiveUploadSession, error) {
+	if len(scanIDs) == 0 {
+		return nil, nil
+	}
+	exists, err := scanDeletionTableExists(ctx, db, "archive_upload_sessions")
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		return nil, nil
+	}
+	var sessions []models.ArchiveUploadSession
+	if err := db.NewSelect().Model(&sessions).Where("scan_id IN (?)", bun.In(scanIDs)).Scan(ctx); err != nil {
+		return nil, err
+	}
+	return sessions, nil
+}
+
+// cleanupArchiveUploadSessions removes only the UUID-scoped directories
+// created by the resumable upload flow. Invalid or legacy paths are ignored;
+// they must never become arbitrary filesystem deletion targets.
+func cleanupArchiveUploadSessions(sessions []models.ArchiveUploadSession) error {
+	var firstErr error
+	for i := range sessions {
+		session := &sessions[i]
+		if !isArchiveUploadPath(session.ID, session.ArchivePath) {
+			continue
+		}
+		if err := os.RemoveAll(archiveUploadDirectory(session.ID)); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}
+
+func deleteArchiveUploadSessionsForScans(ctx context.Context, db bun.IDB, scanIDs []uuid.UUID) error {
+	if len(scanIDs) == 0 {
+		return nil
+	}
+	exists, err := scanDeletionTableExists(ctx, db, "archive_upload_sessions")
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return nil
+	}
+	_, err = db.NewDelete().TableExpr("archive_upload_sessions").Where("scan_id IN (?)", bun.In(scanIDs)).Exec(ctx)
+	return err
 }
 
 func validateArchiveFilename(filename string) error {

--- a/services/backend/handlers/scans/archive_uploads_test.go
+++ b/services/backend/handlers/scans/archive_uploads_test.go
@@ -1,0 +1,54 @@
+package scans
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"justscan-backend/pkg/models"
+
+	"github.com/google/uuid"
+)
+
+func TestArchiveUploadRetryReconcilesBytesAfterOffsetUpdateFailure(t *testing.T) {
+	sessionID := uuid.New()
+	directory := archiveUploadDirectory(sessionID)
+	if err := os.MkdirAll(directory, 0o700); err != nil {
+		t.Fatalf("create upload directory: %v", err)
+	}
+	defer os.RemoveAll(directory)
+
+	path := filepath.Join(directory, "image.tar")
+	if err := os.WriteFile(path, []byte("base"), 0o600); err != nil {
+		t.Fatalf("create archive: %v", err)
+	}
+	session := &models.ArchiveUploadSession{ID: sessionID, ArchivePath: path, UploadedSize: int64(len("base"))}
+
+	// The append succeeds, but imagine the DB offset update fails afterwards.
+	// The durable offset remains four bytes, while the file is eight bytes.
+	if _, err := appendArchiveUploadChunk(session, bytes.NewReader([]byte("next"))); err != nil {
+		t.Fatalf("append first chunk: %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat unapplied archive: %v", err)
+	}
+	if info.Size() != int64(len("basenext")) {
+		t.Fatalf("expected unapplied file bytes after simulated DB failure, size=%v", info.Size())
+	}
+
+	if err := reconcileArchiveUploadFile(session); err != nil {
+		t.Fatalf("reconcile stale file bytes: %v", err)
+	}
+	if _, err := appendArchiveUploadChunk(session, bytes.NewReader([]byte("next"))); err != nil {
+		t.Fatalf("append retried chunk: %v", err)
+	}
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read reconciled archive: %v", err)
+	}
+	if string(contents) != "basenext" {
+		t.Fatalf("expected one copy of retried chunk, got %q", contents)
+	}
+}

--- a/services/backend/handlers/scans/bulk.go
+++ b/services/backend/handlers/scans/bulk.go
@@ -58,12 +58,21 @@ func BulkDeleteScans(db *bun.DB) gin.HandlerFunc {
 				return
 			}
 		}
+		archiveSessions, err := loadArchiveUploadSessionsForScans(c.Request.Context(), db, ids)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to resolve uploaded archive cleanup"})
+			return
+		}
 
 		if err := db.RunInTx(c.Request.Context(), nil, func(ctx context.Context, tx bun.Tx) error {
 			return deleteScanRecords(ctx, tx, ids)
 		}); err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to delete scans"})
 			return
+		}
+		_ = cleanupArchiveUploadSessions(archiveSessions)
+		for index := range scans {
+			_ = cleanupQueuedUploadedArchiveScan(&scans[index])
 		}
 		go audit.Write(context.Background(), db, userID.String(), "scan.bulk_delete",
 			fmt.Sprintf("Bulk deleted %d scans", len(ids)))

--- a/services/backend/handlers/scans/cancel.go
+++ b/services/backend/handlers/scans/cancel.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
+	log "github.com/sirupsen/logrus"
 	"github.com/uptrace/bun"
 )
 
@@ -33,6 +34,16 @@ func CancelScan(db *bun.DB) gin.HandlerFunc {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "scan is not pending or running"})
 			return
 		}
+		wasPending := scan.Status == models.ScanStatusPending
+		queuedScan := *scan
+		var archiveSessions []models.ArchiveUploadSession
+		if scan.ScanSource == models.ScanSourceUploadedArchive {
+			archiveSessions, err = loadArchiveUploadSessionsForScans(c.Request.Context(), db, []uuid.UUID{scanID})
+			if err != nil {
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to resolve uploaded archive cleanup"})
+				return
+			}
+		}
 
 		// Signal the worker to stop if it is currently running
 		scanner.CancelScan(scanID)
@@ -44,23 +55,46 @@ func CancelScan(db *bun.DB) gin.HandlerFunc {
 		scan.CurrentStep = models.ScanStepCancelled
 		scan.ErrorMessage = "Cancelled by user"
 		scan.CompletedAt = &now
-		columns := []string{"status", "error_message", "completed_at"}
+		scan.LastProgressAt = &now
+		columns := []string{"status", "current_step", "error_message", "completed_at", "last_progress_at"}
 		if scan.ScanProvider == models.ScanProviderArtifactoryXray {
 			scan.ExternalStatus = models.ScanStatusCancelled
 			columns = append(columns, "external_status")
 		}
-		if _, err := db.NewUpdate().Model(scan).
+		result, err := db.NewUpdate().Model(scan).
 			Column(columns...).
-			Where("id = ?", scanID).
-			Exec(ctx); err != nil {
+			Where("id = ? AND status IN (?)", scanID, bun.In([]string{models.ScanStatusPending, models.ScanStatusRunning})).
+			Exec(ctx)
+		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to cancel scan"})
 			return
+		}
+		rows, rowsErr := result.RowsAffected()
+		if rowsErr != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to cancel scan"})
+			return
+		}
+		if rows == 0 {
+			c.JSON(http.StatusConflict, gin.H{"error": "scan reached a terminal state before cancellation"})
+			return
+		}
+		if wasPending && len(archiveSessions) > 0 {
+			if err := deleteArchiveUploadSessionsForScans(ctx, db, []uuid.UUID{scanID}); err != nil {
+				log.WithError(err).Warnf("failed to remove archive upload session for cancelled scan %s", scanID)
+			}
+		}
+		// A pending scan has no worker that can perform archive cleanup. A
+		// running scan is allowed to finish its worker defer after cancellation.
+		// Keep the original queued state for the one-shot cleanup guard because
+		// the in-memory scan has now transitioned to cancelled.
+		if wasPending {
+			_ = cleanupArchiveUploadSessions(archiveSessions)
+			_ = cleanupQueuedUploadedArchiveScan(&queuedScan)
 		}
 		if err := scanner.MarkScanCancelled(ctx, db, scanID, scan.ErrorMessage); err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to record cancelled scan step"})
 			return
 		}
-
 		go audit.Write(ctx, db, userID.String(), "scan.cancel",
 			fmt.Sprintf("Scan cancelled: %s:%s (id=%s)", scan.ImageName, scan.ImageTag, scanID))
 

--- a/services/backend/handlers/scans/create.go
+++ b/services/backend/handlers/scans/create.go
@@ -535,8 +535,10 @@ func createUploadedArchiveScan(db *bun.DB, orgInPath bool) gin.HandlerFunc {
 		}
 
 		if err := scanner.DispatchScan(c.Request.Context(), db, scan, nil, platform); err != nil {
-			_ = os.Remove(archivePath)
 			log.Warnf("CreateUploadedArchiveScan dispatch failed for %s: %v", scan.ID, err)
+			if !scanner.IsScanQueueCapacityError(err) {
+				_ = os.RemoveAll(filepath.Dir(archivePath))
+			}
 			if markErr := scanner.MarkScanFailed(c.Request.Context(), db, scan.ID, err.Error()); markErr != nil {
 				log.Errorf("CreateUploadedArchiveScan failed to persist dispatch error for %s: %v", scan.ID, markErr)
 			}

--- a/services/backend/handlers/scans/create_upload_test.go
+++ b/services/backend/handlers/scans/create_upload_test.go
@@ -2,10 +2,29 @@ package scans
 
 import (
 	"mime/multipart"
+	"path/filepath"
 	"testing"
 
 	"github.com/google/uuid"
 )
+
+func TestIsArchiveUploadPathRejectsTraversalAndAbsolutePath(t *testing.T) {
+	id := uuid.New()
+	directory := archiveUploadDirectory(id)
+	valid := filepath.Join(directory, "image.tar")
+	if !isArchiveUploadPath(id, valid) {
+		t.Fatal("expected direct archive path to be accepted")
+	}
+	for _, path := range []string{
+		filepath.Join(directory, "nested", "image.tar"),
+		filepath.Join(directory, "..", "other", "image.tar"),
+		"/etc/passwd",
+	} {
+		if isArchiveUploadPath(id, path) {
+			t.Fatalf("expected unsafe archive path %q to be rejected", path)
+		}
+	}
+}
 
 func TestValidateUploadedArchiveFile(t *testing.T) {
 	valid := &multipart.FileHeader{Filename: "image.tar", Size: 1024}

--- a/services/backend/handlers/scans/deletion_test.go
+++ b/services/backend/handlers/scans/deletion_test.go
@@ -1,0 +1,41 @@
+package scans
+
+import (
+	"context"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/google/uuid"
+	"github.com/uptrace/bun"
+	"github.com/uptrace/bun/dialect/pgdialect"
+)
+
+func TestScanDeletionExplicitlyRemovesFindingAndSBOMDependents(t *testing.T) {
+	sqldb, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create mock database: %v", err)
+	}
+	defer sqldb.Close()
+	db := bun.NewDB(sqldb, pgdialect.New())
+	defer db.Close()
+
+	for range 4 {
+		mock.ExpectQuery("SELECT to_regclass").
+			WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(true))
+		mock.ExpectExec("DELETE FROM").WillReturnResult(sqlmock.NewResult(0, 1))
+	}
+	mock.ExpectQuery("SELECT to_regclass").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(true))
+	mock.ExpectExec("DELETE FROM").WillReturnResult(sqlmock.NewResult(0, 1))
+
+	scanIDs := []uuid.UUID{uuid.New(), uuid.New()}
+	if err := deleteScanFindingDependents(context.Background(), db, scanIDs); err != nil {
+		t.Fatalf("delete finding dependents: %v", err)
+	}
+	if err := deleteScanSBOMDependents(context.Background(), db, scanIDs); err != nil {
+		t.Fatalf("delete SBOM dependents: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/services/backend/handlers/scans/deletion_test.go
+++ b/services/backend/handlers/scans/deletion_test.go
@@ -2,12 +2,16 @@ package scans
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/google/uuid"
 	"github.com/uptrace/bun"
 	"github.com/uptrace/bun/dialect/pgdialect"
+
+	"justscan-backend/pkg/models"
 )
 
 func TestScanDeletionExplicitlyRemovesFindingAndSBOMDependents(t *testing.T) {
@@ -37,5 +41,100 @@ func TestScanDeletionExplicitlyRemovesFindingAndSBOMDependents(t *testing.T) {
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestCleanupQueuedUploadedArchiveScanRemovesOnlyControlledDirectory(t *testing.T) {
+	scanID := uuid.New()
+	directory := archiveUploadDirectory(scanID)
+	if err := os.MkdirAll(directory, 0o700); err != nil {
+		t.Fatalf("create upload directory: %v", err)
+	}
+	defer os.RemoveAll(directory)
+	archivePath := filepath.Join(directory, "archive.tar")
+	if err := os.WriteFile(archivePath, []byte("archive"), 0o600); err != nil {
+		t.Fatalf("create upload file: %v", err)
+	}
+
+	scan := &models.Scan{
+		ID:            scanID,
+		ScanSource:    models.ScanSourceUploadedArchive,
+		ImageLocation: archivePath,
+		Status:        models.ScanStatusPending,
+		CurrentStep:   models.ScanStepQueued,
+	}
+	if err := cleanupQueuedUploadedArchiveScan(scan); err != nil {
+		t.Fatalf("cleanup controlled archive: %v", err)
+	}
+	if _, err := os.Stat(directory); !os.IsNotExist(err) {
+		t.Fatalf("expected controlled upload directory to be removed, stat err=%v", err)
+	}
+
+	outside := filepath.Join(t.TempDir(), "must-survive.tar")
+	if err := os.WriteFile(outside, []byte("keep"), 0o600); err != nil {
+		t.Fatalf("create outside file: %v", err)
+	}
+	traversal := &models.Scan{
+		ID:            uuid.New(),
+		ScanSource:    models.ScanSourceUploadedArchive,
+		ImageLocation: filepath.Join(archiveUploadDirectory(scanID), "..", "..", filepath.Base(outside)),
+		Status:        models.ScanStatusPending,
+		CurrentStep:   models.ScanStepQueued,
+	}
+	if err := cleanupQueuedUploadedArchiveScan(traversal); err != nil {
+		t.Fatalf("unexpected traversal cleanup error: %v", err)
+	}
+	if _, err := os.Stat(outside); err != nil {
+		t.Fatalf("arbitrary path was removed: %v", err)
+	}
+
+	foreignID := uuid.New()
+	foreignDirectory := archiveUploadDirectory(foreignID)
+	if err := os.MkdirAll(foreignDirectory, 0o700); err != nil {
+		t.Fatalf("create foreign upload directory: %v", err)
+	}
+	defer os.RemoveAll(foreignDirectory)
+	foreignPath := filepath.Join(foreignDirectory, "foreign.tar")
+	if err := os.WriteFile(foreignPath, []byte("keep"), 0o600); err != nil {
+		t.Fatalf("create foreign upload: %v", err)
+	}
+	foreignScan := *scan
+	foreignScan.ImageLocation = foreignPath
+	if err := cleanupQueuedUploadedArchiveScan(&foreignScan); err != nil {
+		t.Fatalf("unexpected foreign cleanup error: %v", err)
+	}
+	if _, err := os.Stat(foreignPath); err != nil {
+		t.Fatalf("one-shot cleanup removed another scan's upload: %v", err)
+	}
+}
+
+func TestCleanupArchiveUploadSessionsRemovesOnlyValidatedSessionDirectories(t *testing.T) {
+	sessionID := uuid.New()
+	directory := archiveUploadDirectory(sessionID)
+	if err := os.MkdirAll(directory, 0o700); err != nil {
+		t.Fatalf("create session directory: %v", err)
+	}
+	defer os.RemoveAll(directory)
+	archivePath := filepath.Join(directory, "archive.tar")
+	if err := os.WriteFile(archivePath, []byte("archive"), 0o600); err != nil {
+		t.Fatalf("create session archive: %v", err)
+	}
+
+	outside := filepath.Join(t.TempDir(), "must-survive.tar")
+	if err := os.WriteFile(outside, []byte("keep"), 0o600); err != nil {
+		t.Fatalf("create outside file: %v", err)
+	}
+	sessions := []models.ArchiveUploadSession{
+		{ID: sessionID, ArchivePath: archivePath},
+		{ID: uuid.New(), ArchivePath: outside},
+	}
+	if err := cleanupArchiveUploadSessions(sessions); err != nil {
+		t.Fatalf("cleanup sessions: %v", err)
+	}
+	if _, err := os.Stat(directory); !os.IsNotExist(err) {
+		t.Fatalf("expected validated session directory to be removed, stat err=%v", err)
+	}
+	if _, err := os.Stat(outside); err != nil {
+		t.Fatalf("arbitrary session path was removed: %v", err)
 	}
 }

--- a/services/backend/handlers/scans/get.go
+++ b/services/backend/handlers/scans/get.go
@@ -122,9 +122,16 @@ func deleteScanRecords(ctx context.Context, db bun.IDB, scanIDs []uuid.UUID) err
 	if err := scanner.LockVulnerabilitiesForUpdate(ctx, db, scanIDs); err != nil {
 		return fmt.Errorf("lock vulnerabilities before scan deletion: %w", err)
 	}
+	if err := deleteScanFindingDependents(ctx, db, scanIDs); err != nil {
+		return err
+	}
+	if err := deleteScanSBOMDependents(ctx, db, scanIDs); err != nil {
+		return err
+	}
 
 	for _, table := range []string{
 		"comments",
+		"scan_intelligence_versions",
 		"vulnerabilities",
 		"sbom_components",
 		"sbom_documents",
@@ -154,6 +161,56 @@ func deleteScanRecords(ctx context.Context, db bun.IDB, scanIDs []uuid.UUID) err
 	_, err := db.NewDelete().Model((*models.Scan)(nil)).Where("id IN (?)", bun.In(scanIDs)).Exec(ctx)
 	if err != nil {
 		return fmt.Errorf("delete scans: %w", err)
+	}
+	return nil
+}
+
+// deleteScanFindingDependents keeps deletion reliable on upgraded databases
+// whose older intelligence constraints may not have ON DELETE CASCADE.
+func deleteScanFindingDependents(ctx context.Context, db bun.IDB, scanIDs []uuid.UUID) error {
+	for _, relation := range []struct {
+		table  string
+		column string
+	}{
+		{table: "vulnerability_posture_events", column: "finding_id"},
+		{table: "vulnerability_postures", column: "finding_id"},
+		{table: "vulnerability_intelligence_evidence", column: "finding_id"},
+		{table: "vulnerability_component_links", column: "vulnerability_id"},
+	} {
+		exists, err := scanDeletionTableExists(ctx, db, relation.table)
+		if err != nil {
+			return fmt.Errorf("check %s: %w", relation.table, err)
+		}
+		if !exists {
+			continue
+		}
+		if _, err := db.NewDelete().
+			TableExpr(relation.table).
+			Where(relation.column+" IN (SELECT id FROM vulnerabilities WHERE scan_id IN (?))", bun.In(scanIDs)).
+			Exec(ctx); err != nil {
+			return fmt.Errorf("delete %s: %w", relation.table, err)
+		}
+	}
+	return nil
+}
+
+// deleteScanSBOMDependents handles installations created before all SBOM graph
+// foreign keys consistently cascaded.
+func deleteScanSBOMDependents(ctx context.Context, db bun.IDB, scanIDs []uuid.UUID) error {
+	exists, err := scanDeletionTableExists(ctx, db, "sbom_dependencies")
+	if err != nil {
+		return fmt.Errorf("check sbom_dependencies: %w", err)
+	}
+	if !exists {
+		return nil
+	}
+	_, err = db.NewDelete().TableExpr("sbom_dependencies").Where(`
+		document_id IN (SELECT id FROM sbom_documents WHERE scan_id IN (?))
+		OR from_component_id IN (SELECT id FROM sbom_components WHERE scan_id IN (?))
+		OR to_component_id IN (SELECT id FROM sbom_components WHERE scan_id IN (?))
+	`, bun.In(scanIDs), bun.In(scanIDs), bun.In(scanIDs)).Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("delete sbom_dependencies: %w", err)
 	}
 	return nil
 }

--- a/services/backend/handlers/scans/get.go
+++ b/services/backend/handlers/scans/get.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
 
 	"justscan-backend/compliance"
 	"justscan-backend/functions/blockedpolicy"
@@ -99,7 +102,13 @@ func DeleteScan(db *bun.DB) gin.HandlerFunc {
 			return
 		}
 
-		if _, _, _, ok := LoadAuthorizedScanForWrite(c, db, scanID); !ok {
+		scan, _, _, ok := LoadAuthorizedScanForWrite(c, db, scanID)
+		if !ok {
+			return
+		}
+		archiveSessions, err := loadArchiveUploadSessionsForScans(c.Request.Context(), db, []uuid.UUID{scanID})
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to resolve uploaded archive cleanup"})
 			return
 		}
 
@@ -109,9 +118,42 @@ func DeleteScan(db *bun.DB) gin.HandlerFunc {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to delete scan"})
 			return
 		}
+		_ = cleanupArchiveUploadSessions(archiveSessions)
+		_ = cleanupQueuedUploadedArchiveScan(scan)
 
 		c.JSON(http.StatusOK, gin.H{"result": "deleted"})
 	}
+}
+
+// cleanupQueuedUploadedArchiveScan only removes the private directory created
+// for this scan. In particular, it never trusts an arbitrary image_location
+// value from the database or request body as a path to delete.
+func cleanupQueuedUploadedArchiveScan(scan *models.Scan) error {
+	if scan == nil || scan.ScanSource != models.ScanSourceUploadedArchive {
+		return nil
+	}
+	if scan.Status != models.ScanStatusPending || scan.CurrentStep != models.ScanStepQueued {
+		return nil
+	}
+	if !isControlledUploadedArchivePath(scan.ImageLocation) {
+		return nil
+	}
+	root := filepath.Join(os.TempDir(), "justscan", "uploads")
+	relative, err := filepath.Rel(root, filepath.Clean(scan.ImageLocation))
+	if err != nil {
+		return nil
+	}
+	parts := strings.Split(relative, string(filepath.Separator))
+	if len(parts) != 2 {
+		return nil
+	}
+	directoryID, err := uuid.Parse(parts[0])
+	if err != nil || directoryID != scan.ID {
+		// This fallback is for one-shot uploads, whose directory is the scan
+		// UUID. Resumable uploads are cleaned through their session row.
+		return nil
+	}
+	return os.RemoveAll(filepath.Dir(filepath.Clean(scan.ImageLocation)))
 }
 
 func deleteScanRecords(ctx context.Context, db bun.IDB, scanIDs []uuid.UUID) error {
@@ -130,6 +172,7 @@ func deleteScanRecords(ctx context.Context, db bun.IDB, scanIDs []uuid.UUID) err
 	}
 
 	for _, table := range []string{
+		"archive_upload_sessions",
 		"comments",
 		"scan_intelligence_versions",
 		"vulnerabilities",

--- a/services/backend/handlers/scans/groups.go
+++ b/services/backend/handlers/scans/groups.go
@@ -68,6 +68,11 @@ func deleteScanGroup(db *bun.DB, requireTag bool) gin.HandlerFunc {
 			}
 			scanIDs = append(scanIDs, scans[index].ID)
 		}
+		archiveSessions, err := loadArchiveUploadSessionsForScans(c.Request.Context(), db, scanIDs)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to resolve uploaded archive cleanup"})
+			return
+		}
 
 		if err := db.RunInTx(c.Request.Context(), nil, func(ctx context.Context, tx bun.Tx) error {
 			return deleteScanRecords(ctx, tx, scanIDs)
@@ -75,6 +80,10 @@ func deleteScanGroup(db *bun.DB, requireTag bool) gin.HandlerFunc {
 			log.WithError(err).Errorf("delete scan group failed for %s", imageName)
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to delete scan group"})
 			return
+		}
+		_ = cleanupArchiveUploadSessions(archiveSessions)
+		for index := range scans {
+			_ = cleanupQueuedUploadedArchiveScan(&scans[index])
 		}
 
 		auditTarget := imageName

--- a/services/backend/handlers/scans/intelligence_filter.go
+++ b/services/backend/handlers/scans/intelligence_filter.go
@@ -1,6 +1,7 @@
 package scans
 
 import (
+	vulnerabilityintelligence "justscan-backend/functions/vulnerabilityintelligence"
 	"justscan-backend/pkg/models"
 
 	"github.com/uptrace/bun"
@@ -10,7 +11,7 @@ import (
 // overview endpoints. scanExpr is always an internal SQL expression supplied
 // by this package, never a user-provided value.
 func scanIntelligenceFilterCondition(scanExpr, filter string) (string, []interface{}, bool) {
-	prefix := "EXISTS (SELECT 1 FROM vulnerabilities AS v JOIN vulnerability_postures AS p ON p.finding_id = v.id JOIN scans AS intelligence_scan ON intelligence_scan.id = v.scan_id WHERE v.scan_id::text = " + scanExpr + "::text AND (p.change_event_id IS NOT NULL OR (intelligence_scan.completed_at IS NOT NULL AND p.observed_at > intelligence_scan.completed_at)) AND "
+	prefix := "EXISTS (SELECT 1 FROM vulnerabilities AS v JOIN vulnerability_postures AS p ON p.finding_id = v.id JOIN scans AS intelligence_scan ON intelligence_scan.id = v.scan_id WHERE v.scan_id::text = " + scanExpr + "::text AND " + vulnerabilityintelligence.PostScanChangeCondition("p", "intelligence_scan") + " AND "
 	switch filter {
 	case "changed":
 		return prefix + "p.state IS NOT NULL AND p.state <> ?)", []interface{}{models.PostureStateUnchanged}, true

--- a/services/backend/handlers/scans/pipeline.go
+++ b/services/backend/handlers/scans/pipeline.go
@@ -152,8 +152,10 @@ func CreatePipelineScan(db *bun.DB) gin.HandlerFunc {
 			if markErr := scanner.MarkScanFailed(c.Request.Context(), db, scan.ID, err.Error()); markErr != nil {
 				log.Errorf("CreatePipelineScan failed to persist dispatch error for %s: %v", scan.ID, markErr)
 			}
-			if queueErr := pipelines.QueueCallbackForScan(c.Request.Context(), db, scan.ID.String()); queueErr != nil && queueErr != sql.ErrNoRows {
-				log.Warnf("CreatePipelineScan failed to queue callback for %s: %v", scan.ID, queueErr)
+			if !scanner.IsScanQueueCapacityError(err) {
+				if queueErr := pipelines.QueueCallbackForScan(c.Request.Context(), db, scan.ID.String()); queueErr != nil && queueErr != sql.ErrNoRows {
+					log.Warnf("CreatePipelineScan failed to queue callback for %s: %v", scan.ID, queueErr)
+				}
 			}
 		}
 

--- a/services/backend/handlers/scans/queue_summary.go
+++ b/services/backend/handlers/scans/queue_summary.go
@@ -2,6 +2,7 @@ package scans
 
 import (
 	"net/http"
+	"time"
 
 	"justscan-backend/functions/authz"
 	"justscan-backend/pkg/models"
@@ -13,13 +14,21 @@ import (
 
 // QueueSummary describes the visible workspace activity and the shared worker capacity.
 type QueueSummary struct {
-	QueuedInJustScan int `json:"queued_in_justscan"`
-	Active           int `json:"active"`
-	WorkerCapacity   int `json:"worker_capacity"`
+	QueuedInJustScan   int        `json:"queued_in_justscan"`
+	Active             int        `json:"active"`
+	WorkerCapacity     int        `json:"worker_capacity"`
+	QueueDepth         int        `json:"queue_depth"`
+	QueueCapacity      int        `json:"queue_capacity"`
+	ActiveWorkers      int        `json:"active_workers"`
+	WorkerUtilization  float64    `json:"worker_utilization"`
+	OldestQueuedAt     *time.Time `json:"oldest_queued_at,omitempty"`
+	OldestQueuedLagSec float64    `json:"oldest_queued_lag_seconds"`
 }
 
-// GetQueueSummary returns workspace-scoped scan activity without exposing
-// queue depth or worker activity from other workspaces.
+// GetQueueSummary returns workspace-scoped scan activity. Instance-wide queue
+// and worker metrics are only included for administrators; regular users see
+// the durable count for their own queued scans and never another workspace's
+// activity.
 func GetQueueSummary(db *bun.DB) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		userID, isAdmin, accessibleOrgIDs, ok := authz.RequireOwnershipContext(c, db)
@@ -34,25 +43,52 @@ func GetQueueSummary(db *bun.DB) gin.HandlerFunc {
 		args = append(args, scopeArgs...)
 
 		var counts struct {
-			QueuedInJustScan int `bun:"queued_in_justscan"`
-			Active           int `bun:"active"`
+			QueuedInJustScan int        `bun:"queued_in_justscan"`
+			Active           int        `bun:"active"`
+			OldestQueuedAt   *time.Time `bun:"oldest_queued_at"`
 		}
 		query := `
 SELECT
     COUNT(*) FILTER (WHERE s.status = ? AND s.current_step = ?) AS queued_in_justscan,
-    COUNT(*) FILTER (WHERE s.status = ?) AS active
+    COUNT(*) FILTER (WHERE s.status = ?) AS active,
+    MIN(s.created_at) FILTER (WHERE s.status = ? AND s.current_step = ?) AS oldest_queued_at
 FROM scans AS s
 WHERE ` + ownershipWhere + ` AND ` + scopeWhere
-		if err := db.NewRaw(query, args...).Scan(c.Request.Context(), &counts); err != nil {
+		queryArgs := append([]interface{}{}, args[:3]...)
+		queryArgs = append(queryArgs, models.ScanStatusPending, models.ScanStepQueued)
+		queryArgs = append(queryArgs, args[3:]...)
+		if err := db.NewRaw(query, queryArgs...).Scan(c.Request.Context(), &counts); err != nil {
 			_ = c.Error(err)
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to load scan queue summary"})
 			return
 		}
 
+		queue := scanner.GetQueueStats()
+		queueDepth := counts.QueuedInJustScan
+		queueCapacity := 0
+		activeWorkers := 0
+		workerUtilization := 0.0
+		if isAdmin {
+			queueDepth = queue.Depth
+			queueCapacity = queue.Capacity
+			activeWorkers = queue.ActiveWorkers
+			workerUtilization = queue.WorkerUtilization
+		}
 		summary := QueueSummary{
-			QueuedInJustScan: counts.QueuedInJustScan,
-			Active:           counts.Active,
-			WorkerCapacity:   scanner.WorkerConcurrency(),
+			QueuedInJustScan:  counts.QueuedInJustScan,
+			Active:            counts.Active,
+			WorkerCapacity:    scanner.WorkerConcurrency(),
+			QueueDepth:        queueDepth,
+			QueueCapacity:     queueCapacity,
+			ActiveWorkers:     activeWorkers,
+			WorkerUtilization: workerUtilization,
+			OldestQueuedAt:    counts.OldestQueuedAt,
+		}
+		if counts.OldestQueuedAt != nil {
+			summary.OldestQueuedLagSec = time.Since(counts.OldestQueuedAt.UTC()).Seconds()
+			if summary.OldestQueuedLagSec < 0 {
+				summary.OldestQueuedLagSec = 0
+			}
 		}
 		c.JSON(http.StatusOK, summary)
 	}

--- a/services/backend/handlers/scans/update.go
+++ b/services/backend/handlers/scans/update.go
@@ -1,7 +1,9 @@
 package scans
 
 import (
+	"errors"
 	"net/http"
+	"strings"
 
 	"justscan-backend/pkg/models"
 
@@ -19,26 +21,59 @@ func UpdateScan(db *bun.DB) gin.HandlerFunc {
 		}
 
 		var body struct {
-			ImageLocation string `json:"image_location"`
+			ImageLocation *string `json:"image_location"`
 		}
 		if err := c.ShouldBindJSON(&body); err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body"})
 			return
 		}
 
-		if _, _, _, ok := LoadAuthorizedScanForWrite(c, db, scanID); !ok {
+		scan, _, _, ok := LoadAuthorizedScanForWrite(c, db, scanID)
+		if !ok {
 			return
 		}
-
-		if _, err := db.NewUpdate().
-			Model((*models.Scan)(nil)).
-			Set("image_location = ?", body.ImageLocation).
-			Where("id = ?", scanID).
-			Exec(c.Request.Context()); err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to update scan"})
+		if err := validateImageLocationUpdate(scan, body.ImageLocation); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 			return
+		}
+		if scan.ScanSource != models.ScanSourceUploadedArchive && *body.ImageLocation != scan.ImageLocation {
+			if _, err := db.NewUpdate().
+				Model((*models.Scan)(nil)).
+				Set("image_location = ?", *body.ImageLocation).
+				Where("id = ?", scanID).
+				Exec(c.Request.Context()); err != nil {
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to update scan"})
+				return
+			}
 		}
 
 		c.JSON(http.StatusOK, gin.H{"ok": true})
 	}
+}
+
+// validateImageLocationUpdate keeps local archive paths under the control of
+// the scan creation flow. The PATCH endpoint historically let a scan owner
+// replace one with an arbitrary absolute or traversal path, which the worker
+// later opened. Registry image_location values are display metadata used by
+// reports, so they retain their existing editing behavior.
+func validateImageLocationUpdate(scan *models.Scan, requested *string) error {
+	if scan == nil {
+		return errors.New("scan not found")
+	}
+	if requested == nil {
+		return errors.New("image_location is required")
+	}
+	if scan.ScanSource != models.ScanSourceRegistry && *requested != scan.ImageLocation {
+		return errors.New("image_location is immutable")
+	}
+	if strings.IndexByte(*requested, 0) >= 0 {
+		return errors.New("image_location contains an invalid character")
+	}
+	if len(*requested) > 4096 {
+		return errors.New("image_location is too long")
+	}
+	if scan.ScanSource == models.ScanSourceUploadedArchive && !isControlledUploadedArchivePath(scan.ImageLocation) {
+		return errors.New("uploaded archive path is invalid")
+	}
+	return nil
 }

--- a/services/backend/handlers/scans/update_test.go
+++ b/services/backend/handlers/scans/update_test.go
@@ -1,0 +1,40 @@
+package scans
+
+import (
+	"path/filepath"
+	"testing"
+
+	"justscan-backend/pkg/models"
+
+	"github.com/google/uuid"
+)
+
+func TestValidateImmutableImageLocationRejectsTraversalAndAbsolutePaths(t *testing.T) {
+	path := filepath.Join(archiveUploadDirectory(uuid.New()), "archive.tar")
+	scan := &models.Scan{ScanSource: models.ScanSourceUploadedArchive, ImageLocation: path}
+	for _, requested := range []string{
+		"../../etc/passwd",
+		"/etc/passwd",
+		"/tmp/justscan/uploads/other-scan/archive.tar",
+		"",
+	} {
+		requested := requested
+		if err := validateImageLocationUpdate(scan, &requested); err == nil {
+			t.Fatalf("expected image_location mutation %q to be rejected", requested)
+		}
+	}
+}
+
+func TestValidateImmutableImageLocationAllowsExactNoOp(t *testing.T) {
+	path := filepath.Join(archiveUploadDirectory(uuid.New()), "archive.tar")
+	if err := validateImageLocationUpdate(&models.Scan{ScanSource: models.ScanSourceUploadedArchive, ImageLocation: path}, &path); err != nil {
+		t.Fatalf("expected exact image_location retry to be accepted: %v", err)
+	}
+}
+
+func TestValidateImageLocationUpdateAllowsRegistryDisplayMetadata(t *testing.T) {
+	requested := "registry.example.com/team/image"
+	if err := validateImageLocationUpdate(&models.Scan{ScanSource: models.ScanSourceRegistry}, &requested); err != nil {
+		t.Fatalf("expected registry location metadata to remain editable: %v", err)
+	}
+}

--- a/services/backend/handlers/scans/vulnerabilities.go
+++ b/services/backend/handlers/scans/vulnerabilities.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"justscan-backend/functions/authz"
 	effectivesuppressions "justscan-backend/functions/suppressions"
 	vulnerabilityintelligence "justscan-backend/functions/vulnerabilityintelligence"
 	"justscan-backend/functions/vulnerabilityview"
@@ -106,6 +107,23 @@ func intelligenceFilterCondition(filter string) (string, []interface{}, bool) {
 	}
 }
 
+// buildFirstSeenVulnerabilityQuery returns only vulnerability history that the
+// requesting principal is allowed to see.  A scan's image name is not an
+// authorization boundary: scans with the same image can belong to different
+// users or organizations.  Keep the visibility predicate on the joined scan
+// rows so a private scan cannot disclose its completed_at timestamp.
+func buildFirstSeenVulnerabilityQuery(db *bun.DB, scanID uuid.UUID, imageName string, userID uuid.UUID, isAdmin bool, accessibleOrgIDs []uuid.UUID) *bun.SelectQuery {
+	q := db.NewSelect().
+		TableExpr("vulnerabilities AS v").
+		ColumnExpr("v.vuln_id, v.pkg_name, MIN(s.completed_at) AS first_seen_at").
+		Join("JOIN scans AS s ON s.id = v.scan_id").
+		Where("s.image_name = ?", imageName).
+		Where("s.status = ?", models.ScanStatusCompleted).
+		Where("s.id != ?", scanID)
+
+	return authz.ApplyOwnershipVisibility(q, "s", "user_id", "owner_user_id", "owner_org_id", "org_scans", "scan_id", userID, isAdmin, accessibleOrgIDs)
+}
+
 func ListVulnerabilities(db *bun.DB) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		if !validateIntelligenceFilter(c) {
@@ -127,7 +145,7 @@ func ListVulnerabilities(db *bun.DB) gin.HandlerFunc {
 		}
 		offset := (page - 1) * limit
 
-		scan, _, _, ok := LoadAuthorizedScan(c, db, scanID)
+		scan, userID, isAdmin, ok := LoadAuthorizedScan(c, db, scanID)
 		if !ok {
 			return
 		}
@@ -209,15 +227,16 @@ func ListVulnerabilities(db *bun.DB) gin.HandlerFunc {
 			FirstSeenAt *time.Time `bun:"first_seen_at"`
 		}
 		var firstSeenRows []firstSeenRow
-		db.NewRaw(`
-			SELECT v.vuln_id, v.pkg_name, MIN(s.completed_at) AS first_seen_at
-			FROM vulnerabilities v
-			JOIN scans s ON s.id = v.scan_id
-			WHERE s.image_name = (SELECT image_name FROM scans WHERE id = ?)
-			  AND s.status = 'completed'
-			  AND s.id != ?
-			GROUP BY v.vuln_id, v.pkg_name
-		`, scanID, scanID).Scan(c.Request.Context(), &firstSeenRows) //nolint:errcheck
+		accessibleOrgIDs, err := authz.ListAccessibleOrgIDs(c.Request.Context(), db, userID, isAdmin)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to resolve vulnerability history visibility"})
+			return
+		}
+		firstSeenQuery := buildFirstSeenVulnerabilityQuery(db, scanID, scan.ImageName, userID, isAdmin, accessibleOrgIDs)
+		if err := firstSeenQuery.GroupExpr("v.vuln_id, v.pkg_name").Scan(c.Request.Context(), &firstSeenRows); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to load vulnerability history"})
+			return
+		}
 
 		firstSeenMap := make(map[string]*time.Time, len(firstSeenRows))
 		for i := range firstSeenRows {

--- a/services/backend/handlers/scans/vulnerabilities.go
+++ b/services/backend/handlers/scans/vulnerabilities.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	effectivesuppressions "justscan-backend/functions/suppressions"
+	vulnerabilityintelligence "justscan-backend/functions/vulnerabilityintelligence"
 	"justscan-backend/functions/vulnerabilityview"
 	"justscan-backend/pkg/models"
 	"justscan-backend/scanner"
@@ -88,17 +89,18 @@ func applyIntelligenceFilter(q *bun.SelectQuery, filter string) *bun.SelectQuery
 }
 
 func intelligenceFilterCondition(filter string) (string, []interface{}, bool) {
+	prefix := "EXISTS (SELECT 1 FROM vulnerability_postures p JOIN scans intelligence_scan ON intelligence_scan.id = p.scan_id WHERE p.finding_id = v.id AND " + vulnerabilityintelligence.PostScanChangeCondition("p", "intelligence_scan") + " AND "
 	switch filter {
 	case "changed":
-		return "EXISTS (SELECT 1 FROM vulnerability_postures p WHERE p.finding_id = v.id AND p.state IS NOT NULL AND p.state <> ?)", []interface{}{models.PostureStateUnchanged}, true
+		return prefix + "p.state IS NOT NULL AND p.state <> ?)", []interface{}{models.PostureStateUnchanged}, true
 	case models.PostureStateNeedsRescan:
-		return "EXISTS (SELECT 1 FROM vulnerability_postures p WHERE p.finding_id = v.id AND p.state = ?)", []interface{}{models.PostureStateNeedsRescan}, true
+		return prefix + "p.state = ?)", []interface{}{models.PostureStateNeedsRescan}, true
 	case models.PostureStateFixAvailable:
-		return "EXISTS (SELECT 1 FROM vulnerability_postures p WHERE p.finding_id = v.id AND p.state = ?)", []interface{}{models.PostureStateFixAvailable}, true
+		return prefix + "p.state = ?)", []interface{}{models.PostureStateFixAvailable}, true
 	case models.PostureStateNotAffected:
-		return "EXISTS (SELECT 1 FROM vulnerability_postures p WHERE p.finding_id = v.id AND p.state = ?)", []interface{}{models.PostureStateNotAffected}, true
+		return prefix + "p.state = ?)", []interface{}{models.PostureStateNotAffected}, true
 	case "disputed_rejected":
-		return "EXISTS (SELECT 1 FROM vulnerability_postures p WHERE p.finding_id = v.id AND p.state IN (?))", []interface{}{bun.In([]string{models.PostureStateDisputed, models.PostureStateRejected})}, true
+		return prefix + "p.state IN (?))", []interface{}{bun.In([]string{models.PostureStateDisputed, models.PostureStateRejected})}, true
 	default:
 		return "", nil, false
 	}
@@ -261,6 +263,8 @@ func GetVulnerabilitySummary(db *bun.DB) gin.HandlerFunc {
 			TableExpr("vulnerabilities AS v").
 			Where("v.scan_id = ?", scanID)
 		baseQuery = applyVulnerabilityFilters(c, baseQuery)
+		postScanChange := vulnerabilityintelligence.PostScanChangeCondition("p", "intelligence_scan")
+		postScanExists := "EXISTS (SELECT 1 FROM vulnerability_postures p JOIN scans intelligence_scan ON intelligence_scan.id = p.scan_id WHERE p.finding_id = v.id AND " + postScanChange + " AND "
 
 		var summary VulnerabilitySummary
 		if err := baseQuery.
@@ -275,9 +279,9 @@ func GetVulnerabilitySummary(db *bun.DB) gin.HandlerFunc {
 					OR COALESCE(jsonb_array_length(v.xray_watch_names), 0) > 0
 					OR COALESCE(jsonb_array_length(v.xray_watch_policy_matches), 0) > 0
 			) AS xray_policy`).
-			ColumnExpr("COUNT(*) FILTER (WHERE EXISTS (SELECT 1 FROM vulnerability_postures p WHERE p.finding_id = v.id AND p.state IS NOT NULL AND p.state <> ?)) AS intelligence_changed", models.PostureStateUnchanged).
-			ColumnExpr("COUNT(*) FILTER (WHERE EXISTS (SELECT 1 FROM vulnerability_postures p WHERE p.finding_id = v.id AND p.state = ?)) AS intelligence_needs_rescan", models.PostureStateNeedsRescan).
-			ColumnExpr("COUNT(*) FILTER (WHERE EXISTS (SELECT 1 FROM vulnerability_postures p WHERE p.finding_id = v.id AND p.state = ?)) AS intelligence_fix_available", models.PostureStateFixAvailable).
+			ColumnExpr("COUNT(*) FILTER (WHERE "+postScanExists+"p.state IS NOT NULL AND p.state <> ?)) AS intelligence_changed", models.PostureStateUnchanged).
+			ColumnExpr("COUNT(*) FILTER (WHERE "+postScanExists+"p.state = ?)) AS intelligence_needs_rescan", models.PostureStateNeedsRescan).
+			ColumnExpr("COUNT(*) FILTER (WHERE "+postScanExists+"p.state = ?)) AS intelligence_fix_available", models.PostureStateFixAvailable).
 			Scan(c.Request.Context(), &summary); err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to summarize vulnerabilities"})
 			return

--- a/services/backend/handlers/scans/vulnerabilities_history_test.go
+++ b/services/backend/handlers/scans/vulnerabilities_history_test.go
@@ -1,0 +1,47 @@
+package scans
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/google/uuid"
+	"github.com/uptrace/bun"
+	"github.com/uptrace/bun/dialect/pgdialect"
+)
+
+func TestBuildFirstSeenVulnerabilityQueryAppliesScanVisibility(t *testing.T) {
+	sqldb, _, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create mock database: %v", err)
+	}
+	defer sqldb.Close()
+
+	db := bun.NewDB(sqldb, pgdialect.New())
+	defer db.Close()
+
+	userID := uuid.New()
+	orgID := uuid.New()
+	query := buildFirstSeenVulnerabilityQuery(db, uuid.New(), "registry.example/app:latest", userID, false, []uuid.UUID{orgID}).
+		GroupExpr("v.vuln_id, v.pkg_name").String()
+
+	for _, expected := range []string{
+		"JOIN scans AS s ON s.id = v.scan_id",
+		"s.image_name = 'registry.example/app:latest'",
+		"s.status = 'completed'",
+		"s.user_id = '",
+		"s.owner_user_id = '",
+		"s.owner_org_id IN",
+		"EXISTS (SELECT 1 FROM org_scans shared WHERE shared.scan_id = s.id AND shared.org_id IN",
+	} {
+		if !strings.Contains(query, expected) {
+			t.Fatalf("visibility query missing %q: %s", expected, query)
+		}
+	}
+
+	adminQuery := buildFirstSeenVulnerabilityQuery(db, uuid.New(), "registry.example/app:latest", userID, true, nil).
+		GroupExpr("v.vuln_id, v.pkg_name").String()
+	if strings.Contains(adminQuery, "owner_user_id") || strings.Contains(adminQuery, "owner_org_id") || strings.Contains(adminQuery, "org_scans") {
+		t.Fatalf("admin query unexpectedly narrowed by ownership visibility: %s", adminQuery)
+	}
+}

--- a/services/backend/mcp/server.go
+++ b/services/backend/mcp/server.go
@@ -15,6 +15,7 @@ import (
 	"justscan-backend/compliance"
 	baseauth "justscan-backend/functions/auth"
 	"justscan-backend/functions/authz"
+	vulnerabilityintelligence "justscan-backend/functions/vulnerabilityintelligence"
 	scanhandlers "justscan-backend/handlers/scans"
 	"justscan-backend/pkg/models"
 
@@ -342,7 +343,7 @@ func applyListFilters(q *bun.SelectQuery, input ListScansInput) (*bun.SelectQuer
 }
 
 func intelligenceFilterCondition(scanExpr, filter string) (string, []interface{}, bool) {
-	prefix := "EXISTS (SELECT 1 FROM vulnerabilities AS v JOIN vulnerability_postures AS p ON p.finding_id = v.id JOIN scans AS intelligence_scan ON intelligence_scan.id = v.scan_id WHERE v.scan_id::text = " + scanExpr + "::text AND (p.change_event_id IS NOT NULL OR (intelligence_scan.completed_at IS NOT NULL AND p.observed_at > intelligence_scan.completed_at)) AND "
+	prefix := "EXISTS (SELECT 1 FROM vulnerabilities AS v JOIN vulnerability_postures AS p ON p.finding_id = v.id JOIN scans AS intelligence_scan ON intelligence_scan.id = v.scan_id WHERE v.scan_id::text = " + scanExpr + "::text AND " + vulnerabilityintelligence.PostScanChangeCondition("p", "intelligence_scan") + " AND "
 	switch filter {
 	case "changed":
 		return prefix + "p.state IS NOT NULL AND p.state <> ?)", []interface{}{models.PostureStateUnchanged}, true

--- a/services/backend/pipelines/pipeline_scans.go
+++ b/services/backend/pipelines/pipeline_scans.go
@@ -24,6 +24,7 @@ import (
 const (
 	callbackPollInterval = 2 * time.Second
 	callbackHTTPTimeout  = 15 * time.Second
+	callbackClaimLease   = 2 * callbackHTTPTimeout
 	maxCallbackAttempts  = 5
 )
 
@@ -213,7 +214,8 @@ func QueueCallbackForScan(ctx context.Context, db bun.IDB, scanID string) error 
 		Set("delivery_status = ?", models.PipelineCallbackStatusPending).
 		Set("next_attempt_at = ?", now).
 		Set("updated_at = ?", now).
-		Where("scan_id = ?", req.ScanID).
+		Where("scan_id = ? AND (delivery_status = ? OR (delivery_status = ? AND last_attempt_at IS NULL))",
+			req.ScanID, models.PipelineCallbackStatusAwaitingTerminal, models.PipelineCallbackStatusPending).
 		Exec(ctx)
 	return err
 }
@@ -339,12 +341,56 @@ func processPendingCallbacks(ctx context.Context, db *bun.DB) error {
 	}
 
 	for i := range requests {
+		if !claimPendingCallback(ctx, db, &requests[i]) {
+			continue
+		}
 		if err := deliverCallback(ctx, db, &requests[i]); err != nil {
 			log.Warnf("pipeline callbacks: request %s failed: %v", requests[i].ID, err)
 		}
 	}
 
 	return nil
+}
+
+// claimPendingCallback atomically leases one callback to this process. The
+// lease is stored in existing delivery timestamps so multiple backend
+// instances do not concurrently POST the same request. An expired lease is
+// eligible for retry after a process crash.
+func claimPendingCallback(ctx context.Context, db *bun.DB, req *models.PipelineScanRequest) bool {
+	if db == nil || req == nil {
+		return false
+	}
+	claimedAt := time.Now().UTC()
+	leaseUntil := claimedAt.Add(callbackClaimLease)
+	result, err := db.NewUpdate().Model((*models.PipelineScanRequest)(nil)).
+		Set("last_attempt_at = ?", claimedAt).
+		Set("next_attempt_at = ?", leaseUntil).
+		Set("updated_at = ?", claimedAt).
+		Where("id = ? AND delivery_status = ? AND (next_attempt_at IS NULL OR next_attempt_at <= ?)",
+			req.ID, models.PipelineCallbackStatusPending, claimedAt).
+		Exec(ctx)
+	if err != nil {
+		log.Warnf("pipeline callbacks: claim %s failed: %v", req.ID, err)
+		return false
+	}
+	rows, err := result.RowsAffected()
+	if err != nil || rows != 1 {
+		return false
+	}
+	req.LastAttemptAt = &claimedAt
+	req.NextAttemptAt = &leaseUntil
+	return true
+}
+
+func releaseCallbackClaim(ctx context.Context, db *bun.DB, req *models.PipelineScanRequest, next time.Time) {
+	if db == nil || req == nil || req.LastAttemptAt == nil {
+		return
+	}
+	_, _ = db.NewUpdate().Model((*models.PipelineScanRequest)(nil)).
+		Set("next_attempt_at = ?", next).
+		Set("updated_at = ?", time.Now().UTC()).
+		Where("id = ? AND delivery_status = ? AND last_attempt_at = ?", req.ID, models.PipelineCallbackStatusPending, *req.LastAttemptAt).
+		Exec(ctx)
 }
 
 func deliverCallback(ctx context.Context, db *bun.DB, req *models.PipelineScanRequest) error {
@@ -357,6 +403,7 @@ func deliverCallback(ctx context.Context, db *bun.DB, req *models.PipelineScanRe
 		return markCallbackFailure(ctx, db, req, err, true)
 	}
 	if !isTerminalScan(scan) {
+		releaseCallbackClaim(ctx, db, req, time.Now().UTC().Add(callbackPollInterval))
 		return nil
 	}
 
@@ -365,6 +412,7 @@ func deliverCallback(ctx context.Context, db *bun.DB, req *models.PipelineScanRe
 		return markCallbackFailure(ctx, db, req, err, true)
 	}
 	if result.Verdict == models.PipelineVerdictPending {
+		releaseCallbackClaim(ctx, db, req, time.Now().UTC().Add(callbackPollInterval))
 		return nil
 	}
 	body, err := json.Marshal(result)
@@ -409,7 +457,7 @@ func deliverCallback(ctx context.Context, db *bun.DB, req *models.PipelineScanRe
 		Set("delivered_at = ?", now).
 		Set("next_attempt_at = NULL").
 		Set("updated_at = ?", now).
-		Where("id = ?", req.ID).
+		Where("id = ? AND delivery_status = ? AND last_attempt_at = ?", req.ID, models.PipelineCallbackStatusPending, callbackClaimTime(req)).
 		Exec(ctx)
 	return err
 }
@@ -434,7 +482,7 @@ func markCallbackFailure(ctx context.Context, db bun.IDB, req *models.PipelineSc
 		Set("last_delivery_error = ?", truncateError(sendErr)).
 		Set("last_attempt_at = ?", now).
 		Set("updated_at = ?", now).
-		Where("id = ?", req.ID)
+		Where("id = ? AND delivery_status = ? AND last_attempt_at = ?", req.ID, models.PipelineCallbackStatusPending, callbackClaimTime(req))
 
 	if nextAttempt == nil {
 		query = query.Set("next_attempt_at = NULL")
@@ -446,6 +494,13 @@ func markCallbackFailure(ctx context.Context, db bun.IDB, req *models.PipelineSc
 		return err
 	}
 	return sendErr
+}
+
+func callbackClaimTime(req *models.PipelineScanRequest) interface{} {
+	if req != nil && req.LastAttemptAt != nil {
+		return *req.LastAttemptAt
+	}
+	return nil
 }
 
 func signPayload(secret string, body []byte) string {

--- a/services/backend/pkg/models/archive_upload_sessions.go
+++ b/services/backend/pkg/models/archive_upload_sessions.go
@@ -18,6 +18,7 @@ type ArchiveUploadSession struct {
 	ID           uuid.UUID  `bun:",pk,type:uuid" json:"id"`
 	OrgID        uuid.UUID  `bun:"org_id,type:uuid,notnull" json:"org_id"`
 	UserID       *uuid.UUID `bun:"user_id,type:uuid" json:"user_id,omitempty"`
+	ScanID       *uuid.UUID `bun:"scan_id,type:uuid" json:"scan_id,omitempty"`
 	Filename     string     `bun:"filename,type:text,notnull" json:"filename"`
 	ImageName    string     `bun:"image_name,type:text,notnull" json:"image_name"`
 	ImageTag     string     `bun:"image_tag,type:text,notnull" json:"image_tag"`

--- a/services/backend/router/health.go
+++ b/services/backend/router/health.go
@@ -1,11 +1,52 @@
 package router
 
 import (
+	"context"
+	"net/http"
+	"time"
+
+	"justscan-backend/scanner"
+
 	"github.com/gin-gonic/gin"
+	"github.com/uptrace/bun"
 )
 
-func Health(router *gin.RouterGroup) {
-	router.GET("/health", func(c *gin.Context) {
-		c.JSON(200, gin.H{"status": "ok"})
+// Health registers compatibility and Kubernetes-style health endpoints. The
+// variadic DB argument preserves the old Health(router) call shape used by
+// embedders and tests.
+func Health(router *gin.RouterGroup, databases ...*bun.DB) {
+	var db *bun.DB
+	if len(databases) > 0 {
+		db = databases[0]
+	}
+	livez := func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"status": "ok"})
+	}
+	router.GET("/health", livez)
+	router.GET("/livez", livez)
+	router.GET("/readyz", func(c *gin.Context) {
+		readyCtx, cancel := context.WithTimeout(c.Request.Context(), 5*time.Second)
+		defer cancel()
+		if db == nil {
+			c.JSON(http.StatusServiceUnavailable, gin.H{"status": "not_ready", "reason": "database is unavailable"})
+			return
+		}
+		if err := db.PingContext(readyCtx); err != nil {
+			c.JSON(http.StatusServiceUnavailable, gin.H{"status": "not_ready", "reason": "database ping failed"})
+			return
+		}
+		// Xray-only deployments intentionally do not require a Trivy binary or
+		// local DB. When local scanning is enabled, require at least one worker
+		// to have a usable runtime before declaring readiness.
+		if scanner.TrivyEnabled() {
+			report := scanner.GetHealthReport(readyCtx)
+			if report.TotalWorkers > 0 && report.HealthyWorkers == 0 && report.ErrorWorkers == report.TotalWorkers {
+				// Keep the unauthenticated probe response deliberately small: the
+				// admin scanner-health endpoint owns cache paths and command errors.
+				c.JSON(http.StatusServiceUnavailable, gin.H{"status": "not_ready", "reason": "local scanner is unavailable"})
+				return
+			}
+		}
+		c.JSON(http.StatusOK, gin.H{"status": "ready"})
 	})
 }

--- a/services/backend/router/health_test.go
+++ b/services/backend/router/health_test.go
@@ -1,0 +1,40 @@
+package router
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"justscan-backend/config"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestHealthRoutesExposeLivenessAndCompatibility(t *testing.T) {
+	previous := config.Config
+	config.Config = &config.RestfulConf{Scanner: config.ScannerConf{EnableTrivy: false}}
+	t.Cleanup(func() { config.Config = previous })
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	Health(router.Group("/api/v1"))
+	for _, path := range []string{"/api/v1/health", "/api/v1/livez"} {
+		recorder := httptest.NewRecorder()
+		request := httptest.NewRequest(http.MethodGet, path, nil)
+		router.ServeHTTP(recorder, request)
+		if recorder.Code != http.StatusOK {
+			t.Fatalf("GET %s status = %d, want 200", path, recorder.Code)
+		}
+	}
+}
+
+func TestReadyzWithoutDatabaseIsNotReady(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	Health(router.Group("/api/v1"))
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/api/v1/readyz", nil))
+	if recorder.Code != http.StatusServiceUnavailable {
+		t.Fatalf("readyz status = %d, want 503", recorder.Code)
+	}
+}

--- a/services/backend/router/main.go
+++ b/services/backend/router/main.go
@@ -39,7 +39,7 @@ func StartRouter(db *bun.DB, port int, config *config.RestfulConf) *http.Server 
 		Auth(v1, db)
 		Token(v1, db)
 		User(v1, db)
-		Health(v1)
+		Health(v1, db)
 		Admin(v1, db)
 		Scans(v1, db)
 		Helm(v1, db)

--- a/services/backend/scanner/capabilities.go
+++ b/services/backend/scanner/capabilities.go
@@ -25,11 +25,18 @@ type CapabilitySnapshot struct {
 }
 
 func TrivyEnabled() bool {
-	return config.Config != nil && config.Config.Scanner.EnableTrivy
+	if config.Config == nil {
+		return false
+	}
+	return effectiveScannerSettings().EnableTrivy
 }
 
 func GrypeEnabled() bool {
-	return config.Config != nil && config.Config.Scanner.EnableTrivy && config.Config.Scanner.EnableGrype
+	if config.Config == nil {
+		return false
+	}
+	settings := effectiveScannerSettings()
+	return settings.EnableTrivy && settings.EnableGrype
 }
 
 func ScannerCapabilities() CapabilitySnapshot {

--- a/services/backend/scanner/cve_history.go
+++ b/services/backend/scanner/cve_history.go
@@ -35,6 +35,7 @@ const (
 	defaultHistoryPageSize      = 2000
 	maxCVEHistoryResponseBytes  = 32 << 20
 	maxCVEHistoryErrorBodyBytes = 2048
+	cveHistoryAdvisoryLockKey   = "justscan:cve-history-sync"
 )
 
 var ErrCVEHistorySyncRunning = errors.New("CVE history sync is already running")
@@ -1235,7 +1236,7 @@ func QueueCVEHistorySync(db *bun.DB) bool {
 	}
 	go func() {
 		defer endCVEHistorySync()
-		if err := performCVEHistorySync(runCtx, db, newCVEHistoryClient(), "manual", startedAt); err != nil {
+		if err := performCVEHistorySyncWithAdvisoryLock(runCtx, db, newCVEHistoryClient(), "manual", startedAt); err != nil {
 			log.Warnf("manual CVE history sync failed: %v", err)
 		}
 	}()
@@ -1299,6 +1300,18 @@ func ReconcileOrphanedCVEHistoryRuns(ctx context.Context, db *bun.DB) (int, erro
 	if CurrentCVEHistorySyncStatus().Running {
 		return 0, nil
 	}
+	lockConn, locked, lockErr := acquireCVEHistoryAdvisoryLock(ctx, db)
+	if lockErr != nil {
+		return 0, fmt.Errorf("acquire CVE history reconciliation lock: %w", lockErr)
+	}
+	if !locked {
+		return 0, ErrCVEHistorySyncRunning
+	}
+	defer releaseCVEHistoryAdvisoryLock(lockConn)
+	return reconcileOrphanedCVEHistoryRuns(ctx, db)
+}
+
+func reconcileOrphanedCVEHistoryRuns(ctx context.Context, db *bun.DB) (int, error) {
 	now := time.Now().UTC()
 	result, err := db.NewUpdate().Model((*models.VulnerabilityIntelligenceSyncRun)(nil)).
 		Set("status = ?", "failed").
@@ -1349,7 +1362,53 @@ func runCVEHistorySync(ctx context.Context, db *bun.DB, client *cveHistoryClient
 		return ErrCVEHistorySyncRunning
 	}
 	defer endCVEHistorySync()
-	return performCVEHistorySync(runCtx, db, client, trigger, startedAt)
+	return performCVEHistorySyncWithAdvisoryLock(runCtx, db, client, trigger, startedAt)
+}
+
+func performCVEHistorySyncWithAdvisoryLock(ctx context.Context, db *bun.DB, client *cveHistoryClient, trigger string, startedAt time.Time) error {
+	lockConn, locked, lockErr := acquireCVEHistoryAdvisoryLock(ctx, db)
+	if lockErr != nil {
+		return fmt.Errorf("acquire CVE history sync lock: %w", lockErr)
+	}
+	if !locked {
+		return ErrCVEHistorySyncRunning
+	}
+	defer releaseCVEHistoryAdvisoryLock(lockConn)
+	return performCVEHistorySync(ctx, db, client, trigger, startedAt)
+}
+
+// PostgreSQL advisory locks provide the cross-instance single-flight guard for
+// the CVE feed. The dedicated connection is important: session advisory locks
+// must be released on the same connection, and a pooled *bun.DB may otherwise
+// release on a different session.
+func acquireCVEHistoryAdvisoryLock(ctx context.Context, db *bun.DB) (bun.Conn, bool, error) {
+	if db == nil {
+		return bun.Conn{}, false, fmt.Errorf("database is required")
+	}
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return bun.Conn{}, false, err
+	}
+	var locked bool
+	if err := conn.NewRaw(`SELECT pg_try_advisory_lock(hashtextextended(?, 0))`, cveHistoryAdvisoryLockKey).Scan(ctx, &locked); err != nil {
+		_ = conn.Close()
+		return bun.Conn{}, false, err
+	}
+	if !locked {
+		_ = conn.Close()
+		return bun.Conn{}, false, nil
+	}
+	return conn, true, nil
+}
+
+func releaseCVEHistoryAdvisoryLock(conn bun.Conn) {
+	if conn.Conn == nil {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, _ = conn.NewRaw(`SELECT pg_advisory_unlock(hashtextextended(?, 0))`, cveHistoryAdvisoryLockKey).Exec(ctx)
+	_ = conn.Close()
 }
 
 func performCVEHistorySync(ctx context.Context, db *bun.DB, client *cveHistoryClient, trigger string, startedAt time.Time) error {

--- a/services/backend/scanner/cve_history_test.go
+++ b/services/backend/scanner/cve_history_test.go
@@ -362,8 +362,12 @@ func TestReconcileOrphanedCVEHistoryRuns(t *testing.T) {
 	endCVEHistorySync()
 	db, mock, cleanup := newMockBunDB(t)
 	defer cleanup()
+	mock.ExpectQuery(`SELECT pg_try_advisory_lock`).WillReturnRows(
+		sqlmock.NewRows([]string{"pg_try_advisory_lock"}).AddRow(true),
+	)
 	mock.ExpectExec(regexp.QuoteMeta(`UPDATE "vulnerability_intelligence_sync_runs"`)).
 		WillReturnResult(sqlmock.NewResult(0, 2))
+	mock.ExpectExec(`SELECT pg_advisory_unlock`).WillReturnResult(sqlmock.NewResult(0, 1))
 
 	recovered, err := ReconcileOrphanedCVEHistoryRuns(context.Background(), db)
 	if err != nil {

--- a/services/backend/scanner/dispatch.go
+++ b/services/backend/scanner/dispatch.go
@@ -3,19 +3,36 @@ package scanner
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"justscan-backend/pipelines"
 	"justscan-backend/pkg/models"
 
 	"github.com/google/uuid"
+	log "github.com/sirupsen/logrus"
 	"github.com/uptrace/bun"
 )
 
+// IsScanQueueCapacityError identifies a transient in-process queue failure.
+// Durable pending rows must remain pending so the recovery dispatcher can
+// retry them once workers become available.
+func IsScanQueueCapacityError(err error) bool {
+	return errors.Is(err, ErrScanQueueFull) || errors.Is(err, ErrScanQueueUnavailable)
+}
+
+// IsScanQueueCapacityMessage preserves the same queue-defer semantic for
+// legacy callers that only pass err.Error() to MarkScanFailed.
+func IsScanQueueCapacityMessage(message string) bool {
+	message = strings.TrimSpace(message)
+	return strings.Contains(message, ErrScanQueueFull.Error()) || strings.Contains(message, ErrScanQueueUnavailable.Error())
+}
+
 // DispatchScan routes a scan to the appropriate provider. Both built-in and
 // external providers execute asynchronously via the existing worker queue.
-func DispatchScan(_ context.Context, db *bun.DB, scan *models.Scan, envVars []string, platform string) error {
+func DispatchScan(ctx context.Context, db *bun.DB, scan *models.Scan, envVars []string, platform string) error {
 	provider := scan.ScanProvider
 	if provider == "" {
 		resolvedProvider, err := DefaultScanProvider()
@@ -29,6 +46,7 @@ func DispatchScan(_ context.Context, db *bun.DB, scan *models.Scan, envVars []st
 		return err
 	}
 
+	var err error
 	switch provider {
 	case models.ScanProviderTrivy:
 		scan.CurrentStep = models.ScanStepQueued
@@ -36,29 +54,48 @@ func DispatchScan(_ context.Context, db *bun.DB, scan *models.Scan, envVars []st
 		if scan.ScanSource == models.ScanSourceUploadedArchive {
 			archivePath = scan.ImageLocation
 		}
-		return EnqueueScan(scan.ID, db, envVars, platform, archivePath)
+		err = EnqueueScanContext(ctx, scan.ID, db, envVars, platform, archivePath)
 	case models.ScanProviderArtifactoryXray:
 		scan.CurrentStep = models.ScanStepQueued
-		return EnqueueScan(scan.ID, db, envVars, platform, "")
+		err = EnqueueScanContext(ctx, scan.ID, db, envVars, platform, "")
 	default:
 		return fmt.Errorf("unsupported scan provider %q", provider)
 	}
+	if IsScanQueueCapacityError(err) {
+		log.Warnf("Scan %s dispatch deferred while the scanner queue is saturated: %v", scan.ID, err)
+		return nil
+	}
+	return err
 }
 
 // MarkScanFailed stores a failure when dispatch exits before a worker picks the scan up.
 func MarkScanFailed(ctx context.Context, db *bun.DB, scanID uuid.UUID, message string) error {
+	if IsScanQueueCapacityMessage(message) {
+		// Queue saturation is recoverable and must never convert durable pending
+		// work into a terminal failure.
+		return nil
+	}
 	completedAt := time.Now()
-	_, err := db.NewUpdate().Model((*models.Scan)(nil)).
+	result, err := db.NewUpdate().Model((*models.Scan)(nil)).
 		Set("status = ?", models.ScanStatusFailed).
+		Set("current_step = ?", models.ScanStepFailed).
 		Set("error_message = ?", message).
 		Set("completed_at = ?", completedAt).
 		Set("last_progress_at = ?", completedAt).
-		Where("id = ?", scanID).
+		Where("id = ? AND status IN (?)", scanID, bun.In([]string{models.ScanStatusPending, models.ScanStatusRunning})).
 		Exec(ctx)
 	if err != nil {
 		return err
 	}
-	if err := setScanStepByID(ctx, db, scanID, models.ScanStepFailed); err != nil {
+	rows, rowsErr := result.RowsAffected()
+	if rowsErr != nil {
+		return rowsErr
+	}
+	if rows == 0 {
+		// Cancellation or another terminal writer won the race.
+		return nil
+	}
+	if err := appendTerminalScanStepLog(ctx, db, scanID, models.ScanStepFailed); err != nil {
 		return err
 	}
 	recordScanStepOutput(ctx, db, scanID, message)
@@ -69,7 +106,7 @@ func MarkScanFailed(ctx context.Context, db *bun.DB, scanID uuid.UUID, message s
 }
 
 func MarkScanCancelled(ctx context.Context, db *bun.DB, scanID uuid.UUID, message string) error {
-	if err := setScanStepByID(ctx, db, scanID, models.ScanStepCancelled); err != nil {
+	if err := appendTerminalScanStepLog(ctx, db, scanID, models.ScanStepCancelled); err != nil {
 		return err
 	}
 	recordScanStepOutput(ctx, db, scanID, message)

--- a/services/backend/scanner/dispatch_test.go
+++ b/services/backend/scanner/dispatch_test.go
@@ -24,7 +24,7 @@ func TestDispatchXrayKeepsScanInJustScanQueueUntilWorkerHandoff(t *testing.T) {
 
 	mock.ExpectQuery(`SELECT .* FROM "scan_step_logs" AS "scan_step_log"`).
 		WillReturnError(sql.ErrNoRows)
-	mock.ExpectExec(regexp.QuoteMeta(`UPDATE "scans" AS "scan" SET current_step = 'queued', last_progress_at = `) + `.*WHERE \(id = '11111111-1111-1111-1111-111111111111'\)`).
+	mock.ExpectExec(regexp.QuoteMeta(`UPDATE "scans" AS "scan" SET current_step = 'queued', last_progress_at = `) + `.*WHERE \(id = '11111111-1111-1111-1111-111111111111' AND status IN \('pending', 'running'\)\)`).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectQuery(`INSERT INTO "scan_step_logs" .*`).WillReturnRows(
 		sqlmock.NewRows([]string{"id", "position", "completed_at"}).AddRow(uuid.New(), 0, nil),
@@ -55,5 +55,35 @@ func TestWorkerConcurrencyDefaultsToTwo(t *testing.T) {
 
 	if got := WorkerConcurrency(); got != 2 {
 		t.Fatalf("WorkerConcurrency() = %d, want 2", got)
+	}
+}
+
+func TestEnqueueScanIsIdempotentForAlreadyOwnedQueueEntry(t *testing.T) {
+	db, mock, cleanup := newMockBunDB(t)
+	defer cleanup()
+
+	scanID := uuid.MustParse("33333333-3333-3333-3333-333333333333")
+	previousQueue := jobQueue
+	jobQueue = make(chan ScanJob, 1)
+	queuedScanIDs.Store(scanID, struct{}{})
+	t.Cleanup(func() {
+		jobQueue = previousQueue
+		queuedScanIDs.Delete(scanID)
+	})
+
+	if err := EnqueueScanContext(context.Background(), scanID, db, nil, "", ""); err != nil {
+		t.Fatalf("duplicate enqueue returned error: %v", err)
+	}
+	if len(jobQueue) != 0 {
+		t.Fatalf("duplicate enqueue added a second job")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unexpected database activity: %v", err)
+	}
+}
+
+func TestMarkScanFailedDefersQueueCapacityWithoutDatabaseWrite(t *testing.T) {
+	if err := MarkScanFailed(context.Background(), nil, uuid.New(), ErrScanQueueFull.Error()); err != nil {
+		t.Fatalf("MarkScanFailed queue result = %v, want nil", err)
 	}
 }

--- a/services/backend/scanner/health.go
+++ b/services/backend/scanner/health.go
@@ -3,8 +3,6 @@ package scanner
 import (
 	"context"
 	"time"
-
-	"justscan-backend/config"
 )
 
 type WorkerHealth struct {
@@ -39,13 +37,14 @@ type HealthReport struct {
 
 func GetHealthReport(ctx context.Context) HealthReport {
 	concurrency := WorkerConcurrency()
+	settings := effectiveScannerSettings()
 
 	report := HealthReport{
 		LocalScannerEnabled: TrivyEnabled(),
 		GrypeEnabled:        GrypeEnabled(),
 		GeneratedAt:         time.Now().UTC(),
 		CacheRoot:           trivyCacheRoot(),
-		MaxAllowedAgeHours:  config.Config.Scanner.DBMaxAgeHours,
+		MaxAllowedAgeHours:  settings.DBMaxAgeHours,
 		TotalWorkers:        concurrency,
 		Workers:             make([]WorkerHealth, 0, concurrency),
 	}

--- a/services/backend/scanner/intelligence.go
+++ b/services/backend/scanner/intelligence.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	vulnerabilityintelligence "justscan-backend/functions/vulnerabilityintelligence"
 	"justscan-backend/pkg/models"
 
 	"github.com/google/uuid"
@@ -421,6 +422,10 @@ func refreshPosturesWithChanges(ctx context.Context, db bun.IDB, keys []intellig
 		}
 		findings = lockedFindings
 	}
+	baselineByScanID, err := loadScanIntelligenceBaselines(ctx, db, findings)
+	if err != nil {
+		return nil, fmt.Errorf("load scan completion baselines for posture refresh: %w", err)
+	}
 
 	identityByFinding := make(map[uuid.UUID]vulnerabilityFindingIdentity, len(findings))
 	for _, finding := range findings {
@@ -508,7 +513,11 @@ func refreshPosturesWithChanges(ctx context.Context, db bun.IDB, keys []intellig
 		}
 
 		exactKey := intelligenceKeyString(intelligenceFindingKey{VulnID: finding.VulnID, PackageName: finding.PkgName})
-		latest := latestEvidenceForFinding(evidenceByKey[exactKey], wildcardEvidenceByVuln[finding.VulnID])
+		latest := latestPostScanEvidenceForFinding(
+			evidenceByKey[exactKey],
+			wildcardEvidenceByVuln[finding.VulnID],
+			baselineByScanID[finding.ScanID],
+		)
 		if len(latest) == 0 {
 			continue
 		}
@@ -715,6 +724,67 @@ func postureEventForTransition(findingID uuid.UUID, previous *models.Vulnerabili
 type evidenceCandidate struct {
 	record      models.VulnerabilityIntelligenceEvidence
 	specificity int
+}
+
+func loadScanIntelligenceBaselines(ctx context.Context, db bun.IDB, findings []models.Vulnerability) (map[uuid.UUID]*time.Time, error) {
+	baselines := make(map[uuid.UUID]*time.Time)
+	if len(findings) == 0 {
+		return baselines, nil
+	}
+
+	scanIDs := make([]uuid.UUID, 0, len(findings))
+	seen := make(map[uuid.UUID]bool, len(findings))
+	for _, finding := range findings {
+		if finding.ScanID == uuid.Nil || seen[finding.ScanID] {
+			continue
+		}
+		seen[finding.ScanID] = true
+		scanIDs = append(scanIDs, finding.ScanID)
+	}
+	if len(scanIDs) == 0 {
+		return baselines, nil
+	}
+
+	type baselineRow struct {
+		ID          uuid.UUID  `bun:"id"`
+		CompletedAt *time.Time `bun:"completed_at"`
+	}
+	var rows []baselineRow
+	if err := db.NewSelect().
+		TableExpr("scans").
+		Column("id", "completed_at").
+		Where("id IN (?)", bun.In(scanIDs)).
+		Scan(ctx, &rows); err != nil {
+		return nil, err
+	}
+	for _, row := range rows {
+		baselines[row.ID] = row.CompletedAt
+	}
+	return baselines, nil
+}
+
+// latestPostScanEvidenceForFinding excludes intelligence already known when
+// the scan completed. Change-event evidence uses its local creation time
+// because a provider may report an old observed_at value for a newly received
+// change.
+func latestPostScanEvidenceForFinding(exact, wildcard []models.VulnerabilityIntelligenceEvidence, completedAt *time.Time) []models.VulnerabilityIntelligenceEvidence {
+	if completedAt == nil || completedAt.IsZero() {
+		return latestEvidenceForFinding(exact, wildcard)
+	}
+	filter := func(records []models.VulnerabilityIntelligenceEvidence) []models.VulnerabilityIntelligenceEvidence {
+		result := make([]models.VulnerabilityIntelligenceEvidence, 0, len(records))
+		for _, record := range records {
+			detectedAt := record.ObservedAt
+			if record.ChangeEventID != nil && !record.CreatedAt.IsZero() {
+				detectedAt = record.CreatedAt
+			}
+			if detectedAt.After(*completedAt) {
+				result = append(result, record)
+			}
+		}
+		return result
+	}
+	return latestEvidenceForFinding(filter(exact), filter(wildcard))
 }
 
 // latestEvidenceForFinding selects one current record per source. Feed
@@ -1115,7 +1185,13 @@ func AttachVulnerabilityIntelligence(ctx context.Context, db *bun.DB, vulnerabil
 	}
 
 	var postures []models.VulnerabilityPosture
-	if err := db.NewSelect().Model(&postures).Where("finding_id IN (?)", bun.In(findingIDs)).Scan(ctx); err != nil {
+	if err := db.NewSelect().
+		TableExpr("vulnerability_postures AS p").
+		ColumnExpr("p.*").
+		Join("JOIN scans AS intelligence_scan ON intelligence_scan.id = p.scan_id").
+		Where("p.finding_id IN (?)", bun.In(findingIDs)).
+		Where(vulnerabilityintelligence.PostScanChangeCondition("p", "intelligence_scan")).
+		Scan(ctx, &postures); err != nil {
 		return fmt.Errorf("load current vulnerability postures: %w", err)
 	}
 	postureByFinding := make(map[uuid.UUID]*models.VulnerabilityPosture, len(postures))

--- a/services/backend/scanner/intelligence_test.go
+++ b/services/backend/scanner/intelligence_test.go
@@ -309,6 +309,40 @@ func TestLatestEvidenceForFindingPrefersFeedAndPackageSpecificRecords(t *testing
 	}
 }
 
+func TestLatestPostScanEvidenceTreatsNewScanAsConfirmation(t *testing.T) {
+	completedAt := time.Date(2026, 8, 20, 12, 0, 0, 0, time.UTC)
+	oldEventID := uuid.New()
+	oldFeed := models.VulnerabilityIntelligenceEvidence{
+		Source:        "nvd",
+		EvidenceKind:  "feed",
+		ChangeEventID: &oldEventID,
+		ObservedAt:    completedAt.Add(-2 * time.Hour),
+		CreatedAt:     completedAt.Add(-time.Hour),
+	}
+	confirmationSnapshot := models.VulnerabilityIntelligenceEvidence{
+		Source:       "trivy",
+		EvidenceKind: "scan",
+		ObservedAt:   completedAt,
+		CreatedAt:    completedAt.Add(time.Second),
+	}
+
+	latest := latestPostScanEvidenceForFinding(
+		[]models.VulnerabilityIntelligenceEvidence{confirmationSnapshot},
+		[]models.VulnerabilityIntelligenceEvidence{oldFeed},
+		&completedAt,
+	)
+	if len(latest) != 0 {
+		t.Fatalf("confirmation scan retained old intelligence: %#v", latest)
+	}
+
+	newFeed := oldFeed
+	newFeed.CreatedAt = completedAt.Add(time.Minute)
+	latest = latestPostScanEvidenceForFinding(nil, []models.VulnerabilityIntelligenceEvidence{newFeed}, &completedAt)
+	if len(latest) != 1 || latest[0].Source != "nvd" {
+		t.Fatalf("newly ingested post-scan evidence was not retained: %#v", latest)
+	}
+}
+
 func TestDerivePostureCarriesFeedEvidenceFields(t *testing.T) {
 	finding := models.Vulnerability{
 		ID:               uuid.New(),

--- a/services/backend/scanner/osv.go
+++ b/services/backend/scanner/osv.go
@@ -87,7 +87,7 @@ type osvPackageKey struct {
 }
 
 func AugmentJavaVulnerabilitiesFromOSV(ctx context.Context, db *bun.DB, scanID uuid.UUID, components []models.SBOMComponent, existing []models.Vulnerability) []models.Vulnerability {
-	if !config.Config.Scanner.EnableOSVJavaAugmentation {
+	if !effectiveScannerSettings().EnableOSVJavaAugmentation {
 		return nil
 	}
 

--- a/services/backend/scanner/progress.go
+++ b/services/backend/scanner/progress.go
@@ -7,7 +7,6 @@ import (
 	"sync"
 	"time"
 
-	"justscan-backend/config"
 	"justscan-backend/pkg/models"
 
 	"github.com/google/uuid"
@@ -26,33 +25,15 @@ const (
 )
 
 func scanCommandTimeout() time.Duration {
-	if config.Config != nil {
-		if seconds := config.Config.Scanner.CommandTimeoutSeconds; seconds > 0 {
-			return time.Duration(seconds) * time.Second
-		}
-		if seconds := config.Config.Scanner.Timeout; seconds > 0 {
-			return time.Duration(seconds) * time.Second
-		}
-	}
-	return defaultScanCommandTimeout
+	return time.Duration(effectiveScannerSettings().CommandTimeoutSeconds) * time.Second
 }
 
 func scanProgressHeartbeatInterval() time.Duration {
-	if config.Config != nil {
-		if seconds := config.Config.Scanner.ProgressHeartbeatSeconds; seconds > 0 {
-			return time.Duration(seconds) * time.Second
-		}
-	}
-	return defaultScanProgressHeartbeat
+	return time.Duration(effectiveScannerSettings().ProgressHeartbeatSeconds) * time.Second
 }
 
 func scanStaleTimeout() time.Duration {
-	if config.Config != nil {
-		if seconds := config.Config.Scanner.StaleTimeoutSeconds; seconds > 0 {
-			return time.Duration(seconds) * time.Second
-		}
-	}
-	return defaultScanStaleTimeout
+	return time.Duration(effectiveScannerSettings().StaleTimeoutSeconds) * time.Second
 }
 
 func xraySummaryWaitWindow() time.Duration {
@@ -101,7 +82,7 @@ func touchScanProgress(ctx context.Context, db *bun.DB, scanID uuid.UUID, progre
 	}
 	if _, err := db.NewUpdate().Model((*models.Scan)(nil)).
 		Set("last_progress_at = ?", progressedAt).
-		Where("id = ?", scanID).
+		Where("id = ? AND status IN (?)", scanID, bun.In([]string{models.ScanStatusPending, models.ScanStatusRunning})).
 		Exec(ctx); err != nil {
 		return fmt.Errorf("failed to update last progress for scan %s: %w", scanID, err)
 	}
@@ -182,13 +163,19 @@ func recoverInterruptedScans(ctx context.Context, db *bun.DB, now time.Time) (in
 	if ctx == nil {
 		ctx = context.Background()
 	}
+	staleTimeout := scanStaleTimeout()
+	if staleTimeout <= 0 {
+		return 0, nil
+	}
+	cutoff := now.Add(-staleTimeout)
 
 	var scans []models.Scan
 	if err := db.NewSelect().Model(&scans).
 		Column("id", "scan_provider", "external_status", "current_step", "status", "last_progress_at").
-		Where("status IN (?)", bun.In([]string{models.ScanStatusPending, models.ScanStatusRunning})).
+		Where("status = ?", models.ScanStatusRunning).
+		Where("last_progress_at IS NULL OR last_progress_at < ?", cutoff).
 		Scan(ctx); err != nil {
-		return 0, fmt.Errorf("failed to query interrupted scans: %w", err)
+		return 0, fmt.Errorf("failed to query interrupted running scans: %w", err)
 	}
 
 	recovered := 0
@@ -209,13 +196,21 @@ func recoverInterruptedScans(ctx context.Context, db *bun.DB, now time.Time) (in
 			columns = append(columns, "external_status")
 		}
 
-		if _, err := db.NewUpdate().Model(scan).
+		result, err := db.NewUpdate().Model(scan).
 			Column(columns...).
-			Where("id = ?", scan.ID).
-			Exec(ctx); err != nil {
+			Where("id = ? AND status = ?", scan.ID, models.ScanStatusRunning).
+			Where("last_progress_at IS NULL OR last_progress_at < ?", cutoff).
+			Exec(ctx)
+		if err != nil {
 			return recovered, fmt.Errorf("failed to mark interrupted scan %s as failed: %w", scan.ID, err)
 		}
-		recovered++
+		rows, rowsErr := result.RowsAffected()
+		if rowsErr != nil {
+			return recovered, fmt.Errorf("failed to count interrupted scan %s update: %w", scan.ID, rowsErr)
+		}
+		if rows == 1 {
+			recovered++
+		}
 	}
 
 	return recovered, nil
@@ -237,7 +232,7 @@ func failStaleScans(ctx context.Context, db *bun.DB, now time.Time, staleTimeout
 	var scans []models.Scan
 	if err := db.NewSelect().Model(&scans).
 		Where("status IN (?)", bun.In([]string{models.ScanStatusPending, models.ScanStatusRunning})).
-		Where("last_progress_at < ?", cutoff).
+		Where("last_progress_at IS NULL OR last_progress_at < ?", cutoff).
 		Scan(ctx); err != nil {
 		return fmt.Errorf("failed to query stale scans: %w", err)
 	}
@@ -247,7 +242,10 @@ func failStaleScans(ctx context.Context, db *bun.DB, now time.Time, staleTimeout
 		if scan.Status == models.ScanStatusRunning {
 			CancelScan(scan.ID)
 		}
-		setFailed(db, scan, staleScanFailureMessage(scan, staleTimeout, now))
+		message := staleScanFailureMessage(scan, staleTimeout, now)
+		if persistFailedScan(ctx, db, scan, message, &cutoff) {
+			finishFailedScan(ctx, db, scan, message)
+		}
 	}
 	return nil
 }

--- a/services/backend/scanner/progress_test.go
+++ b/services/backend/scanner/progress_test.go
@@ -2,7 +2,6 @@ package scanner
 
 import (
 	"context"
-	"regexp"
 	"testing"
 	"time"
 
@@ -65,30 +64,27 @@ func TestStaleScanFailureMessageIncludesElapsedProgressGap(t *testing.T) {
 	}
 }
 
-func TestRecoverInterruptedScansMarksPendingAndRunningScansFailed(t *testing.T) {
+func TestRecoverInterruptedScansLeavesPendingScansDurable(t *testing.T) {
 	db, mock, cleanup := newMockBunDB(t)
 	defer cleanup()
 
 	now := time.Date(2026, time.May, 4, 10, 30, 0, 0, time.UTC)
-	pendingID := uuid.MustParse("11111111-1111-1111-1111-111111111111")
 	runningID := uuid.MustParse("22222222-2222-2222-2222-222222222222")
-	lastProgress := now.Add(-15 * time.Second)
+	lastProgress := now.Add(-3 * time.Hour)
 
-	mock.ExpectQuery(`SELECT .* FROM "scans" AS "scan" WHERE \(status IN \('pending', 'running'\)\)`).WillReturnRows(
+	mock.ExpectQuery(`SELECT .* FROM "scans" AS "scan" WHERE \(status = 'running'\).*last_progress_at IS NULL OR last_progress_at <`).WillReturnRows(
 		sqlmock.NewRows([]string{"id", "scan_provider", "external_status", "current_step", "status", "last_progress_at"}).
-			AddRow(pendingID.String(), models.ScanProviderTrivy, "", models.ScanStepQueued, models.ScanStatusPending, lastProgress).
 			AddRow(runningID.String(), models.ScanProviderArtifactoryXray, "waiting_for_xray", models.ScanStepWaitingForXray, models.ScanStatusRunning, lastProgress),
 	)
 
-	mock.ExpectExec(regexp.QuoteMeta(`UPDATE "scans" AS "scan" SET "status" = 'failed', "current_step" = 'failed', "error_message" = 'scan interrupted because the backend restarted while in queued', "completed_at" = `) + `.*WHERE \(id = '11111111-1111-1111-1111-111111111111'\)`).WillReturnResult(sqlmock.NewResult(0, 1))
-	mock.ExpectExec(`UPDATE "scans" AS "scan" SET .*"status" = 'failed'.*"current_step" = 'failed'.*"error_message" = 'scan interrupted because the backend restarted while in waiting for xray'.*"completed_at" = .*"last_progress_at" = .*"external_status" = 'failed'.*WHERE \(id = '22222222-2222-2222-2222-222222222222'\)`).WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec(`UPDATE "scans" AS "scan" SET .*"status" = 'failed'.*"current_step" = 'failed'.*"error_message" = 'scan interrupted because the backend restarted while in waiting for xray'.*"completed_at" = .*"last_progress_at" = .*"external_status" = 'failed'.*WHERE \(id = '22222222-2222-2222-2222-222222222222' AND status = 'running'\).*last_progress_at IS NULL OR last_progress_at <`).WillReturnResult(sqlmock.NewResult(0, 1))
 
 	recovered, err := recoverInterruptedScans(context.TODO(), db, now)
 	if err != nil {
 		t.Fatalf("recoverInterruptedScans returned error: %v", err)
 	}
-	if recovered != 2 {
-		t.Fatalf("recoverInterruptedScans() recovered %d scans, want 2", recovered)
+	if recovered != 1 {
+		t.Fatalf("recoverInterruptedScans() recovered %d scans, want 1 running scan", recovered)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("unmet SQL expectations: %v", err)

--- a/services/backend/scanner/registry.go
+++ b/services/backend/scanner/registry.go
@@ -16,7 +16,7 @@ import (
 
 // ResolveRegistryForScan returns the registry to use for a scan request and
 // any auth environment variables required for Trivy-backed execution.
-func ResolveRegistryForScan(ctx context.Context, db *bun.DB, imageName string, registryID *uuid.UUID) (*models.Registry, []string, error) {
+func ResolveRegistryForScan(ctx context.Context, db bun.IDB, imageName string, registryID *uuid.UUID) (*models.Registry, []string, error) {
 	if registryID != nil {
 		registry := &models.Registry{}
 		if err := db.NewSelect().Model(registry).Where("id = ?", *registryID).Scan(ctx); err != nil {

--- a/services/backend/scanner/settings.go
+++ b/services/backend/scanner/settings.go
@@ -1,0 +1,100 @@
+package scanner
+
+import "justscan-backend/config"
+
+// ScannerSettings is the effective scanner runtime configuration. Values are
+// read from the persisted admin settings when a resolver is available and
+// otherwise fall back to the process configuration. Command timeout, database
+// age, engine toggles, and OSV enrichment are intentionally resolved at use
+// time so an admin update takes effect without silently requiring a restart.
+type ScannerSettings struct {
+	EnableTrivy               bool
+	EnableGrype               bool
+	Concurrency               int
+	CommandTimeoutSeconds     int
+	ProgressHeartbeatSeconds  int
+	StaleTimeoutSeconds       int
+	DBMaxAgeHours             int
+	EnableOSVJavaAugmentation bool
+}
+
+func effectiveScannerSettings() ScannerSettings {
+	settings := ScannerSettings{
+		EnableTrivy:               true,
+		EnableGrype:               false,
+		Concurrency:               2,
+		CommandTimeoutSeconds:     int(defaultScanCommandTimeout.Seconds()),
+		ProgressHeartbeatSeconds:  int(defaultScanProgressHeartbeat.Seconds()),
+		StaleTimeoutSeconds:       int(defaultScanStaleTimeout.Seconds()),
+		DBMaxAgeHours:             24,
+		EnableOSVJavaAugmentation: true,
+	}
+	if config.Config != nil {
+		cfg := config.Config.Scanner
+		settings.EnableTrivy = cfg.EnableTrivy
+		settings.EnableGrype = cfg.EnableGrype
+		settings.Concurrency = cfg.Concurrency
+		settings.CommandTimeoutSeconds = cfg.CommandTimeoutSeconds
+		if settings.CommandTimeoutSeconds <= 0 {
+			// timeout was the original config key. Keep it as a config-file
+			// fallback while the canonical runtime key is command_timeout_seconds.
+			settings.CommandTimeoutSeconds = cfg.Timeout
+		}
+		settings.ProgressHeartbeatSeconds = cfg.ProgressHeartbeatSeconds
+		settings.StaleTimeoutSeconds = cfg.StaleTimeoutSeconds
+		settings.DBMaxAgeHours = cfg.DBMaxAgeHours
+		settings.EnableOSVJavaAugmentation = cfg.EnableOSVJavaAugmentation
+	}
+	if settings.Concurrency <= 0 {
+		settings.Concurrency = 2
+	}
+	if settings.CommandTimeoutSeconds <= 0 {
+		settings.CommandTimeoutSeconds = int(defaultScanCommandTimeout.Seconds())
+	}
+	if settings.ProgressHeartbeatSeconds <= 0 {
+		settings.ProgressHeartbeatSeconds = int(defaultScanProgressHeartbeat.Seconds())
+	}
+	if settings.StaleTimeoutSeconds <= 0 {
+		settings.StaleTimeoutSeconds = int(defaultScanStaleTimeout.Seconds())
+	}
+	if settings.DBMaxAgeHours <= 0 {
+		settings.DBMaxAgeHours = 24
+	}
+
+	if resolver := config.GetResolver(); resolver != nil {
+		settings.EnableTrivy = resolver.GetBool("scanner.enable_trivy", settings.EnableTrivy)
+		settings.EnableGrype = resolver.GetBool("scanner.enable_grype", settings.EnableGrype)
+		settings.Concurrency = resolver.GetInt("scanner.concurrency", settings.Concurrency)
+		settings.CommandTimeoutSeconds = resolver.GetIntAny(
+			[]string{"scanner.command_timeout_seconds", "scanner.timeout_seconds"},
+			settings.CommandTimeoutSeconds,
+		)
+		settings.ProgressHeartbeatSeconds = resolver.GetInt("scanner.progress_heartbeat_seconds", settings.ProgressHeartbeatSeconds)
+		settings.StaleTimeoutSeconds = resolver.GetInt("scanner.stale_timeout_seconds", settings.StaleTimeoutSeconds)
+		settings.DBMaxAgeHours = resolver.GetInt("scanner.db_max_age_hours", settings.DBMaxAgeHours)
+		settings.EnableOSVJavaAugmentation = resolver.GetBool("scanner.enable_osv_java_augmentation", settings.EnableOSVJavaAugmentation)
+	}
+
+	if settings.Concurrency <= 0 {
+		settings.Concurrency = 2
+	}
+	if settings.CommandTimeoutSeconds <= 0 {
+		settings.CommandTimeoutSeconds = int(defaultScanCommandTimeout.Seconds())
+	}
+	if settings.ProgressHeartbeatSeconds <= 0 {
+		settings.ProgressHeartbeatSeconds = int(defaultScanProgressHeartbeat.Seconds())
+	}
+	if settings.StaleTimeoutSeconds <= 0 {
+		settings.StaleTimeoutSeconds = int(defaultScanStaleTimeout.Seconds())
+	}
+	if settings.DBMaxAgeHours <= 0 {
+		settings.DBMaxAgeHours = 24
+	}
+	return settings
+}
+
+// EffectiveScannerSettings exposes the same resolver-backed view for health
+// and operational reporting without duplicating key/alias handling.
+func EffectiveScannerSettings() ScannerSettings {
+	return effectiveScannerSettings()
+}

--- a/services/backend/scanner/steps.go
+++ b/services/backend/scanner/steps.go
@@ -3,6 +3,7 @@ package scanner
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -13,6 +14,10 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/uptrace/bun"
 )
+
+// ErrScanStateFinalized indicates that a stale worker attempted to advance a
+// scan after cancellation or another terminal writer had already won.
+var ErrScanStateFinalized = errors.New("scan state is already finalized")
 
 func isTerminalScanStep(step string) bool {
 	switch step {
@@ -51,12 +56,13 @@ func setScanStepByID(ctx context.Context, db *bun.DB, scanID uuid.UUID, step str
 	}
 
 	if hasLatest && latest.Step == step {
-		if _, err := db.NewUpdate().Model((*models.Scan)(nil)).
-			Set("current_step = ?", step).
-			Set("last_progress_at = ?", now).
-			Where("id = ?", scanID).
-			Exec(ctx); err != nil {
+		updated, err := updateScanCurrentStep(ctx, db, scanID, step, now)
+		if err != nil {
 			return fmt.Errorf("failed to update current step for scan %s: %w", scanID, err)
+		}
+		if !updated {
+			// A terminal writer won the race; do not append a stale step log.
+			return ErrScanStateFinalized
 		}
 		if latest.CompletedAt == nil || isTerminalScanStep(step) {
 			return nil
@@ -72,12 +78,13 @@ func setScanStepByID(ctx context.Context, db *bun.DB, scanID uuid.UUID, step str
 		}
 	}
 
-	if _, err := db.NewUpdate().Model((*models.Scan)(nil)).
-		Set("current_step = ?", step).
-		Set("last_progress_at = ?", now).
-		Where("id = ?", scanID).
-		Exec(ctx); err != nil {
+	updated, err := updateScanCurrentStep(ctx, db, scanID, step, now)
+	if err != nil {
 		return fmt.Errorf("failed to update current step for scan %s: %w", scanID, err)
+	}
+	if !updated {
+		// A terminal writer won the race; do not append a stale step log.
+		return ErrScanStateFinalized
 	}
 
 	nextPosition := 0
@@ -98,6 +105,91 @@ func setScanStepByID(ctx context.Context, db *bun.DB, scanID uuid.UUID, step str
 		return fmt.Errorf("failed to create step log for scan %s: %w", scanID, err)
 	}
 	return nil
+}
+
+// appendTerminalScanStepLog records the terminal step without issuing a
+// second scan-row update. Terminal callers first transition status,
+// current_step, and last_progress_at together in one conditional UPDATE; a
+// separate setScanStep call would otherwise briefly (or permanently, after a
+// crash) expose a terminal status with an active step.
+func appendTerminalScanStepLog(ctx context.Context, db *bun.DB, scanID uuid.UUID, step string) error {
+	if scanID == uuid.Nil || !isTerminalScanStep(step) {
+		return nil
+	}
+	now := time.Now()
+
+	var latest models.ScanStepLog
+	hasLatest := true
+	if err := db.NewSelect().Model(&latest).
+		Where("scan_id = ?", scanID).
+		OrderExpr("position DESC").
+		Limit(1).
+		Scan(ctx); err != nil {
+		if err != sql.ErrNoRows {
+			return fmt.Errorf("failed to load latest step log for scan %s: %w", scanID, err)
+		}
+		hasLatest = false
+	}
+	if hasLatest && latest.Step == step && latest.CompletedAt != nil {
+		return nil
+	}
+	if hasLatest && latest.CompletedAt == nil {
+		if _, err := db.NewUpdate().Model((*models.ScanStepLog)(nil)).
+			Set("completed_at = ?", now).
+			Where("id = ?", latest.ID).
+			Exec(ctx); err != nil {
+			return fmt.Errorf("failed to complete previous step log for scan %s: %w", scanID, err)
+		}
+	}
+	position := 0
+	if hasLatest {
+		position = latest.Position + 1
+	}
+	entry := &models.ScanStepLog{
+		ScanID:      scanID,
+		Step:        step,
+		Position:    position,
+		StartedAt:   now,
+		CompletedAt: &now,
+		Output:      []string{},
+	}
+	if _, err := db.NewInsert().Model(entry).Exec(ctx); err != nil {
+		return fmt.Errorf("failed to create terminal step log for scan %s: %w", scanID, err)
+	}
+	return nil
+}
+
+func updateScanCurrentStep(ctx context.Context, db *bun.DB, scanID uuid.UUID, step string, now time.Time) (bool, error) {
+	statusClause := "status IN (?)"
+	statusArg := interface{}(bun.In([]string{models.ScanStatusPending, models.ScanStatusRunning}))
+	switch step {
+	case models.ScanStepCompleted:
+		statusClause = "status = ?"
+		statusArg = models.ScanStatusCompleted
+	case models.ScanStepFailed:
+		// Xray policy blocks record a failed provider step while the worker is
+		// still unwinding; the worker then performs the conditional running ->
+		// failed terminal transition. A terminal scan is still required before a
+		// completed failure log is appended.
+		statusClause = "status IN (?)"
+		statusArg = bun.In([]string{models.ScanStatusRunning, models.ScanStatusFailed})
+	case models.ScanStepCancelled:
+		statusClause = "status = ?"
+		statusArg = models.ScanStatusCancelled
+	}
+	result, err := db.NewUpdate().Model((*models.Scan)(nil)).
+		Set("current_step = ?", step).
+		Set("last_progress_at = ?", now).
+		Where("id = ? AND "+statusClause, scanID, statusArg).
+		Exec(ctx)
+	if err != nil {
+		return false, err
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	return rows == 1, nil
 }
 
 func appendScanStepOutput(ctx context.Context, db *bun.DB, scanID uuid.UUID, message string) error {
@@ -125,8 +217,12 @@ func appendScanStepOutput(ctx context.Context, db *bun.DB, scanID uuid.UUID, mes
 		Exec(ctx); err != nil {
 		return fmt.Errorf("failed to append step output for scan %s: %w", scanID, err)
 	}
-	if err := touchScanProgress(ctx, db, scanID, time.Now()); err != nil {
-		return err
+	// Terminal step output is still useful, but it must not make a finalized
+	// scan appear active again by moving last_progress_at forward.
+	if latest.CompletedAt == nil {
+		if err := touchScanProgress(ctx, db, scanID, time.Now()); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/services/backend/scanner/trivy.go
+++ b/services/backend/scanner/trivy.go
@@ -704,7 +704,7 @@ func shouldRefreshDatabases(info *TrivyRuntimeInfo) bool {
 	if info == nil {
 		return true
 	}
-	maxAge := time.Duration(config.Config.Scanner.DBMaxAgeHours) * time.Hour
+	maxAge := time.Duration(effectiveScannerSettings().DBMaxAgeHours) * time.Hour
 	if maxAge <= 0 {
 		maxAge = 24 * time.Hour
 	}

--- a/services/backend/scanner/worker.go
+++ b/services/backend/scanner/worker.go
@@ -3,15 +3,16 @@ package scanner
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"justscan-backend/compliance"
-	"justscan-backend/config"
 	effectivesuppressions "justscan-backend/functions/suppressions"
 	"justscan-backend/notifications"
 	"justscan-backend/pipelines"
@@ -33,16 +34,60 @@ type ScanJob struct {
 
 var jobQueue chan ScanJob
 
+var (
+	activeWorkers  atomic.Int64
+	workerPoolSize atomic.Int64
+	completedJobs  atomic.Uint64
+	queuedScanIDs  sync.Map
+)
+
+var (
+	ErrScanQueueUnavailable = errors.New("scanner queue is not initialized")
+	ErrScanQueueFull        = errors.New("scanner queue is full")
+)
+
+// QueueStats is a lightweight operational view of the in-process worker pool.
+// Queue depth is intentionally paired with the durable workspace-scoped counts
+// in the queue summary handler; it is not used for authorization decisions.
+type QueueStats struct {
+	Depth             int
+	Capacity          int
+	ActiveWorkers     int
+	WorkerUtilization float64
+	CompletedJobs     uint64
+}
+
+func GetQueueStats() QueueStats {
+	capacity := 0
+	depth := 0
+	if jobQueue != nil {
+		capacity = cap(jobQueue)
+		depth = len(jobQueue)
+	}
+	active := int(activeWorkers.Load())
+	utilization := 0.0
+	if capacity > 0 {
+		poolSize := int(workerPoolSize.Load())
+		if poolSize <= 0 {
+			poolSize = WorkerConcurrency()
+		}
+		utilization = float64(active) / float64(poolSize)
+		if utilization > 1 {
+			utilization = 1
+		}
+	}
+	return QueueStats{
+		Depth:             depth,
+		Capacity:          capacity,
+		ActiveWorkers:     active,
+		WorkerUtilization: utilization,
+		CompletedJobs:     completedJobs.Load(),
+	}
+}
+
 // WorkerConcurrency returns the instance-wide number of shared scan workers.
 func WorkerConcurrency() int {
-	if config.Config == nil {
-		return 2
-	}
-	concurrency := config.Config.Scanner.Concurrency
-	if concurrency <= 0 {
-		return 2
-	}
-	return concurrency
+	return effectiveScannerSettings().Concurrency
 }
 
 // cancelMap stores cancel functions for in-progress scans so they can be interrupted.
@@ -69,12 +114,7 @@ func InitWorker(db *bun.DB) {
 	concurrency := WorkerConcurrency()
 
 	jobQueue = make(chan ScanJob, 64)
-
-	if recovered, err := recoverInterruptedScans(context.Background(), db, time.Now()); err != nil {
-		log.Warnf("Scanner startup recovery failed: %v", err)
-	} else if recovered > 0 {
-		log.Warnf("Scanner startup marked %d interrupted scans as failed", recovered)
-	}
+	workerPoolSize.Store(int64(concurrency))
 
 	for i := 0; i < concurrency; i++ {
 		cacheDir := workerCacheDir(i)
@@ -103,6 +143,21 @@ func InitWorker(db *bun.DB) {
 		go workerLoop(i)
 	}
 
+	// Workers are ready before recovery starts so a large durable backlog is
+	// drained continuously instead of filling the bounded channel once and
+	// leaving later rows stranded.
+	if requeued, recovered, err := recoverScansAfterRestart(context.Background(), db, time.Now()); err != nil {
+		log.Warnf("Scanner startup recovery failed: %v", err)
+	} else {
+		if requeued > 0 {
+			log.Infof("Scanner startup requeued %d pending scans", requeued)
+		}
+		if recovered > 0 {
+			log.Warnf("Scanner startup marked %d interrupted scans as failed", recovered)
+		}
+	}
+	startPendingScanRecovery(db)
+
 	log.Infof("Scanner worker pool started with concurrency=%d", concurrency)
 	startScanStaleWatchdog(db)
 	StartCVEHistorySync(db)
@@ -112,7 +167,7 @@ func InitWorker(db *bun.DB) {
 	// warmup failed due to the network not being ready yet).
 	if TrivyEnabled() {
 		go func() {
-			refreshInterval := time.Duration(config.Config.Scanner.DBMaxAgeHours) * time.Hour
+			refreshInterval := time.Duration(effectiveScannerSettings().DBMaxAgeHours) * time.Hour
 			if refreshInterval <= 0 {
 				refreshInterval = 12 * time.Hour
 			}
@@ -142,20 +197,223 @@ func InitWorker(db *bun.DB) {
 
 // EnqueueScan queues a scan job. The scan row must already exist in the DB with status=pending.
 func EnqueueScan(scanID uuid.UUID, db *bun.DB, envVars []string, platform, archivePath string) error {
-	if err := setScanStepByID(context.Background(), db, scanID, models.ScanStepQueued); err != nil {
+	return EnqueueScanContext(context.Background(), scanID, db, envVars, platform, archivePath)
+}
+
+// EnqueueScanContext performs a bounded, non-blocking queue send. Callers can
+// turn ErrScanQueueFull into a deferred response (or an HTTP 503) instead of
+// tying up a request goroutine while the scanner is saturated. The scan row
+// remains pending for the recovery dispatcher.
+func EnqueueScanContext(ctx context.Context, scanID uuid.UUID, db *bun.DB, envVars []string, platform, archivePath string) error {
+	if db == nil || jobQueue == nil {
+		return ErrScanQueueUnavailable
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+	if _, loaded := queuedScanIDs.LoadOrStore(scanID, struct{}{}); loaded {
+		// Queueing is idempotent: a retry of the same dispatch request must not
+		// turn the already-owned scan into a failure in its caller.
+		return nil
+	}
+	reserved := true
+	defer func() {
+		if reserved {
+			queuedScanIDs.Delete(scanID)
+		}
+	}()
+	if err := setScanStepByID(ctx, db, scanID, models.ScanStepQueued); err != nil {
 		return err
 	}
-	recordScanStepOutput(context.Background(), db, scanID, "Scan accepted and queued for execution.")
-	jobQueue <- ScanJob{ScanID: scanID, DB: db, EnvVars: envVars, Platform: platform, ArchivePath: archivePath}
-	return nil
+	recordScanStepOutput(ctx, db, scanID, "Scan accepted and queued for execution.")
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case jobQueue <- ScanJob{ScanID: scanID, DB: db, EnvVars: envVars, Platform: platform, ArchivePath: archivePath}:
+		reserved = false
+		return nil
+	default:
+		return ErrScanQueueFull
+	}
 }
 
 func workerLoop(id int) {
 	log.Infof("Scanner worker %d ready", id)
 	cacheDir := workerCacheDir(id)
 	for job := range jobQueue {
+		queuedScanIDs.Delete(job.ScanID)
+		activeWorkers.Add(1)
 		processScan(job, cacheDir)
+		activeWorkers.Add(-1)
+		completedJobs.Add(1)
 	}
+}
+
+// startPendingScanRecovery retries durable pending rows left behind when the
+// initial bounded queue was full. The in-memory set prevents duplicate queue
+// entries within this process; claimScanForWorker remains the cross-instance
+// guard when two processes recover the same durable row.
+func startPendingScanRecovery(db *bun.DB) {
+	if db == nil {
+		return
+	}
+	go func() {
+		ticker := time.NewTicker(10 * time.Second)
+		defer ticker.Stop()
+		for range ticker.C {
+			recoverPendingScanBatch(db)
+		}
+	}()
+}
+
+func recoverPendingScanBatch(db *bun.DB) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	var scans []models.Scan
+	if err := db.NewSelect().Model(&scans).
+		Where("status = ?", models.ScanStatusPending).
+		OrderExpr("created_at ASC").
+		Limit(64).
+		Scan(ctx); err != nil {
+		log.Warnf("Scanner pending recovery query failed: %v", err)
+		return
+	}
+	for i := range scans {
+		scan := &scans[i]
+		if _, queued := queuedScanIDs.Load(scan.ID); queued {
+			continue
+		}
+		var envVars []string
+		if scan.ScanProvider == models.ScanProviderTrivy || scan.ScanProvider == "" {
+			_, resolvedEnvVars, resolveErr := ResolveRegistryForScan(ctx, db, scan.ImageName, scan.RegistryID)
+			if resolveErr != nil {
+				log.Warnf("Scanner pending recovery could not resolve registry for %s: %v", scan.ID, resolveErr)
+				continue
+			}
+			envVars = resolvedEnvVars
+		}
+		archivePath := ""
+		if scan.ScanSource == models.ScanSourceUploadedArchive {
+			archivePath = scan.ImageLocation
+			if !archiveFileAvailable(archivePath) {
+				log.Warnf("Scanner pending recovery is waiting for local archive for %s: %s", scan.ID, archivePath)
+				continue
+			}
+		}
+		if err := EnqueueScanContext(ctx, scan.ID, db, envVars, scan.Platform, archivePath); err != nil {
+			if !errors.Is(err, ErrScanQueueFull) {
+				log.Warnf("Scanner pending recovery could not enqueue %s: %v", scan.ID, err)
+			}
+			return
+		}
+	}
+}
+
+// recoverScansAfterRestart preserves durable pending work and re-enqueues it,
+// while only scans that were actually running are failed as interrupted. This
+// avoids turning a full queue or a process restart into silent data loss.
+func recoverScansAfterRestart(ctx context.Context, db *bun.DB, now time.Time) (int, int, error) {
+	if db == nil {
+		return 0, 0, nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	// Normalize pending rows left between insert and queue handoff. They remain
+	// pending and are then re-enqueued below; terminal rows are not touched.
+	if _, err := db.NewUpdate().Model((*models.Scan)(nil)).
+		Set("current_step = ?", models.ScanStepQueued).
+		Set("last_progress_at = ?", now).
+		Where("status = ?", models.ScanStatusPending).
+		Exec(ctx); err != nil {
+		return 0, 0, fmt.Errorf("normalize pending scans: %w", err)
+	}
+
+	var pending []models.Scan
+	if err := db.NewSelect().Model(&pending).
+		Where("status = ?", models.ScanStatusPending).
+		OrderExpr("created_at ASC").
+		Scan(ctx); err != nil {
+		return 0, 0, fmt.Errorf("load pending scans for recovery: %w", err)
+	}
+	requeued := 0
+	for i := range pending {
+		scan := &pending[i]
+		var envVars []string
+		if scan.ScanProvider == models.ScanProviderTrivy || scan.ScanProvider == "" {
+			_, resolvedEnvVars, resolveErr := ResolveRegistryForScan(ctx, db, scan.ImageName, scan.RegistryID)
+			if resolveErr != nil {
+				log.Warnf("Scanner startup could not resolve registry for %s: %v", scan.ID, resolveErr)
+				continue
+			}
+			envVars = resolvedEnvVars
+		}
+		archivePath := ""
+		if scan.ScanSource == models.ScanSourceUploadedArchive {
+			archivePath = scan.ImageLocation
+			if !archiveFileAvailable(archivePath) {
+				log.Warnf("Scanner startup is waiting for local archive for %s: %s", scan.ID, archivePath)
+				continue
+			}
+		}
+		if err := EnqueueScanContext(ctx, scan.ID, db, envVars, scan.Platform, archivePath); err != nil {
+			if errors.Is(err, ErrScanQueueFull) {
+				log.Warnf("Scanner startup queue full; leaving pending scan %s for a later recovery pass", scan.ID)
+				break
+			}
+			log.Warnf("Scanner startup could not requeue pending scan %s: %v", scan.ID, err)
+			continue
+		}
+		requeued++
+	}
+
+	// A process restart must not finalize work that another replica is still
+	// executing. Without an owner lease, the only safe recovery signal is a
+	// heartbeat that is older than the configured stale window (or is missing).
+	// Keep the status predicate in the UPDATE as well because a worker or
+	// watchdog may win the race after this SELECT.
+	staleTimeout := scanStaleTimeout()
+	if staleTimeout <= 0 {
+		return requeued, 0, nil
+	}
+	cutoff := now.Add(-staleTimeout)
+	var running []models.Scan
+	if err := db.NewSelect().Model(&running).
+		Where("status = ?", models.ScanStatusRunning).
+		Where("last_progress_at IS NULL OR last_progress_at < ?", cutoff).
+		Scan(ctx); err != nil {
+		return requeued, 0, fmt.Errorf("load stale running scans for recovery: %w", err)
+	}
+	recovered := 0
+	for i := range running {
+		scan := &running[i]
+		message := interruptedScanFailureMessage(scan)
+		result, err := db.NewUpdate().Model((*models.Scan)(nil)).
+			Set("status = ?", models.ScanStatusFailed).
+			Set("current_step = ?", models.ScanStepFailed).
+			Set("error_message = ?", message).
+			Set("completed_at = ?", now).
+			Set("last_progress_at = ?", now).
+			Where("id = ? AND status = ?", scan.ID, models.ScanStatusRunning).
+			Where("last_progress_at IS NULL OR last_progress_at < ?", cutoff).
+			Exec(ctx)
+		if err != nil {
+			return requeued, recovered, fmt.Errorf("mark interrupted scan %s: %w", scan.ID, err)
+		}
+		rows, rowsErr := result.RowsAffected()
+		if rowsErr != nil {
+			return requeued, recovered, rowsErr
+		}
+		if rows == 1 {
+			recovered++
+		}
+	}
+	return requeued, recovered, nil
 }
 
 func processScan(job ScanJob, cacheDir string) {
@@ -169,17 +427,42 @@ func processScan(job ScanJob, cacheDir string) {
 		return
 	}
 
-	// If the scan was cancelled before a worker picked it up, skip processing.
-	if scan.Status == models.ScanStatusCancelled {
-		log.Infof("Worker: scan %s was cancelled before processing, skipping", scanID)
-		return
-	}
+	cleanupArchive := false
+	cleanupArchivePath := ""
 	if scan.ScanSource == models.ScanSourceUploadedArchive {
 		if job.ArchivePath == "" {
 			job.ArchivePath = scan.ImageLocation
 		}
-		defer cleanupScanArchive(scan.ID, job.ArchivePath)
+		// Register cleanup before checking cancellation. A queued upload can be
+		// cancelled before a worker picks it up and must not strand its archive.
+		cleanupArchivePath = job.ArchivePath
+		defer func() {
+			if cleanupArchive {
+				CleanupScanArchive(context.Background(), db, scan.ID, cleanupArchivePath)
+			}
+		}()
 	}
+
+	// Claim atomically. A stale queue entry must never resurrect a cancelled,
+	// failed, or completed scan after another request/watchdog has finalized it.
+	now := time.Now()
+	claimed, err := claimScanForWorker(context.Background(), db, scanID, now)
+	if err != nil {
+		log.Errorf("Worker: failed to claim scan %s: %v", scanID, err)
+		return
+	}
+	if !claimed {
+		log.Infof("Worker: scan %s is no longer pending, skipping", scanID)
+		// A duplicate queue entry can observe a scan already running in another
+		// worker. It must not remove that worker's archive; a terminal/cancelled
+		// row, however, still owns cleanup for this stale queue entry.
+		var currentStatus string
+		if statusErr := db.NewSelect().Model((*models.Scan)(nil)).Column("status").Where("id = ?", scanID).Scan(context.Background(), &currentStatus); statusErr == nil {
+			cleanupArchive = currentStatus != models.ScanStatusRunning
+		}
+		return
+	}
+	cleanupArchive = true
 
 	// Create a cancellable context so this scan can be interrupted via CancelScan().
 	ctx, cancel := context.WithCancel(context.Background())
@@ -192,16 +475,24 @@ func processScan(job ScanJob, cacheDir string) {
 		delete(cancelMap, scanID)
 		cancelMu.Unlock()
 	}()
+	// Cancellation can win immediately after the atomic claim but before the
+	// in-process cancel function is registered. Re-read the state once so that
+	// race cannot start provider work after a committed cancellation.
+	var currentStatus string
+	if err := db.NewSelect().Model((*models.Scan)(nil)).Column("status").Where("id = ?", scanID).Scan(ctx, &currentStatus); err != nil {
+		log.Warnf("Worker: failed to confirm claimed scan %s is still running: %v", scanID, err)
+		return
+	}
+	if currentStatus != models.ScanStatusRunning {
+		log.Infof("Worker: scan %s was finalized during claim, skipping", scanID)
+		return
+	}
 
-	// Mark as running
-	now := time.Now()
+	// The database claim above is the state transition; keep the in-memory copy
+	// in sync for the provider flow and completion logic.
 	scan.Status = models.ScanStatusRunning
 	scan.StartedAt = &now
 	scan.LastProgressAt = &now
-	if _, err := db.NewUpdate().Model(scan).Column("status", "started_at", "last_progress_at").Where("id = ?", scanID).Exec(ctx); err != nil {
-		log.Errorf("Worker: failed to update scan status to running: %v", err)
-		return
-	}
 
 	imageRef := buildImageRef(scan.ImageName, scan.ImageTag)
 	log.Infof("Worker: starting scan %s for %s", scanID, imageRef)
@@ -434,6 +725,7 @@ func processScan(job ScanJob, cacheDir string) {
 	completedAt := time.Now()
 	scan.Status = models.ScanStatusCompleted
 	scan.CompletedAt = &completedAt
+	scan.LastProgressAt = &completedAt
 	scan.CurrentStep = models.ScanStepCompleted
 	if runtimeInfo != nil && runtimeInfo.Version != "" {
 		scan.TrivyVersion = runtimeInfo.Version
@@ -468,14 +760,29 @@ func processScan(job ScanJob, cacheDir string) {
 		recordScanStepOutput(context.Background(), db, scanID, fmt.Sprintf("Suppression count recalculated: %d findings suppressed.", suppressedCount))
 	}
 
-	if _, err := db.NewUpdate().Model(scan).
-		Column("status", "completed_at", "trivy_version", "grype_version", "image_digest",
+	result, err := db.NewUpdate().Model(scan).
+		Column("status", "current_step", "last_progress_at", "completed_at", "trivy_version", "grype_version", "image_digest",
 			"trivy_vuln_db_updated_at", "trivy_vuln_db_downloaded_at",
 			"trivy_java_db_updated_at", "trivy_java_db_downloaded_at",
 			"critical_count", "high_count", "medium_count", "low_count", "unknown_count", "suppressed_count",
 			"architecture", "os_family", "os_name").
-		Where("id = ?", scanID).Exec(context.Background()); err != nil {
+		Where("id = ? AND status = ?", scanID, models.ScanStatusRunning).Exec(context.Background())
+	if err != nil {
 		log.Errorf("Worker: failed to mark scan %s as completed: %v", scanID, err)
+		return
+	}
+	rows, rowsErr := result.RowsAffected()
+	if rowsErr != nil {
+		log.Errorf("Worker: failed to confirm terminal transition for scan %s: %v", scanID, rowsErr)
+		return
+	}
+	if rows == 0 {
+		// Cancellation or the stale watchdog won the terminal-state race.
+		log.Infof("Worker: scan %s was finalized before completion could be persisted", scanID)
+		return
+	}
+	if err := appendTerminalScanStepLog(context.Background(), db, scanID, models.ScanStepCompleted); err != nil {
+		log.Errorf("Worker: failed to record completed step for scan %s: %v", scanID, err)
 		return
 	}
 	if err := RecordIntelligenceSnapshot(context.Background(), db, scan); err != nil {
@@ -483,10 +790,6 @@ func processScan(job ScanJob, cacheDir string) {
 		recordScanStepOutput(context.Background(), db, scanID, fmt.Sprintf("Scan-time intelligence snapshot failed, but the scan result remains available: %v", err))
 	} else {
 		recordScanStepOutput(context.Background(), db, scanID, "Stored scan-time vulnerability intelligence and refreshed current posture.")
-	}
-	if err := setScanStep(context.Background(), db, scan, models.ScanStepCompleted); err != nil {
-		log.Errorf("Worker: failed to record completed step for scan %s: %v", scanID, err)
-		return
 	}
 	recordScanStepOutput(context.Background(), db, scanID, fmt.Sprintf("Scan completed with %d total findings.", len(vulns)+len(osvVulns)))
 	recordScanStepOutput(context.Background(), db, scanID, "Queued compliance evaluation, auto-tagging, and completion notifications.")
@@ -540,22 +843,59 @@ func matchesPattern(pattern, s string) bool {
 func setFailed(db *bun.DB, scan *models.Scan, msg string) {
 	ctx := context.Background()
 	log.Errorf("Worker: scan %s failed: %s", scan.ID, msg)
+	if !persistFailedScan(ctx, db, scan, msg, nil) {
+		return
+	}
+	finishFailedScan(ctx, db, scan, msg)
+}
+
+// persistFailedScan applies a conditional terminal transition. staleBefore,
+// when provided, makes the watchdog re-check last_progress_at in the same SQL
+// statement so a heartbeat committed after its initial SELECT wins the race.
+func persistFailedScan(ctx context.Context, db *bun.DB, scan *models.Scan, msg string, staleBefore *time.Time) bool {
+	if db == nil || scan == nil {
+		return false
+	}
 	scan.Status = models.ScanStatusFailed
 	scan.CurrentStep = models.ScanStepFailed
 	scan.ErrorMessage = msg
 	completedAt := time.Now()
 	scan.CompletedAt = &completedAt
-	columns := []string{"status", "error_message", "completed_at", "critical_count", "high_count", "medium_count", "low_count", "unknown_count", "suppressed_count"}
+	scan.LastProgressAt = &completedAt
+	columns := []string{"status", "current_step", "last_progress_at", "error_message", "completed_at", "critical_count", "high_count", "medium_count", "low_count", "unknown_count", "suppressed_count"}
 	if scan.ScanProvider == models.ScanProviderArtifactoryXray {
 		if !preserveXrayExternalStatusOnFailure(scan.ExternalStatus) {
 			scan.ExternalStatus = models.ScanStatusFailed
 		}
 		columns = append(columns, "external_status")
 	}
-	db.NewUpdate().Model(scan).
+	query := db.NewUpdate().Model(scan).
 		Column(columns...).
-		Where("id = ?", scan.ID).Exec(ctx) //nolint:errcheck
-	if err := setScanStep(ctx, db, scan, models.ScanStepFailed); err != nil {
+		Where("id = ? AND status IN (?)", scan.ID, bun.In([]string{models.ScanStatusPending, models.ScanStatusRunning}))
+	if staleBefore != nil {
+		query = query.Where("last_progress_at IS NULL OR last_progress_at < ?", *staleBefore)
+	}
+	result, err := query.Exec(ctx)
+	if err != nil {
+		log.Warnf("Worker: failed to persist failure for scan %s: %v", scan.ID, err)
+		return false
+	}
+	rows, rowsErr := result.RowsAffected()
+	if rowsErr != nil {
+		log.Warnf("Worker: failed to confirm failure transition for scan %s: %v", scan.ID, rowsErr)
+		return false
+	}
+	if rows == 0 {
+		// A terminal writer (usually cancellation) won the race. Do not append
+		// a failed step or emit a duplicate failure notification/callback.
+		log.Infof("Worker: scan %s was already terminal; failure result discarded", scan.ID)
+		return false
+	}
+	return true
+}
+
+func finishFailedScan(ctx context.Context, db *bun.DB, scan *models.Scan, msg string) {
+	if err := appendTerminalScanStepLog(ctx, db, scan.ID, models.ScanStepFailed); err != nil {
 		log.Warnf("Worker: failed to persist failed step for scan %s: %v", scan.ID, err)
 	}
 	recordScanStepOutput(ctx, db, scan.ID, msg)
@@ -581,16 +921,115 @@ func preserveXrayExternalStatusOnFailure(status string) bool {
 	}
 }
 
-func cleanupScanArchive(scanID uuid.UUID, archivePath string) {
+// CleanupScanArchive removes an uploaded archive only after proving ownership
+// of its immediate upload directory. One-shot uploads use scanID as the
+// directory ID; resumable uploads use archive_upload_sessions.scan_id to bind
+// the session directory to this scan. A UUID-shaped path by itself is not
+// sufficient because a corrupted scan row could otherwise delete another
+// user's upload directory.
+func CleanupScanArchive(ctx context.Context, db *bun.DB, scanID uuid.UUID, archivePath string) {
 	trimmed := strings.TrimSpace(archivePath)
-	if trimmed == "" {
+	if trimmed == "" || scanID == uuid.Nil {
 		return
 	}
-	if err := os.Remove(trimmed); err != nil && !os.IsNotExist(err) {
-		log.Warnf("Worker: failed to remove uploaded archive for scan %s at %s: %v", scanID, trimmed, err)
-	} else {
-		log.Infof("Worker: removed uploaded archive for scan %s at %s", scanID, trimmed)
+	root, uploadID, ok := validatedUploadDirectoryWithID(trimmed)
+	if !ok {
+		log.Warnf("Worker: refusing to remove archive outside a validated upload directory for scan %s: %s", scanID, trimmed)
+		return
 	}
+	if uploadID != scanID {
+		if db == nil || ctx == nil {
+			log.Warnf("Worker: refusing to remove resumable archive without ownership lookup for scan %s: %s", scanID, trimmed)
+			return
+		}
+		var session struct {
+			ID          uuid.UUID  `bun:"id"`
+			ScanID      *uuid.UUID `bun:"scan_id"`
+			ArchivePath string     `bun:"archive_path"`
+		}
+		err := db.NewSelect().TableExpr("archive_upload_sessions").
+			Column("id", "scan_id", "archive_path").
+			Where("id = ? AND scan_id = ? AND archive_path = ?", uploadID, scanID, filepath.Clean(trimmed)).
+			Scan(ctx, &session)
+		if err != nil {
+			log.Warnf("Worker: refusing to remove archive without matching upload session for scan %s at %s: %v", scanID, trimmed, err)
+			return
+		}
+	}
+	if err := os.RemoveAll(root); err != nil {
+		log.Warnf("Worker: failed to remove uploaded archive directory for scan %s at %s: %v", scanID, root, err)
+	} else {
+		log.Infof("Worker: removed uploaded archive directory for scan %s at %s", scanID, root)
+		if uploadID != scanID && db != nil {
+			if _, err := db.NewDelete().TableExpr("archive_upload_sessions").
+				Where("id = ? AND scan_id = ? AND archive_path = ?", uploadID, scanID, filepath.Clean(trimmed)).
+				Exec(ctx); err != nil {
+				log.Warnf("Worker: failed to remove archive upload session for scan %s: %v", scanID, err)
+			}
+		}
+	}
+}
+
+// cleanupScanArchive is retained for package-local callers/tests and is
+// intentionally strict: without the session table it can only remove a
+// one-shot directory whose UUID is exactly the scan ID.
+func cleanupScanArchive(scanID uuid.UUID, archivePath string) {
+	CleanupScanArchive(context.Background(), nil, scanID, archivePath)
+}
+
+func validatedUploadDirectoryWithID(archivePath string) (string, uuid.UUID, bool) {
+	uploadsRoot := filepath.Join(os.TempDir(), "justscan", "uploads")
+	cleanPath := filepath.Clean(strings.TrimSpace(archivePath))
+	relativeToUploads, err := filepath.Rel(uploadsRoot, cleanPath)
+	if err != nil || relativeToUploads == "." || filepath.IsAbs(relativeToUploads) || relativeToUploads == ".." || strings.HasPrefix(relativeToUploads, ".."+string(filepath.Separator)) {
+		return "", uuid.Nil, false
+	}
+	parts := strings.Split(relativeToUploads, string(filepath.Separator))
+	if len(parts) < 2 {
+		return "", uuid.Nil, false
+	}
+	uploadID, err := uuid.Parse(parts[0])
+	if err != nil {
+		return "", uuid.Nil, false
+	}
+	return filepath.Join(uploadsRoot, parts[0]), uploadID, true
+}
+
+func validatedUploadDirectory(archivePath string) (string, bool) {
+	root, _, ok := validatedUploadDirectoryWithID(archivePath)
+	return root, ok
+}
+
+// archiveFileAvailable shares containment validation with cleanup but is read-only.
+func archiveFileAvailable(archivePath string) bool {
+	if _, ok := validatedUploadDirectory(archivePath); !ok {
+		return false
+	}
+	info, err := os.Stat(filepath.Clean(archivePath))
+	return err == nil && !info.IsDir()
+}
+
+// claimScanForWorker performs the only pending -> running transition. Rows
+// affected is deliberately checked so a queued duplicate cannot overwrite a
+// terminal state that was committed by cancellation or the watchdog.
+func claimScanForWorker(ctx context.Context, db *bun.DB, scanID uuid.UUID, startedAt time.Time) (bool, error) {
+	if db == nil || scanID == uuid.Nil {
+		return false, fmt.Errorf("database and scan ID are required")
+	}
+	result, err := db.NewUpdate().Model((*models.Scan)(nil)).
+		Set("status = ?", models.ScanStatusRunning).
+		Set("started_at = ?", startedAt).
+		Set("last_progress_at = ?", startedAt).
+		Where("id = ? AND status = ?", scanID, models.ScanStatusPending).
+		Exec(ctx)
+	if err != nil {
+		return false, err
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	return rows == 1, nil
 }
 
 // backfillKB populates vuln_kb from the existing vulnerabilities table for any

--- a/services/backend/scanner/worker_upload_cleanup_test.go
+++ b/services/backend/scanner/worker_upload_cleanup_test.go
@@ -9,6 +9,25 @@ import (
 )
 
 func TestCleanupScanArchiveRemovesFile(t *testing.T) {
+	uploadID := uuid.New()
+	dir := filepath.Join(os.TempDir(), "justscan", "uploads", uploadID.String())
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("failed to create upload directory: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(filepath.Join(os.TempDir(), "justscan", "uploads", uploadID.String())) })
+	path := filepath.Join(dir, "image.tar")
+	if err := os.WriteFile(path, []byte("archive"), 0o644); err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+
+	cleanupScanArchive(uploadID, path)
+
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Fatalf("expected upload directory to be removed, stat err=%v", err)
+	}
+}
+
+func TestCleanupScanArchiveRefusesOutsideUploadRoot(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "image.tar")
 	if err := os.WriteFile(path, []byte("archive"), 0o644); err != nil {
@@ -17,7 +36,27 @@ func TestCleanupScanArchiveRemovesFile(t *testing.T) {
 
 	cleanupScanArchive(uuid.New(), path)
 
-	if _, err := os.Stat(path); !os.IsNotExist(err) {
-		t.Fatalf("expected file to be removed, stat err=%v", err)
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("expected arbitrary path to remain untouched, stat err=%v", err)
+	}
+}
+
+func TestCleanupScanArchiveRefusesForeignUploadDirectory(t *testing.T) {
+	uploadID := uuid.New()
+	scanID := uuid.New()
+	dir := filepath.Join(os.TempDir(), "justscan", "uploads", uploadID.String())
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("failed to create upload directory: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	path := filepath.Join(dir, "image.tar")
+	if err := os.WriteFile(path, []byte("archive"), 0o644); err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+
+	cleanupScanArchive(scanID, path)
+
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("expected foreign upload archive to remain untouched, stat err=%v", err)
 	}
 }

--- a/services/backend/scanner/xray.go
+++ b/services/backend/scanner/xray.go
@@ -4,6 +4,7 @@ import (
 	"archive/zip"
 	"bytes"
 	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -18,6 +19,7 @@ import (
 	"justscan-backend/compliance"
 	effectivesuppressions "justscan-backend/functions/suppressions"
 	"justscan-backend/notifications"
+	"justscan-backend/pipelines"
 	"justscan-backend/pkg/models"
 
 	"github.com/google/uuid"
@@ -589,23 +591,32 @@ func processXrayScan(ctx context.Context, db *bun.DB, scan *models.Scan) error {
 	completedAt := time.Now()
 	scan.Status = models.ScanStatusCompleted
 	scan.CompletedAt = &completedAt
+	scan.LastProgressAt = &completedAt
 	scan.ExternalStatus = "completed"
 	scan.CurrentStep = models.ScanStepCompleted
 
-	if _, err := db.NewUpdate().Model(scan).
-		Column("status", "completed_at", "critical_count", "high_count", "medium_count", "low_count", "unknown_count", "suppressed_count", "external_scan_id", "external_status", "image_config", "architecture", "os_family", "os_name").
-		Where("id = ?", scan.ID).
-		Exec(ctx); err != nil {
+	result, err := db.NewUpdate().Model(scan).
+		Column("status", "current_step", "last_progress_at", "completed_at", "critical_count", "high_count", "medium_count", "low_count", "unknown_count", "suppressed_count", "external_scan_id", "external_status", "image_config", "architecture", "os_family", "os_name").
+		Where("id = ? AND status = ?", scan.ID, models.ScanStatusRunning).
+		Exec(ctx)
+	if err != nil {
 		return fmt.Errorf("failed to mark xray scan as completed: %w", err)
+	}
+	rows, rowsErr := result.RowsAffected()
+	if rowsErr != nil {
+		return fmt.Errorf("failed to confirm xray scan completion: %w", rowsErr)
+	}
+	if rows == 0 {
+		return nil
+	}
+	if err := appendTerminalScanStepLog(ctx, db, scan.ID, models.ScanStepCompleted); err != nil {
+		return err
 	}
 	if err := RecordIntelligenceSnapshot(ctx, db, scan); err != nil {
 		log.Warnf("Xray: intelligence snapshot failed for scan %s (non-fatal): %v", scan.ID, err)
 		recordScanStepOutput(ctx, db, scan.ID, fmt.Sprintf("Scan-time intelligence snapshot failed, but the Xray result remains available: %v", err))
 	} else {
 		recordScanStepOutput(ctx, db, scan.ID, "Stored scan-time vulnerability intelligence and refreshed current posture.")
-	}
-	if err := setScanStep(ctx, db, scan, models.ScanStepCompleted); err != nil {
-		return err
 	}
 	recordScanStepOutput(ctx, db, scan.ID, fmt.Sprintf("Xray scan completed with %d total findings.", scan.CriticalCount+scan.HighCount+scan.MediumCount+scan.LowCount+scan.UnknownCount))
 	recordScanStepOutput(ctx, db, scan.ID, "Queued compliance evaluation, auto-tagging, and completion notifications.")
@@ -620,6 +631,9 @@ func processXrayScan(ctx context.Context, db *bun.DB, scan *models.Scan) error {
 		Details: fmt.Sprintf("Critical: %d  High: %d  Medium: %d  Low: %d",
 			scan.CriticalCount, scan.HighCount, scan.MediumCount, scan.LowCount),
 	})
+	if err := pipelines.QueueCallbackForScan(context.Background(), db, scan.ID.String()); err != nil && err != sql.ErrNoRows {
+		log.Warnf("Xray: failed to queue pipeline callback for completed scan %s: %v", scan.ID, err)
+	}
 
 	return nil
 }

--- a/services/backend/scheduler/scheduler.go
+++ b/services/backend/scheduler/scheduler.go
@@ -2,6 +2,7 @@ package scheduler
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -19,6 +20,10 @@ import (
 var cronRunner *cron.Cron
 var scheduleMu sync.Mutex
 var scheduledEntries map[string]cron.EntryID
+
+const schedulerDuplicateWindow = 45 * time.Second
+
+var errSchedulerLockUnavailable = errors.New("scheduler advisory lock is held by another instance")
 
 // Start initialises the cron scheduler and registers all enabled watchlist items.
 func Start(db *bun.DB) {
@@ -76,39 +81,62 @@ func scheduleItem(db *bun.DB, item models.WatchlistItem) {
 		return
 	}
 	entryID, err := cronRunner.AddFunc(spec, func() {
+		ctx := context.Background()
 		currentItem := itemCopy
-		if err := db.NewSelect().Model(&currentItem).Where("id = ?", itemCopy.ID).Scan(context.Background()); err != nil {
-			log.Errorf("scheduler: failed to refresh watchlist item %s: %v", itemCopy.ID, err)
-			return
-		}
-		log.Infof("scheduler: triggering scan for %s:%s", currentItem.ImageName, currentItem.ImageTag)
-		registry, envVars, err := scanner.ResolveRegistryForScan(context.Background(), db, currentItem.ImageName, currentItem.RegistryID)
-		if err != nil {
-			log.Errorf("scheduler: failed to resolve registry for %s:%s: %v", currentItem.ImageName, currentItem.ImageTag, err)
-			return
-		}
-		provider, err := scanner.ProviderForRegistry(registry)
-		if err != nil {
-			log.Errorf("scheduler: unavailable provider for %s:%s: %v", currentItem.ImageName, currentItem.ImageTag, err)
-			return
-		}
-		normalizedImageName, normalizedImageTag := scanner.NormalizeScanTarget(currentItem.ImageName, currentItem.ImageTag, registry)
-		scan := newScheduledScan(currentItem, normalizedImageName, normalizedImageTag, provider, currentItem.RegistryID, time.Now())
-		if registry != nil {
-			scan.RegistryID = &registry.ID
-		}
-		if err := db.RunInTx(context.Background(), nil, func(ctx context.Context, tx bun.Tx) error {
-			if _, err := tx.NewInsert().Model(scan).Exec(ctx); err != nil {
+		var scan *models.Scan
+		var envVars []string
+		err := withWatchlistAdvisoryLock(ctx, db, itemCopy.ID.String(), func(lockDB bun.IDB) error {
+			if err := lockDB.NewSelect().Model(&currentItem).Where("id = ?", itemCopy.ID).Scan(ctx); err != nil {
+				return fmt.Errorf("failed to refresh watchlist item %s: %w", itemCopy.ID, err)
+			}
+			if !currentItem.Enabled {
+				return nil
+			}
+			if currentItem.LastScannedAt != nil && time.Since(*currentItem.LastScannedAt) < schedulerDuplicateWindow {
+				return nil
+			}
+			log.Infof("scheduler: triggering scan for %s:%s", currentItem.ImageName, currentItem.ImageTag)
+			registry, resolvedEnvVars, err := scanner.ResolveRegistryForScan(ctx, lockDB, currentItem.ImageName, currentItem.RegistryID)
+			if err != nil {
+				return fmt.Errorf("failed to resolve registry for %s:%s: %w", currentItem.ImageName, currentItem.ImageTag, err)
+			}
+			provider, err := scanner.ProviderForRegistry(registry)
+			if err != nil {
+				return fmt.Errorf("unavailable provider for %s:%s: %w", currentItem.ImageName, currentItem.ImageTag, err)
+			}
+			normalizedImageName, normalizedImageTag := scanner.NormalizeScanTarget(currentItem.ImageName, currentItem.ImageTag, registry)
+			scan = newScheduledScan(currentItem, normalizedImageName, normalizedImageTag, provider, currentItem.RegistryID, time.Now())
+			if registry != nil {
+				scan.RegistryID = &registry.ID
+			}
+			if _, err := lockDB.NewInsert().Model(scan).Exec(ctx); err != nil {
 				return err
 			}
 			if scan.OwnerOrgID != nil {
-				if err := ensureOrgScanLink(ctx, tx, *scan.OwnerOrgID, scan.ID); err != nil {
+				if err := ensureOrgScanLink(ctx, lockDB, *scan.OwnerOrgID, scan.ID); err != nil {
 					return err
 				}
 			}
+			now := time.Now()
+			currentItem.LastScannedAt = &now
+			currentItem.LastScanID = &scan.ID
+			if _, err := lockDB.NewUpdate().Model(&currentItem).
+				Column("last_scanned_at", "last_scan_id").
+				Where("id = ?", currentItem.ID).
+				Exec(ctx); err != nil {
+				return err
+			}
+			envVars = resolvedEnvVars
 			return nil
-		}); err != nil {
+		})
+		if errors.Is(err, errSchedulerLockUnavailable) {
+			return
+		}
+		if err != nil {
 			log.Errorf("scheduler: failed to create scan for %s: %v", currentItem.ImageName, err)
+			return
+		}
+		if scan == nil {
 			return
 		}
 		if err := scanner.DispatchScan(context.Background(), db, scan, envVars, ""); err != nil {
@@ -117,13 +145,6 @@ func scheduleItem(db *bun.DB, item models.WatchlistItem) {
 				log.Errorf("scheduler: failed to persist dispatch error for %s: %v", scan.ID, markErr)
 			}
 		}
-		now := time.Now()
-		currentItem.LastScannedAt = &now
-		currentItem.LastScanID = &scan.ID
-		db.NewUpdate().Model(&currentItem).
-			Column("last_scanned_at", "last_scan_id").
-			Where("id = ?", currentItem.ID).
-			Exec(context.Background()) //nolint:errcheck
 	})
 	if err != nil {
 		log.Errorf("scheduler: invalid cron schedule %q for item %s: %v", item.Schedule, item.ID, err)
@@ -132,6 +153,38 @@ func scheduleItem(db *bun.DB, item models.WatchlistItem) {
 	scheduleMu.Lock()
 	scheduledEntries[item.ID.String()] = entryID
 	scheduleMu.Unlock()
+}
+
+// withWatchlistAdvisoryLock holds a session-level PostgreSQL advisory lock on
+// a dedicated pooled connection while the callback creates and marks a scan.
+// A second backend instance skips the tick while the first one owns the lock.
+func withWatchlistAdvisoryLock(ctx context.Context, db *bun.DB, watchlistID string, fn func(bun.IDB) error) error {
+	if db == nil {
+		return fmt.Errorf("database is required")
+	}
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+	lockName := "justscan:watchlist:" + watchlistID
+	var locked bool
+	if err := conn.NewRaw(`SELECT pg_try_advisory_lock(hashtextextended(?, 0))`, lockName).Scan(ctx, &locked); err != nil {
+		return err
+	}
+	if !locked {
+		return errSchedulerLockUnavailable
+	}
+	defer func() {
+		_, _ = conn.NewRaw(`SELECT pg_advisory_unlock(hashtextextended(?, 0))`, lockName).Exec(context.Background())
+	}()
+	// Keep the scan insert, organization link, and watchlist marker in one
+	// transaction on the same dedicated connection that owns the advisory lock.
+	// Using db.RunInTx here would lease another pooled connection and would not
+	// make the lock protect the transaction's writes.
+	return conn.RunInTx(ctx, nil, func(_ context.Context, tx bun.Tx) error {
+		return fn(&tx)
+	})
 }
 
 func newScheduledScan(item models.WatchlistItem, imageName string, imageTag string, provider string, registryID *uuid.UUID, createdAt time.Time) *models.Scan {
@@ -233,7 +286,9 @@ func startInsightLogCleanup(db *bun.DB) {
 			res, err := db.NewDelete().TableExpr("api_request_logs").Where("created_at < ?", cutoff).Exec(ctx)
 			if err != nil {
 				log.Warnf("insight cleanup: failed to prune api_request_logs: %v", err)
-			} else if n, _ := res.RowsAffected(); n > 0 {
+			} else if n, rowsErr := res.RowsAffected(); rowsErr != nil {
+				log.Warnf("insight cleanup: failed to count pruned api_request_logs: %v", rowsErr)
+			} else if n > 0 {
 				log.Infof("insight cleanup: pruned %d api_request_logs older than %d days", n, apiDays)
 			}
 		}
@@ -243,7 +298,9 @@ func startInsightLogCleanup(db *bun.DB) {
 			res, err := db.NewDelete().TableExpr("xray_request_logs").Where("created_at < ?", cutoff).Exec(ctx)
 			if err != nil {
 				log.Warnf("insight cleanup: failed to prune xray_request_logs: %v", err)
-			} else if n, _ := res.RowsAffected(); n > 0 {
+			} else if n, rowsErr := res.RowsAffected(); rowsErr != nil {
+				log.Warnf("insight cleanup: failed to count pruned xray_request_logs: %v", rowsErr)
+			} else if n > 0 {
 				log.Infof("insight cleanup: pruned %d xray_request_logs older than %d days", n, xrayDays)
 			}
 		}

--- a/services/docs/content/docs/deploy/docker-compose.mdx
+++ b/services/docs/content/docs/deploy/docker-compose.mdx
@@ -31,7 +31,7 @@ Set at least:
 
 Replace every `change-me-in-production` value in `backend-config.yaml` before production use. Generate distinct values for `jwt.secret` and `encryption.key`, and set `allow_origins` to the URL users open in their browser. Keep database passwords, JWT secrets, encryption keys, and provider credentials in the host secret manager where possible.
 
-For a remote host, the published frontend image expects the local development API address by default. If the browser must reach a different backend URL, build the frontend locally with `NEXT_PUBLIC_API_URL` set to that public API URL.
+The frontend uses the same-origin `/api` proxy by default, which keeps the bundled Compose deployment on one host. For a deployment where the browser must call a backend on another host, build the frontend with `NEXT_PUBLIC_API_URL` set to that backend's public URL (including `https://`); browser requests will then use that configured API origin. Local split-port development continues to use `http://localhost:8080` directly.
 
 ## Start and verify
 
@@ -39,7 +39,7 @@ For a remote host, the published frontend image expects the local development AP
 docker compose up -d
 ```
 
-Open `http://HOST[:HTTP_PORT]` and verify that `/`, `/docs`, `/swagger`, and `/api/v1/health` resolve through nginx. Then continue with [first-time setup](/setup/quick-start) to create the initial administrator.
+Open `http://HOST[:HTTP_PORT]` and verify that `/`, `/docs`, `/swagger`, and `/api/v1/health` resolve through nginx. The backend container healthcheck uses `/api/v1/readyz`; use `/api/v1/livez` for a process-only liveness check. Then continue with [first-time setup](/setup/quick-start) to create the initial administrator.
 
 ## Large archive uploads
 

--- a/services/docs/content/docs/deploy/helm.mdx
+++ b/services/docs/content/docs/deploy/helm.mdx
@@ -52,4 +52,4 @@ kubectl get pods --namespace justscan
 helm status justscan --namespace justscan
 ```
 
-Verify the public hostname returns `/`, `/docs`, `/swagger`, and `/api/v1/health`, then follow [first-time setup](/setup/quick-start) to create the initial administrator. Use the same command with the new chart version for upgrades, and review [upgrades and maintenance](/operate/upgrades-and-maintenance) before changing persistent releases.
+Verify the public hostname returns `/`, `/docs`, `/swagger`, and `/api/v1/health`. The chart probes `/api/v1/livez` for liveness and `/api/v1/readyz` for dependency-aware readiness. Then follow [first-time setup](/setup/quick-start) to create the initial administrator. Use the same command with the new chart version for upgrades, and review [upgrades and maintenance](/operate/upgrades-and-maintenance) before changing persistent releases.

--- a/services/docs/content/docs/operate/observability-and-maintenance.mdx
+++ b/services/docs/content/docs/operate/observability-and-maintenance.mdx
@@ -7,11 +7,14 @@ Treat JustScan as a release-decision service once CI depends on policy outcomes.
 
 ## Signals to review
 
-- **Backend health:** query `/api/v1/health` through the same route used by users and CI.
+- **Backend health:** use `/api/v1/livez` for process liveness and `/api/v1/readyz` for dependency-aware readiness. `/api/v1/health` remains a compatibility endpoint. Readiness checks PostgreSQL and checks local Trivy only when Trivy is enabled; an Xray-only backend does not require a Trivy binary or local database.
 - **Scan activity:** review pending, active, stale, and failed scans; inspect scan step progress and backend logs before changing global timeouts.
 - **Scanner readiness:** use the administration scanner health view and confirm registry reachability, database freshness, and available worker capacity.
+- **Queue capacity:** administrators can use the scan queue summary's queue depth, oldest queued lag, active workers, and utilization fields. Non-administrators receive only workspace-scoped durable activity, so one workspace cannot infer another workspace's queue.
 - **Notifications:** test channels and inspect delivery logs and queued delivery state after configuration changes.
 - **Audit records:** review organization and administrator activity when investigating access, ownership, policy, or token changes.
+
+The admin scanner settings API applies engine toggles, command timeout, scanner database age, and OSV Java enrichment on subsequent work. Worker concurrency is fixed when the backend starts and is reported as restart-required; pending durable scans are requeued during startup and by the recovery dispatcher.
 
 ## CVE Intelligence health
 

--- a/services/docs/content/docs/reference/backend-configuration.mdx
+++ b/services/docs/content/docs/reference/backend-configuration.mdx
@@ -3,40 +3,42 @@ title: Backend configuration reference
 description: Reference the current backend YAML settings and supported BACKEND_ environment overrides.
 ---
 
-| Setting                                                     | Default                   | Purpose                                                             |
-| ----------------------------------------------------------- | ------------------------- | ------------------------------------------------------------------- |
-| `log_level`                                                 | `info`                    | Backend log verbosity: `debug`, `info`, `warn`, or `error`          |
-| `database.server`, `port`, `name`, `user`, `password`       | Local PostgreSQL defaults | PostgreSQL connection settings                                      |
-| `jwt.secret`                                                | Required in production    | Signs JustScan authentication tokens; 32+ characters in production  |
-| `encryption.key`                                            | Required in production    | Encrypts registry credentials at rest; 32+ characters in production |
-| `port`                                                      | `8080`                    | Backend HTTP port                                                   |
-| `allow_origins`                                             | Local frontend origins    | Browser origins allowed by CORS                                     |
-| `scanner.enable_trivy`                                      | `true`                    | Enable local Trivy scans                                            |
-| `scanner.enable_grype`                                      | `false`                   | Enable Grype augmentation                                           |
-| `scanner.trivy_path`, `grype_path`                          | `trivy`, `grype`          | Scanner executable paths in the backend image                       |
-| `scanner.timeout`                                           | `600`                     | Scanner timeout setting                                             |
-| `scanner.concurrency`                                       | `2`                       | Maximum concurrent scanner workers                                  |
-| `scanner.command_timeout_seconds`                           | `7200`                    | Scanner process timeout                                             |
-| `scanner.progress_heartbeat_seconds`                        | `30`                      | Scan progress heartbeat interval                                    |
-| `scanner.stale_timeout_seconds`                             | `7200`                    | Duration after which inactive scan work is stale                    |
-| `scanner.db_max_age_hours`                                  | `24`                      | Maximum local scanner database age                                  |
-| `scanner.enable_osv_java_augmentation`                      | `true`                    | Enable OSV Java enrichment                                          |
-| `vuln_kb.cache_days`                                        | `7`                       | NVD enrichment cache lifetime                                       |
-| `vuln_kb.nvd_api_key`                                       | Empty                     | Optional NVD API key for CVE enrichment                             |
-| `vuln_kb.cve_history_enabled`                               | `true`                    | Poll NVD CVE change history and re-evaluate retained findings       |
-| `vuln_kb.cve_history_interval_minutes`                      | `120`                     | Interval between CVE change-history sync attempts                   |
-| `vuln_kb.cve_history_initial_lookback_hours`                | `24`                      | History window used by the first sync; capped at 120 days           |
-| `local_auth.enabled`                                        | `true`                    | Enable username/password login                                      |
-| `mcp.enabled`                                               | `false`                   | Enable the JustScan MCP tools                                       |
-| `mcp.http_enabled`                                          | `false`                   | Expose the protected Streamable HTTP MCP endpoint                   |
-| `mcp.endpoint`                                              | `/mcp`                    | MCP endpoint path under `/api/v1`                                   |
-| `mcp.max_page_size`                                         | `50`                      | Maximum results returned by one MCP page                            |
-| `mcp.max_request_body_bytes`                                | `4194304`                 | Maximum MCP HTTP request body size                                  |
-| `security.allow_insecure_defaults`                          | `false`                   | Allow development-only insecure JWT/encryption defaults             |
-| `security.callback_allowed_hosts`, `callback_allowed_cidrs` | Empty                     | Explicit private callback target allowlists                         |
+| Setting                                                     | Default                   | Purpose                                                                    |
+| ----------------------------------------------------------- | ------------------------- | -------------------------------------------------------------------------- |
+| `log_level`                                                 | `info`                    | Backend log verbosity: `debug`, `info`, `warn`, or `error`                 |
+| `database.server`, `port`, `name`, `user`, `password`       | Local PostgreSQL defaults | PostgreSQL connection settings                                             |
+| `jwt.secret`                                                | Required in production    | Signs JustScan authentication tokens; 32+ characters in production         |
+| `encryption.key`                                            | Required in production    | Encrypts registry credentials at rest; 32+ characters in production        |
+| `port`                                                      | `8080`                    | Backend HTTP port                                                          |
+| `allow_origins`                                             | Local frontend origins    | Browser origins allowed by CORS                                            |
+| `scanner.enable_trivy`                                      | `true`                    | Enable local Trivy scans                                                   |
+| `scanner.enable_grype`                                      | `false`                   | Enable Grype augmentation                                                  |
+| `scanner.trivy_path`, `grype_path`                          | `trivy`, `grype`          | Scanner executable paths in the backend image                              |
+| `scanner.timeout`                                           | `600`                     | Legacy scanner timeout setting; `command_timeout_seconds` takes precedence |
+| `scanner.concurrency`                                       | `2`                       | Maximum concurrent scanner workers                                         |
+| `scanner.command_timeout_seconds`                           | `7200`                    | Scanner process timeout                                                    |
+| `scanner.progress_heartbeat_seconds`                        | `30`                      | Scan progress heartbeat interval                                           |
+| `scanner.stale_timeout_seconds`                             | `7200`                    | Duration after which inactive scan work is stale                           |
+| `scanner.db_max_age_hours`                                  | `24`                      | Maximum local scanner database age                                         |
+| `scanner.enable_osv_java_augmentation`                      | `true`                    | Enable OSV Java enrichment                                                 |
+| `vuln_kb.cache_days`                                        | `7`                       | NVD enrichment cache lifetime                                              |
+| `vuln_kb.nvd_api_key`                                       | Empty                     | Optional NVD API key for CVE enrichment                                    |
+| `vuln_kb.cve_history_enabled`                               | `true`                    | Poll NVD CVE change history and re-evaluate retained findings              |
+| `vuln_kb.cve_history_interval_minutes`                      | `120`                     | Interval between CVE change-history sync attempts                          |
+| `vuln_kb.cve_history_initial_lookback_hours`                | `24`                      | History window used by the first sync; capped at 120 days                  |
+| `local_auth.enabled`                                        | `true`                    | Enable username/password login                                             |
+| `mcp.enabled`                                               | `false`                   | Enable the JustScan MCP tools                                              |
+| `mcp.http_enabled`                                          | `false`                   | Expose the protected Streamable HTTP MCP endpoint                          |
+| `mcp.endpoint`                                              | `/mcp`                    | MCP endpoint path under `/api/v1`                                          |
+| `mcp.max_page_size`                                         | `50`                      | Maximum results returned by one MCP page                                   |
+| `mcp.max_request_body_bytes`                                | `4194304`                 | Maximum MCP HTTP request body size                                         |
+| `security.allow_insecure_defaults`                          | `false`                   | Allow development-only insecure JWT/encryption defaults                    |
+| `security.callback_allowed_hosts`, `callback_allowed_cidrs` | Empty                     | Explicit private callback target allowlists                                |
 
 Every supported setting can be overridden with a `BACKEND_` environment variable using underscore-separated names. For example, `scanner.concurrency` becomes `BACKEND_SCANNER_CONCURRENCY`. Comma-separated callback host and CIDR values are parsed as lists. Keep `jwt.secret`, `encryption.key`, database passwords, and NVD keys in secret injection rather than plain YAML. CVE history polling uses the official NVD history and CVE APIs, retries rate limits and transient failures, and checkpoints only after the corresponding official CVE and NVD records have been re-evaluated. A feed outage therefore leaves the last verified posture unchanged.
 
 CVE history is cursor-based: normal scheduled runs process changes since the last successful checkpoint and do not enumerate every row in `vuln_kb`. The first run uses `cve_history_initial_lookback_hours`, and a larger lookback can create a significant backlog because each distinct changed CVE requires current-record enrichment. Use the [CVE Intelligence guide](/operate/vulnerability-intelligence) for rollout, progress, and recovery guidance.
 
 `scanner.enable_grype=true` requires `scanner.enable_trivy=true`. Do not set `security.allow_insecure_defaults=true` outside local development.
+
+The administrator scanner-settings API accepts both `timeout_seconds` (the original API field) and `command_timeout_seconds`; both persist the canonical `scanner.command_timeout_seconds` key, while older `scanner.timeout_seconds` rows remain a fallback. Engine toggles, command timeout, database age, and OSV enrichment are resolved for subsequent work. Worker concurrency is fixed at process start and requires a backend restart; pending scans are recovered from durable `pending` rows during startup.

--- a/services/frontend/app/(app)/dashboard/page.tsx
+++ b/services/frontend/app/(app)/dashboard/page.tsx
@@ -53,7 +53,6 @@ import {
   ScannerHealth,
   WatchlistItem,
 } from '@/lib/api';
-import { deferEffect } from '@/lib/defer-effect';
 import { getWatchlistPolicyAttentionItems } from '@/lib/watchlist-posture';
 import { Button, Card, Chip, ProgressBar, Separator, useOverlayState } from '@heroui/react';
 import {
@@ -65,7 +64,7 @@ import {
 } from 'hugeicons-react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 // ── severity config ──────────────────────────────────────────────────
 const SEV = [
@@ -166,6 +165,13 @@ function toTimestamp(value?: string | null): number | null {
   if (!value) return null;
   const parsed = Date.parse(value);
   return Number.isNaN(parsed) ? null : parsed;
+}
+
+function isAbortError(error: unknown): boolean {
+  return (
+    (error instanceof Error && error.name === 'AbortError') ||
+    (typeof error === 'object' && error !== null && 'name' in error && error.name === 'AbortError')
+  );
 }
 
 function sumAvgFindings(point: DashboardVulnTrendPoint): number {
@@ -754,6 +760,26 @@ export default function DashboardPage() {
   const [watchlistItems, setWatchlistItems] = useState<WatchlistItem[]>([]);
   const [watchlistLoading, setWatchlistLoading] = useState(false);
   const [watchlistError, setWatchlistError] = useState('');
+  const dashboardRequestRef = useRef<{
+    controller: AbortController;
+    version: number;
+  } | null>(null);
+  const dashboardRequestVersionRef = useRef(0);
+  const vulnTrendRequestRef = useRef<{
+    controller: AbortController;
+    version: number;
+  } | null>(null);
+  const vulnTrendRequestVersionRef = useRef(0);
+  const statsRefreshRequestRef = useRef<{
+    controller: AbortController;
+    version: number;
+  } | null>(null);
+  const statsRefreshVersionRef = useRef(0);
+  const drilldownRequestRef = useRef<{
+    controller: AbortController;
+    version: number;
+  } | null>(null);
+  const drilldownRequestVersionRef = useRef(0);
   const currentUser = getUser() as { role?: string } | null;
   const isAdmin = currentUser?.role === 'admin' || getTokenType() === 'admin';
 
@@ -770,66 +796,174 @@ export default function DashboardPage() {
     (scan) => scan.status === 'pending' || scan.status === 'running'
   );
   const refreshStats = useCallback(() => {
-    getStats()
-      .then(setStats)
-      .catch(() => {});
+    statsRefreshRequestRef.current?.controller.abort();
+    const controller = new AbortController();
+    const version = ++statsRefreshVersionRef.current;
+    statsRefreshRequestRef.current = { controller, version };
+    getStats({ signal: controller.signal })
+      .then((nextStats) => {
+        if (statsRefreshRequestRef.current?.version === version) {
+          setStats(nextStats);
+        }
+      })
+      .catch((reason: unknown) => {
+        if (statsRefreshRequestRef.current?.version !== version || isAbortError(reason)) return;
+      })
+      .finally(() => {
+        if (statsRefreshRequestRef.current?.version === version) {
+          statsRefreshRequestRef.current = null;
+        }
+      });
   }, []);
 
   useConditionalInterval(refreshStats, hasActiveScans, 5000);
 
   useEffect(() => {
+    statsRefreshRequestRef.current?.controller.abort();
+    statsRefreshRequestRef.current = null;
+    dashboardRequestRef.current?.controller.abort();
+    const controller = new AbortController();
+    const requestVersion = ++dashboardRequestVersionRef.current;
+    dashboardRequestRef.current = { controller, version: requestVersion };
     const healthPromise = isAdmin
-      ? getScannerHealth()
+      ? getScannerHealth({ signal: controller.signal })
           .then((health) => ({ health, error: '' }))
-          .catch((e: Error) => ({ health: null, error: e.message }))
+          .catch((reason: unknown) => {
+            if (isAbortError(reason)) throw reason;
+            return {
+              health: null,
+              error: reason instanceof Error ? reason.message : 'Failed to load scanner health',
+            };
+          })
       : Promise.resolve({ health: null, error: '' });
 
     Promise.all([
-      getStats(),
-      getDashboardTrends(scanOutcomeRange).catch(() => [] as DashboardTrendPoint[]),
-      getDashboardVulnTrends(vulnTrendPeriod).catch(() => [] as DashboardVulnTrendPoint[]),
+      getStats({ signal: controller.signal }),
+      getDashboardTrends(scanOutcomeRange, { signal: controller.signal }).catch(
+        (reason: unknown) => {
+          if (isAbortError(reason)) throw reason;
+          return [] as DashboardTrendPoint[];
+        }
+      ),
       healthPromise,
     ])
-      .then(([s, t, vt, healthResult]) => {
+      .then(([s, t, healthResult]) => {
+        if (dashboardRequestRef.current?.version !== requestVersion) return;
         setStats(s);
         setTrends(t);
-        setVulnTrends(vt);
         setScannerHealth(healthResult.health);
         setScannerHealthError(healthResult.error);
         setChartRefreshKey((current) => current + 1);
       })
-      .catch((e: Error) => setError(e.message))
-      .finally(() => setLoading(false));
-  }, [isAdmin, scopeKey]); // eslint-disable-line react-hooks/exhaustive-deps
+      .catch((reason: unknown) => {
+        if (dashboardRequestRef.current?.version !== requestVersion || isAbortError(reason)) return;
+        setError(reason instanceof Error ? reason.message : 'Failed to load dashboard data');
+      })
+      .finally(() => {
+        if (dashboardRequestRef.current?.version !== requestVersion) return;
+        dashboardRequestRef.current = null;
+        setScanOutcomeLoading(false);
+        setLoading(false);
+      });
+
+    return () => {
+      if (dashboardRequestRef.current?.version === requestVersion) {
+        controller.abort();
+      }
+    };
+  }, [isAdmin, scanOutcomeRange, scopeKey]);
 
   useEffect(() => {
-    return deferEffect(() => {
-      listWatchlist()
-        .then((items) => setWatchlistOverviewItems(items))
-        .catch((watchlistLoadError: Error) => {
-          setWatchlistOverviewItems([]);
-          console.warn('Failed to load watchlist overview', watchlistLoadError);
-        });
-    });
+    vulnTrendRequestRef.current?.controller.abort();
+    const controller = new AbortController();
+    const requestVersion = ++vulnTrendRequestVersionRef.current;
+    vulnTrendRequestRef.current = { controller, version: requestVersion };
+    getDashboardVulnTrends(vulnTrendPeriod, { signal: controller.signal })
+      .then((nextTrends) => {
+        if (vulnTrendRequestRef.current?.version === requestVersion) {
+          setVulnTrends(nextTrends);
+        }
+      })
+      .catch((reason: unknown) => {
+        if (vulnTrendRequestRef.current?.version !== requestVersion || isAbortError(reason)) return;
+        setVulnTrends([]);
+      })
+      .finally(() => {
+        if (vulnTrendRequestRef.current?.version === requestVersion) {
+          vulnTrendRequestRef.current = null;
+        }
+      });
+
+    return () => {
+      if (vulnTrendRequestRef.current?.version === requestVersion) {
+        controller.abort();
+      }
+    };
+  }, [scopeKey, vulnTrendPeriod]);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    let cancelled = false;
+    void listWatchlist({ signal: controller.signal })
+      .then((items) => {
+        if (!cancelled) setWatchlistOverviewItems(items);
+      })
+      .catch((reason: unknown) => {
+        if (cancelled || isAbortError(reason)) return;
+        setWatchlistOverviewItems([]);
+        console.warn('Failed to load watchlist overview', reason);
+      });
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
   }, [scopeKey]);
 
   useEffect(() => {
-    if (!activeDrilldown || !drilldownModal.isOpen) return;
-
-    if (activeDrilldown === 'watchlist') {
-      listWatchlist()
-        .then((items) => setWatchlistItems(items))
-        .catch((watchlistLoadError: Error) => {
-          setWatchlistItems([]);
-          setWatchlistError(watchlistLoadError.message);
-        })
-        .finally(() => setWatchlistLoading(false));
+    drilldownRequestRef.current?.controller.abort();
+    if (!activeDrilldown || !drilldownModal.isOpen) {
+      drilldownRequestRef.current = null;
       return;
+    }
+
+    const controller = new AbortController();
+    const requestVersion = ++drilldownRequestVersionRef.current;
+    drilldownRequestRef.current = { controller, version: requestVersion };
+
+    if (activeDrilldown === 'watchlist' || activeDrilldown === 'watchlist_attention') {
+      listWatchlist({ signal: controller.signal })
+        .then((items) => {
+          if (drilldownRequestRef.current?.version !== requestVersion) return;
+          setWatchlistItems(
+            activeDrilldown === 'watchlist_attention'
+              ? getWatchlistPolicyAttentionItems(items)
+              : items
+          );
+        })
+        .catch((reason: unknown) => {
+          if (drilldownRequestRef.current?.version !== requestVersion || isAbortError(reason)) {
+            return;
+          }
+          setWatchlistItems([]);
+          setWatchlistError(
+            reason instanceof Error ? reason.message : 'Failed to load watchlist items'
+          );
+        })
+        .finally(() => {
+          if (drilldownRequestRef.current?.version !== requestVersion) return;
+          drilldownRequestRef.current = null;
+          setWatchlistLoading(false);
+        });
+      return () => {
+        if (drilldownRequestRef.current?.version === requestVersion) {
+          controller.abort();
+        }
+      };
     }
 
     const { from, to } = getRecentActivityBounds(recentActivityRange);
 
-    const request = listScans(
+    listScans(
       1,
       50,
       undefined,
@@ -838,33 +972,43 @@ export default function DashboardPage() {
       undefined,
       undefined,
       from,
-      to
-    ).then((result) => result.data ?? []);
-
-    request
-      .then((scans) => setModalScans(scans))
-      .catch((modalError: Error) => {
-        setModalScans([]);
-        setModalScansError(modalError.message);
+      to,
+      undefined,
+      undefined,
+      undefined,
+      { signal: controller.signal }
+    )
+      .then((result) => {
+        if (drilldownRequestRef.current?.version === requestVersion) {
+          setModalScans(result.data ?? []);
+        }
       })
-      .finally(() => setModalScansLoading(false));
+      .catch((reason: unknown) => {
+        if (drilldownRequestRef.current?.version !== requestVersion || isAbortError(reason)) return;
+        setModalScans([]);
+        setModalScansError(reason instanceof Error ? reason.message : 'Failed to load scans');
+      })
+      .finally(() => {
+        if (drilldownRequestRef.current?.version !== requestVersion) return;
+        drilldownRequestRef.current = null;
+        setModalScansLoading(false);
+      });
+
+    return () => {
+      if (drilldownRequestRef.current?.version === requestVersion) {
+        controller.abort();
+      }
+    };
   }, [activeDrilldown, drilldownModal.isOpen, recentActivityRange, scopeKey]);
 
   function handleVulnPeriodChange(days: number) {
     setVulnTrendPeriod(days);
-    getDashboardVulnTrends(days)
-      .then(setVulnTrends)
-      .catch(() => setVulnTrends([]));
   }
 
   function handleScanOutcomeRangeChange(range: RecentActivityRange) {
     if (range === scanOutcomeRange) return;
     setScanOutcomeRange(range);
     setScanOutcomeLoading(true);
-    getDashboardTrends(range)
-      .then(setTrends)
-      .catch(() => setTrends([]))
-      .finally(() => setScanOutcomeLoading(false));
   }
 
   function openScanOutcomeStatus(filters: { status?: string; policy?: string }) {
@@ -968,7 +1112,7 @@ export default function DashboardPage() {
           .join(' · ');
 
   function prepareDrilldown(card: DashboardDrilldownKey) {
-    if (card === 'watchlist') {
+    if (card === 'watchlist' || card === 'watchlist_attention') {
       setWatchlistLoading(true);
       setWatchlistError('');
       return;
@@ -1204,7 +1348,7 @@ export default function DashboardPage() {
               Review scan outcomes
               <ArrowRight01Icon size={15} />
             </Button>
-            <Button onPress={() => openDrilldown('watchlist')} variant="ghost">
+            <Button onPress={() => openDrilldown('watchlist_attention')} variant="ghost">
               Open watchlist attention
             </Button>
           </Card.Footer>
@@ -1338,7 +1482,11 @@ export default function DashboardPage() {
         activeCard={activeDrilldown}
         totalScans={stats.total_scans}
         completedCount={completedCount}
-        watchlistCount={stats.watchlist_count}
+        watchlistCount={
+          activeDrilldown === 'watchlist_attention'
+            ? watchlistAttentionCount
+            : stats.watchlist_count
+        }
         recentActivityRange={recentActivityRange}
         onRecentActivityRangeChange={handleRecentActivityRangeChange}
         recentActivityRangeLabel={recentActivityRangeLabel}

--- a/services/frontend/app/(app)/scans/[id]/page.tsx
+++ b/services/frontend/app/(app)/scans/[id]/page.tsx
@@ -482,6 +482,13 @@ function scanImageHref(imageName: string) {
   return `/scans/images/${imageName.split('/').map(encodeURIComponent).join('/')}`;
 }
 
+function isAbortError(error: unknown): boolean {
+  return (
+    (error instanceof Error && error.name === 'AbortError') ||
+    (typeof error === 'object' && error !== null && 'name' in error && error.name === 'AbortError')
+  );
+}
+
 function ScanOverviewMetric({
   label,
   value,
@@ -567,7 +574,12 @@ export default function ScanDetailPage() {
   const [shareVisibility, setShareVisibility] = useState<'public' | 'authenticated'>('public');
   const [shareCopied, setShareCopied] = useState(false);
   const loadVersionRef = useRef(0);
-  const loadScanInFlightRef = useRef<Promise<Scan> | null>(null);
+  const loadScanInFlightRef = useRef<{
+    controller: AbortController;
+    id: string;
+    promise: Promise<Scan>;
+    version: number;
+  } | null>(null);
   const defaultTabInitializedRef = useRef(false);
   const vulnerabilityViewInitializedRef = useRef(false);
   const vulnerabilityViewScopeKeyRef = useRef('');
@@ -605,6 +617,23 @@ export default function ScanDetailPage() {
 
   const pkgDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const cveDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const vulnerabilityRequestRef = useRef<{
+    version: number;
+    controller: AbortController;
+  } | null>(null);
+  const vulnerabilityRequestVersionRef = useRef(0);
+  const vulnerabilitySummaryRequestRef = useRef<{
+    version: number;
+    controller: AbortController;
+  } | null>(null);
+  const vulnerabilitySummaryRequestVersionRef = useRef(0);
+  const complianceRequestRef = useRef<{
+    id: string;
+    version: number;
+    controller: AbortController;
+  } | null>(null);
+  const complianceRequestVersionRef = useRef(0);
+  const currentScanIdRef = useRef(id);
   const scanStatus = scan?.status;
   const activeWorkScopeOrgId = workScope.kind === 'org' ? workScope.orgId : '';
   const vulnerabilityViewScopeKey =
@@ -671,6 +700,10 @@ export default function ScanDetailPage() {
     advancedVulnerabilityFilterCount > 0;
 
   useEffect(() => {
+    currentScanIdRef.current = id;
+  }, [id]);
+
+  useEffect(() => {
     setRouteContext({
       scopeType: 'scan',
       scopeRef: id,
@@ -696,12 +729,15 @@ export default function ScanDetailPage() {
   useEffect(() => () => setOverlayContext(null), [setOverlayContext]);
 
   const loadScan = useCallback(async () => {
-    if (loadScanInFlightRef.current) {
-      return loadScanInFlightRef.current;
+    const currentRequest = loadScanInFlightRef.current;
+    if (currentRequest?.id === id) {
+      return currentRequest.promise;
     }
 
+    currentRequest?.controller.abort();
     const loadVersion = ++loadVersionRef.current;
-    const request = getScan(id)
+    const controller = new AbortController();
+    const request = getScan(id, { signal: controller.signal })
       .then((nextScan) => {
         if (loadVersion === loadVersionRef.current) {
           setScan(nextScan);
@@ -709,14 +745,46 @@ export default function ScanDetailPage() {
         return nextScan;
       })
       .finally(() => {
-        if (loadScanInFlightRef.current === request) {
+        if (loadScanInFlightRef.current?.version === loadVersion) {
           loadScanInFlightRef.current = null;
         }
       });
 
-    loadScanInFlightRef.current = request;
+    loadScanInFlightRef.current = { controller, id, promise: request, version: loadVersion };
     return request;
   }, [id]);
+
+  const loadComplianceForScan = useCallback((scanId: string) => {
+    if (currentScanIdRef.current !== scanId) {
+      return Promise.resolve([] as ComplianceResult[]);
+    }
+
+    complianceRequestRef.current?.controller.abort();
+    const requestVersion = ++complianceRequestVersionRef.current;
+    const controller = new AbortController();
+    const request = { id: scanId, version: requestVersion, controller };
+    complianceRequestRef.current = request;
+
+    return getScanCompliance(scanId, { signal: controller.signal })
+      .then((results) => {
+        if (
+          currentScanIdRef.current === scanId &&
+          complianceRequestRef.current?.id === scanId &&
+          complianceRequestRef.current.version === requestVersion
+        ) {
+          setCompliance(results);
+        }
+        return results;
+      })
+      .finally(() => {
+        if (
+          complianceRequestRef.current?.id === scanId &&
+          complianceRequestRef.current.version === requestVersion
+        ) {
+          complianceRequestRef.current = null;
+        }
+      });
+  }, []);
 
   const applyVulnerabilityViewPreference = useCallback(
     (preference: VulnerabilityViewPreferenceResponse) => {
@@ -740,6 +808,9 @@ export default function ScanDetailPage() {
 
   useEffect(() => {
     return deferEffect(() => {
+      setLoading(true);
+      setError('');
+      setScan(null);
       defaultTabInitializedRef.current = false;
       vulnerabilityViewInitializedRef.current = false;
       setActiveTab('vulns');
@@ -759,6 +830,7 @@ export default function ScanDetailPage() {
       setComplianceVulnById({});
       setComplianceVulnLoaded(false);
       setComplianceVulnLoading(false);
+      setComplianceLoading(false);
       setPolicyImpact(null);
       appliedRouteVulnerabilityFocusKeyRef.current = '';
     });
@@ -766,19 +838,40 @@ export default function ScanDetailPage() {
 
   // Initial load
   useEffect(() => {
+    let cancelled = false;
     loadScan()
-      .catch((e: Error) => setError(e.message))
-      .finally(() => setLoading(false));
+      .catch((e: unknown) => {
+        if (!cancelled && !isAbortError(e)) {
+          setError(e instanceof Error ? e.message : 'Failed to load scan');
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
     listTags()
-      .then(setAllTags)
+      .then((tags) => {
+        if (!cancelled) setAllTags(tags);
+      })
       .catch(() => {});
-    getScanCompliance(id)
-      .then(setCompliance)
-      .catch(() => {});
+    loadComplianceForScan(id).catch(() => {});
     listOrgs()
-      .then(setAllOrgs)
+      .then((orgs) => {
+        if (!cancelled) setAllOrgs(orgs);
+      })
       .catch(() => {});
-  }, [id, loadScan]);
+
+    return () => {
+      cancelled = true;
+      if (loadScanInFlightRef.current?.id === id) {
+        loadScanInFlightRef.current.controller.abort();
+      }
+      if (complianceRequestRef.current?.id === id) {
+        complianceRequestVersionRef.current += 1;
+        complianceRequestRef.current.controller.abort();
+        complianceRequestRef.current = null;
+      }
+    };
+  }, [id, loadComplianceForScan, loadScan]);
 
   useEffect(() => {
     let cancelled = false;
@@ -803,13 +896,11 @@ export default function ScanDetailPage() {
     void loadScan()
       .then((nextScan) => {
         if (nextScan.status === 'completed' || nextScan.status === 'failed') {
-          void getScanCompliance(id)
-            .then(setCompliance)
-            .catch(() => {});
+          void loadComplianceForScan(id).catch(() => {});
         }
       })
       .catch(() => {});
-  }, [id, loadScan]);
+  }, [id, loadComplianceForScan, loadScan]);
 
   useConditionalInterval(
     refreshActiveScan,
@@ -999,8 +1090,18 @@ export default function ScanDetailPage() {
   }, [expandedVuln]);
 
   function loadVulns() {
-    if (!scan || scan.status === 'pending' || scan.status === 'running' || !viewSettingsReady)
+    const previousRequest = vulnerabilityRequestRef.current;
+    previousRequest?.controller.abort();
+    const requestVersion = ++vulnerabilityRequestVersionRef.current;
+
+    if (!scan || scan.status === 'pending' || scan.status === 'running' || !viewSettingsReady) {
+      vulnerabilityRequestRef.current = null;
+      setVulnLoading(false);
       return;
+    }
+
+    const controller = new AbortController();
+    vulnerabilityRequestRef.current = { controller, version: requestVersion };
     setVulnLoading(true);
     setVulnError('');
     const severityParts = severityFilter
@@ -1053,7 +1154,9 @@ export default function ScanDetailPage() {
           const all: Vulnerability[] = [];
 
           for (;;) {
-            const res = await listVulnerabilities(id, nextPage, pageSize, ...baseArgs);
+            const res = await listVulnerabilities(id, nextPage, pageSize, ...baseArgs, {
+              signal: controller.signal,
+            });
             const rows = res.data ?? [];
             total = res.total ?? total;
             all.push(...rows);
@@ -1080,16 +1183,19 @@ export default function ScanDetailPage() {
             : filteredByPolicy;
           const start = (page - 1) * LIMIT;
           const end = start + LIMIT;
-          setFilteredVulnSummaryOverride(summarizeVisibleVulnerabilities(filteredBySuppression));
+          if (vulnerabilityRequestRef.current?.version === requestVersion) {
+            setFilteredVulnSummaryOverride(summarizeVisibleVulnerabilities(filteredBySuppression));
+          }
           return {
             data: filteredBySuppression.slice(start, end),
             total: filteredBySuppression.length,
           };
         })()
-      : listVulnerabilities(id, page, LIMIT, ...baseArgs);
+      : listVulnerabilities(id, page, LIMIT, ...baseArgs, { signal: controller.signal });
 
     loadPromise
       .then((res) => {
+        if (vulnerabilityRequestRef.current?.version !== requestVersion) return;
         const rows = hideSuppressed
           ? (res.data ?? []).filter((vulnerability) => !vulnerability.suppression)
           : (res.data ?? []);
@@ -1097,14 +1203,27 @@ export default function ScanDetailPage() {
         setVulnTotal(res.total ?? rows.length);
       })
       .catch((reason: unknown) => {
+        if (vulnerabilityRequestRef.current?.version !== requestVersion || isAbortError(reason)) {
+          return;
+        }
         setVulnError(reason instanceof Error ? reason.message : 'Failed to load vulnerabilities');
         setFilteredVulnSummaryOverride(null);
       })
-      .finally(() => setVulnLoading(false));
+      .finally(() => {
+        if (vulnerabilityRequestRef.current?.version !== requestVersion) return;
+        vulnerabilityRequestRef.current = null;
+        setVulnLoading(false);
+      });
   }
 
   useEffect(() => {
-    return deferEffect(loadVulns);
+    const cancelDeferred = deferEffect(loadVulns);
+    return () => {
+      cancelDeferred();
+      vulnerabilityRequestRef.current?.controller.abort();
+      vulnerabilityRequestRef.current = null;
+      vulnerabilityRequestVersionRef.current += 1;
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     id,
@@ -1128,7 +1247,21 @@ export default function ScanDetailPage() {
   ]);
 
   useEffect(() => {
-    return deferEffect(() => {
+    const requestVersion = ++vulnerabilitySummaryRequestVersionRef.current;
+    vulnerabilitySummaryRequestRef.current?.controller.abort();
+    vulnerabilitySummaryRequestRef.current = null;
+
+    const invalidateRequest = () => {
+      if (vulnerabilitySummaryRequestVersionRef.current !== requestVersion) return;
+      vulnerabilitySummaryRequestVersionRef.current += 1;
+      if (vulnerabilitySummaryRequestRef.current?.version === requestVersion) {
+        vulnerabilitySummaryRequestRef.current.controller.abort();
+        vulnerabilitySummaryRequestRef.current = null;
+      }
+    };
+
+    const cancelDeferred = deferEffect(() => {
+      if (vulnerabilitySummaryRequestVersionRef.current !== requestVersion) return;
       if (!scan || scan.status === 'pending' || scan.status === 'running' || !viewSettingsReady) {
         setVulnSummary(null);
         return;
@@ -1138,17 +1271,51 @@ export default function ScanDetailPage() {
         return;
       }
 
+      const controller = new AbortController();
+      vulnerabilitySummaryRequestRef.current = { controller, version: requestVersion };
+
       getVulnerabilitySummary(
         id,
         severityFilter || undefined,
         pkgFilter || undefined,
         hasFix || undefined,
         minCvss || undefined,
-        intelligenceFilter === 'all' ? undefined : intelligenceFilter
+        intelligenceFilter === 'all' ? undefined : intelligenceFilter,
+        { signal: controller.signal }
       )
-        .then(setVulnSummary)
-        .catch(() => setVulnSummary(null));
+        .then((summary) => {
+          if (
+            vulnerabilitySummaryRequestVersionRef.current === requestVersion &&
+            vulnerabilitySummaryRequestRef.current?.version === requestVersion
+          ) {
+            setVulnSummary(summary);
+          }
+        })
+        .catch((reason: unknown) => {
+          if (
+            vulnerabilitySummaryRequestVersionRef.current === requestVersion &&
+            vulnerabilitySummaryRequestRef.current?.version === requestVersion &&
+            !isAbortError(reason)
+          ) {
+            setVulnSummary(null);
+          }
+        })
+        .finally(() => {
+          if (
+            vulnerabilitySummaryRequestVersionRef.current === requestVersion &&
+            vulnerabilitySummaryRequestRef.current?.version === requestVersion
+          ) {
+            vulnerabilitySummaryRequestRef.current = null;
+          }
+        });
+
+      return invalidateRequest;
     });
+
+    return () => {
+      cancelDeferred();
+      invalidateRequest();
+    };
   }, [
     filteredVulnSummaryOverride,
     hasFix,
@@ -1345,22 +1512,25 @@ export default function ScanDetailPage() {
   async function handleAssignOrg(orgId: string) {
     if (!canMutateScan()) return;
     await assignScanToOrg(orgId, id).catch(() => {});
-    const results = await getScanCompliance(id).catch(() => [] as ComplianceResult[]);
-    setCompliance(results);
+    await loadComplianceForScan(id).catch(() => {});
   }
 
   async function handleRemoveOrg(orgId: string) {
     if (!canMutateScan()) return;
     await removeScanFromOrg(orgId, id).catch(() => {});
-    setCompliance((c) => c.filter((r) => r.org_id !== orgId));
+    if (currentScanIdRef.current === id) {
+      setCompliance((c) => c.filter((r) => r.org_id !== orgId));
+    }
   }
 
   async function handleReEvaluate() {
     if (!canMutateScan()) return;
     setComplianceLoading(true);
     const results = await reEvaluateCompliance(id).catch(() => [] as ComplianceResult[]);
-    setCompliance(results);
-    setComplianceLoading(false);
+    if (currentScanIdRef.current === id) {
+      setCompliance(results);
+      setComplianceLoading(false);
+    }
   }
 
   async function handleReScan() {
@@ -1398,8 +1568,7 @@ export default function ScanDetailPage() {
       setComplianceVulnLoaded(false);
       setComplianceVulnLoading(false);
       setPage(1);
-      const results = await getScanCompliance(id).catch(() => [] as ComplianceResult[]);
-      setCompliance(results);
+      await loadComplianceForScan(id).catch(() => {});
       const suffix = result.violation_count === 1 ? 'violation' : 'violations';
       toast.success(`Xray policy data refreshed (${result.violation_count} ${suffix})`);
     } catch (e: unknown) {

--- a/services/frontend/app/(app)/scans/images/[...image]/page.tsx
+++ b/services/frontend/app/(app)/scans/images/[...image]/page.tsx
@@ -32,6 +32,7 @@ import {
   Disclosure,
   Label,
   ListBox,
+  Pagination,
   SearchField,
   Select,
   Skeleton,
@@ -63,6 +64,8 @@ const STATUS_OPTIONS = [
   { id: 'cancelled', label: 'Cancelled' },
 ];
 
+const ARTIFACT_PAGE_SIZE = 30;
+
 function decodeImage(parts: string[] | undefined) {
   return (parts ?? [])
     .map((part) => {
@@ -79,6 +82,12 @@ function formatDuration(durationMs: number) {
   const seconds = Math.max(0, Math.round(durationMs / 1000));
   if (seconds < 60) return `${seconds}s`;
   return `${Math.floor(seconds / 60)}m ${seconds % 60}s`;
+}
+
+function visiblePageNumbers(totalPages: number, currentPage: number) {
+  const start = Math.max(1, currentPage - 2);
+  const end = Math.min(totalPages, currentPage + 2);
+  return Array.from({ length: Math.max(0, end - start + 1) }, (_, index) => start + index);
 }
 
 function Metric({
@@ -118,6 +127,7 @@ export default function ImageScansPage() {
   const [stats, setStats] = useState<ImageStats | null>(null);
   const [artifacts, setArtifacts] = useState<ArtifactSummary[]>([]);
   const [total, setTotal] = useState(0);
+  const [artifactPage, setArtifactPage] = useState(1);
   const [loading, setLoading] = useState(true);
   const [statsLoading, setStatsLoading] = useState(true);
   const [error, setError] = useState('');
@@ -135,6 +145,7 @@ export default function ImageScansPage() {
   const bounds = useMemo(() => (range ? getRecentActivityBounds(range) : null), [range]);
   const filterCount = [policy, range].filter(Boolean).length;
   const hasFilters = Boolean(query || status || critical || policy || range);
+  const artifactTotalPages = Math.max(1, Math.ceil(total / ARTIFACT_PAGE_SIZE));
 
   useEffect(
     () =>
@@ -173,8 +184,8 @@ export default function ImageScansPage() {
         setLoading(true);
         setError('');
         void listScanArtifacts(
-          1,
-          100,
+          artifactPage,
+          ARTIFACT_PAGE_SIZE,
           query || undefined,
           status || undefined,
           critical,
@@ -200,7 +211,26 @@ export default function ImageScansPage() {
           cancelled = true;
         };
       }),
-    [bounds?.from, bounds?.to, critical, imageName, policy, query, refreshKey, scopeKey, status]
+    [
+      artifactPage,
+      bounds?.from,
+      bounds?.to,
+      critical,
+      imageName,
+      policy,
+      query,
+      refreshKey,
+      scopeKey,
+      status,
+    ]
+  );
+
+  useEffect(
+    () =>
+      deferEffect(() => {
+        setArtifactPage(1);
+      }),
+    [bounds?.from, bounds?.to, critical, imageName, policy, query, scopeKey, status]
   );
 
   async function confirmDelete() {
@@ -553,6 +583,48 @@ export default function ImageScansPage() {
           selectedScans={selectedScans}
         />
       </Card>
+      {total > 0 ? (
+        <Pagination size="sm" className="flex-wrap justify-between gap-3">
+          <Pagination.Summary className="text-xs text-muted">
+            Showing {(artifactPage - 1) * ARTIFACT_PAGE_SIZE + 1}-
+            {Math.min(artifactPage * ARTIFACT_PAGE_SIZE, total)} of {total} tags
+          </Pagination.Summary>
+          {artifactTotalPages > 1 ? (
+            <Pagination.Content>
+              <Pagination.Item>
+                <Pagination.Previous
+                  isDisabled={artifactPage === 1}
+                  onPress={() => setArtifactPage((current) => Math.max(1, current - 1))}
+                >
+                  <Pagination.PreviousIcon />
+                  <span>Previous</span>
+                </Pagination.Previous>
+              </Pagination.Item>
+              {visiblePageNumbers(artifactTotalPages, artifactPage).map((value) => (
+                <Pagination.Item key={value}>
+                  <Pagination.Link
+                    isActive={value === artifactPage}
+                    onPress={() => setArtifactPage(value)}
+                  >
+                    {value}
+                  </Pagination.Link>
+                </Pagination.Item>
+              ))}
+              <Pagination.Item>
+                <Pagination.Next
+                  isDisabled={artifactPage === artifactTotalPages}
+                  onPress={() =>
+                    setArtifactPage((current) => Math.min(artifactTotalPages, current + 1))
+                  }
+                >
+                  <span>Next</span>
+                  <Pagination.NextIcon />
+                </Pagination.Next>
+              </Pagination.Item>
+            </Pagination.Content>
+          ) : null}
+        </Pagination>
+      ) : null}
     </PageContainer>
   );
 }

--- a/services/frontend/app/(app)/watchlist/page.tsx
+++ b/services/frontend/app/(app)/watchlist/page.tsx
@@ -447,9 +447,14 @@ export default function WatchlistPage() {
       variant: 'danger',
     });
     if (!ok) return;
-    await deleteWatchlistItem(id).catch(() => {});
-    toast.success('Removed from watchlist');
-    load();
+    try {
+      await deleteWatchlistItem(id);
+      await load();
+      toast.success('Removed from watchlist');
+    } catch (error: unknown) {
+      toast.error(error instanceof Error ? error.message : 'Failed to remove from watchlist');
+      await load();
+    }
   }
   async function handleTrigger(id: string) {
     const item = items.find((candidate) => candidate.id === id);
@@ -457,12 +462,13 @@ export default function WatchlistPage() {
     setTriggering(id);
     try {
       await triggerWatchlistScan(id);
+      await load();
       toast.success('Scan triggered');
-    } catch {
-      /* ignore */
+    } catch (error: unknown) {
+      toast.error(error instanceof Error ? error.message : 'Failed to trigger scan');
+      await load();
     } finally {
       setTriggering('');
-      load();
     }
   }
 
@@ -1052,12 +1058,6 @@ export default function WatchlistPage() {
                   </div>
                   {registryOptions.length > 0 && (
                     <div className="space-y-1.5">
-                      <label className="text-sm font-medium">
-                        Registry{' '}
-                        <span className="text-zinc-400 dark:text-zinc-600 font-normal">
-                          (optional)
-                        </span>
-                      </label>
                       <Select
                         value={registryId || '__none__'}
                         onChange={(value) =>
@@ -1065,6 +1065,12 @@ export default function WatchlistPage() {
                         }
                         className="pt-1"
                       >
+                        <Label className="text-sm font-medium">
+                          Registry{' '}
+                          <span className="text-zinc-400 dark:text-zinc-600 font-normal">
+                            (optional)
+                          </span>
+                        </Label>
                         <Select.Trigger className={selectTriggerCls + ' bg-surface-secondary'}>
                           <Select.Value />
                           <Select.Indicator />

--- a/services/frontend/components/dashboard/dashboard-drilldown-modal.tsx
+++ b/services/frontend/components/dashboard/dashboard-drilldown-modal.tsx
@@ -10,12 +10,13 @@ import { getWatchlistPosture } from '@/lib/watchlist-posture';
 import { Button, Card, Chip, Link as HeroLink, Modal, useOverlayState } from '@heroui/react';
 import { CheckmarkCircle02Icon, Clock01Icon, Shield01Icon } from 'hugeicons-react';
 
-export type DashboardDrilldownKey = 'total' | 'completed' | 'watchlist';
+export type DashboardDrilldownKey = 'total' | 'completed' | 'watchlist' | 'watchlist_attention';
 
 const drilldownHeaderMeta = {
   total: { Icon: Shield01Icon, className: 'bg-default text-foreground' },
   completed: { Icon: CheckmarkCircle02Icon, className: 'bg-success/10 text-success' },
   watchlist: { Icon: Clock01Icon, className: 'bg-warning/10 text-warning' },
+  watchlist_attention: { Icon: Clock01Icon, className: 'bg-danger/10 text-danger' },
 } satisfies Record<DashboardDrilldownKey, { Icon: typeof Shield01Icon; className: string }>;
 
 function WatchlistModalRow({ item }: { item: WatchlistItem }) {
@@ -84,11 +85,13 @@ function WatchlistModalList({
   watchlistLoading,
   watchlistItems,
   displayedWatchlistItems,
+  attentionOnly,
 }: {
   watchlistError: string;
   watchlistLoading: boolean;
   watchlistItems: WatchlistItem[];
   displayedWatchlistItems: WatchlistItem[];
+  attentionOnly: boolean;
 }) {
   if (watchlistError) {
     return (
@@ -114,7 +117,9 @@ function WatchlistModalList({
     return (
       <Card variant="secondary">
         <Card.Content className="py-8 text-center text-sm text-muted">
-          No watchlist items in this scope.
+          {attentionOnly
+            ? 'No watchlist items need attention in this scope.'
+            : 'No watchlist items in this scope.'}
         </Card.Content>
       </Card>
     );
@@ -150,11 +155,13 @@ function WatchlistBody({
   watchlistLoading,
   watchlistItems,
   displayedWatchlistItems,
+  attentionOnly,
 }: {
   watchlistError: string;
   watchlistLoading: boolean;
   watchlistItems: WatchlistItem[];
   displayedWatchlistItems: WatchlistItem[];
+  attentionOnly: boolean;
 }) {
   return (
     <div className="space-y-3">
@@ -169,6 +176,7 @@ function WatchlistBody({
         watchlistLoading={watchlistLoading}
         watchlistItems={watchlistItems}
         displayedWatchlistItems={displayedWatchlistItems}
+        attentionOnly={attentionOnly}
       />
     </div>
   );
@@ -296,25 +304,38 @@ export function DashboardDrilldownModal({
 }: DashboardDrilldownModalProps) {
   if (!activeCard) return null;
 
-  const isWatchlist = activeCard === 'watchlist';
+  const isWatchlist = activeCard === 'watchlist' || activeCard === 'watchlist_attention';
+  const isWatchlistAttention = activeCard === 'watchlist_attention';
   const heading =
     activeCard === 'total'
       ? 'Recent scans'
       : activeCard === 'completed'
         ? 'Completed scans'
-        : 'Watchlist';
+        : isWatchlistAttention
+          ? 'Watchlist attention'
+          : 'Watchlist';
   const description =
     activeCard === 'total'
       ? `${totalScans.toLocaleString()} total scans overall. Showing activity from ${recentActivityRangeLabel.toLowerCase()}.`
       : activeCard === 'completed'
         ? `${completedCount.toLocaleString()} completed scans overall. Showing completions from ${recentActivityRangeLabel.toLowerCase()}.`
-        : `${watchlistCount.toLocaleString()} watchlist item${watchlistCount === 1 ? '' : 's'} in the current scope.`;
+        : isWatchlistAttention
+          ? `${watchlistCount.toLocaleString()} watchlist item${watchlistCount === 1 ? '' : 's'} need attention in the current scope.`
+          : `${watchlistCount.toLocaleString()} watchlist item${watchlistCount === 1 ? '' : 's'} in the current scope.`;
   const emptyMessage =
     activeCard === 'completed'
       ? `No completed scans in ${recentActivityRangeLabel.toLowerCase()}.`
       : `No scans started in ${recentActivityRangeLabel.toLowerCase()}.`;
-  const primaryHref = isWatchlist ? '/watchlist' : recentActivityHref;
-  const primaryLabel = isWatchlist ? 'Open watchlist' : 'Open full list';
+  const primaryHref = isWatchlist
+    ? isWatchlistAttention
+      ? '/watchlist?focus=attention'
+      : '/watchlist'
+    : recentActivityHref;
+  const primaryLabel = isWatchlist
+    ? isWatchlistAttention
+      ? 'Open attention items'
+      : 'Open watchlist'
+    : 'Open full list';
   const displayedWatchlistItems = isWatchlist
     ? watchlistItems.toSorted((left, right) => {
         const rank = (item: WatchlistItem) => {
@@ -362,6 +383,7 @@ export function DashboardDrilldownModal({
                   watchlistLoading={watchlistLoading}
                   watchlistItems={watchlistItems}
                   displayedWatchlistItems={displayedWatchlistItems}
+                  attentionOnly={isWatchlistAttention}
                 />
               ) : (
                 <>

--- a/services/frontend/lib/api/base.ts
+++ b/services/frontend/lib/api/base.ts
@@ -1,4 +1,4 @@
-const DEFAULT_API = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:8080';
+const DEFAULT_API = process.env.NEXT_PUBLIC_API_URL?.trim() || 'http://localhost:8080';
 
 const LOCAL_HOSTS = new Set(['localhost', '127.0.0.1', '::1']);
 
@@ -20,6 +20,13 @@ function shouldUseConfiguredApiInBrowser(configuredApi: string): boolean {
     if (configuredIsLocal && currentIsLocal) {
       return configured.port !== current.port || configured.protocol !== current.protocol;
     }
+
+    // An explicitly configured non-local API is the backend for remote deployments. Keep using
+    // it even when the frontend itself is served from another origin; otherwise browser requests
+    // silently fall back to the frontend origin and bypass the configured backend entirely.
+    if (!configuredIsLocal) {
+      return true;
+    }
   } catch {
     return false;
   }
@@ -36,4 +43,3 @@ export function getApiBase(): string {
   // Same-origin in browser by default for multi-ingress host affinity.
   return '';
 }
-

--- a/services/frontend/lib/api/core.ts
+++ b/services/frontend/lib/api/core.ts
@@ -4,6 +4,8 @@ import { getApiBase } from './base';
 
 export const API = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:8080';
 
+export type ApiRequestOptions = Pick<RequestInit, 'signal'>;
+
 type ApiErrorPayload = {
   message?: string;
   error?: string;
@@ -43,15 +45,23 @@ function authHeadersWithoutContentType(): HeadersInit {
 }
 
 async function getErrorMessage(response: Response): Promise<string> {
-  const error = await response.json().catch(() => ({ error: response.statusText })) as ApiErrorPayload;
+  const error = (await response
+    .json()
+    .catch(() => ({ error: response.statusText }))) as ApiErrorPayload;
   return error.message ?? error.error_description ?? error.error ?? response.statusText;
 }
 
-export async function req<T>(method: string, path: string, body?: unknown): Promise<T> {
+export async function req<T>(
+  method: string,
+  path: string,
+  body?: unknown,
+  options?: ApiRequestOptions
+): Promise<T> {
   const response = await fetch(`${getApiBase()}${path}`, {
     method,
     headers: authHeaders(),
     body: body !== undefined ? JSON.stringify(body) : undefined,
+    ...options,
   });
 
   if (response.status === 401) {
@@ -70,11 +80,17 @@ export async function req<T>(method: string, path: string, body?: unknown): Prom
   return parseResponseBody<T>(response);
 }
 
-export async function reqForm<T>(method: string, path: string, body: FormData): Promise<T> {
+export async function reqForm<T>(
+  method: string,
+  path: string,
+  body: FormData,
+  options?: ApiRequestOptions
+): Promise<T> {
   const response = await fetch(`${getApiBase()}${path}`, {
     method,
     headers: authHeadersWithoutContentType(),
     body,
+    ...options,
   });
 
   if (response.status === 401) {
@@ -93,11 +109,17 @@ export async function reqForm<T>(method: string, path: string, body: FormData): 
   return parseResponseBody<T>(response);
 }
 
-export async function publicReq<T>(method: string, path: string, body?: unknown): Promise<T> {
+export async function publicReq<T>(
+  method: string,
+  path: string,
+  body?: unknown,
+  options?: ApiRequestOptions
+): Promise<T> {
   const response = await fetch(`${getApiBase()}${path}`, {
     method,
     headers: { 'Content-Type': 'application/json' },
     body: body !== undefined ? JSON.stringify(body) : undefined,
+    ...options,
   });
 
   if (!response.ok) {
@@ -108,17 +130,26 @@ export async function publicReq<T>(method: string, path: string, body?: unknown)
 }
 
 export class ApiError extends Error {
-  constructor(public status: number, message: string) {
+  constructor(
+    public status: number,
+    message: string
+  ) {
     super(message);
     this.name = 'ApiError';
   }
 }
 
-export async function sharedReq<T>(method: string, path: string, body?: unknown): Promise<T> {
+export async function sharedReq<T>(
+  method: string,
+  path: string,
+  body?: unknown,
+  options?: ApiRequestOptions
+): Promise<T> {
   const response = await fetch(`${getApiBase()}${path}`, {
     method,
     headers: authHeaders(),
     body: body !== undefined ? JSON.stringify(body) : undefined,
+    ...options,
   });
 
   if (!response.ok) {

--- a/services/frontend/lib/api/dashboard.ts
+++ b/services/frontend/lib/api/dashboard.ts
@@ -1,4 +1,4 @@
-import { req } from './core';
+import { req, type ApiRequestOptions } from './core';
 import { appendScope } from './scope';
 import type {
   DashboardStats,
@@ -7,31 +7,44 @@ import type {
   ScannerHealth,
 } from './types/dashboard';
 
-export const getStats = () => {
+export const getStats = (options?: ApiRequestOptions) => {
   const params = new URLSearchParams();
   appendScope(params);
   const qs = params.toString();
-  return req<DashboardStats>('GET', `/api/v1/dashboard/stats${qs ? `?${qs}` : ''}`);
+  return req<DashboardStats>(
+    'GET',
+    `/api/v1/dashboard/stats${qs ? `?${qs}` : ''}`,
+    undefined,
+    options
+  );
 };
 
-export const getScannerHealth = () => req<ScannerHealth>('GET', '/api/v1/dashboard/scanner-health');
+export const getScannerHealth = (options?: ApiRequestOptions) =>
+  req<ScannerHealth>('GET', '/api/v1/dashboard/scanner-health', undefined, options);
 
-export const getDashboardTrends = (range: '6h' | '24h' | '7d' | '30d' = '30d') => {
+export const getDashboardTrends = (
+  range: '6h' | '24h' | '7d' | '30d' = '30d',
+  options?: ApiRequestOptions
+) => {
   const params = new URLSearchParams();
   params.set('range', range);
   appendScope(params);
   const qs = params.toString();
   return req<{ data: DashboardTrendPoint[] }>(
     'GET',
-    `/api/v1/dashboard/trends${qs ? `?${qs}` : ''}`
+    `/api/v1/dashboard/trends${qs ? `?${qs}` : ''}`,
+    undefined,
+    options
   ).then((result) => result.data ?? []);
 };
 
-export const getDashboardVulnTrends = (days = 30) => {
+export const getDashboardVulnTrends = (days = 30, options?: ApiRequestOptions) => {
   const params = new URLSearchParams({ days: String(days) });
   appendScope(params);
   return req<{ data: DashboardVulnTrendPoint[] }>(
     'GET',
-    `/api/v1/dashboard/vuln-trends?${params.toString()}`
+    `/api/v1/dashboard/vuln-trends?${params.toString()}`,
+    undefined,
+    options
   ).then((result) => result.data ?? []);
 };

--- a/services/frontend/lib/api/orgs.ts
+++ b/services/frontend/lib/api/orgs.ts
@@ -1,6 +1,19 @@
-import { req } from './core';
+import { req, type ApiRequestOptions } from './core';
 import { notifyOrgMembershipChanged } from './scope';
-import type { AuditEntry, ComplianceResult, Org, OrgInvite, OrgMember, OrgPolicy, OrgRiskScore, OrgRole, PipelineScanHistoryItem, PolicyRule, TrendPoint, VulnerabilityViewSettings } from './types/orgs';
+import type {
+  AuditEntry,
+  ComplianceResult,
+  Org,
+  OrgInvite,
+  OrgMember,
+  OrgPolicy,
+  OrgRiskScore,
+  OrgRole,
+  PipelineScanHistoryItem,
+  PolicyRule,
+  TrendPoint,
+  VulnerabilityViewSettings,
+} from './types/orgs';
 import type { Scan } from './types/scans';
 
 export const listOrgs = () =>
@@ -12,14 +25,20 @@ export const createOrg = (name: string, description: string) =>
     return org;
   });
 
-export const getOrg = (id: string) =>
-  req<Org>('GET', `/api/v1/orgs/${id}`);
+export const getOrg = (id: string) => req<Org>('GET', `/api/v1/orgs/${id}`);
 
 export const updateOrg = (id: string, data: Partial<Org>) =>
   req<Org>('PUT', `/api/v1/orgs/${id}`, data);
 
-export const updateOrgVulnerabilityViewSettings = (id: string, settings: VulnerabilityViewSettings) =>
-  req<{ settings: VulnerabilityViewSettings }>('PUT', `/api/v1/orgs/${id}/vulnerability-view`, settings);
+export const updateOrgVulnerabilityViewSettings = (
+  id: string,
+  settings: VulnerabilityViewSettings
+) =>
+  req<{ settings: VulnerabilityViewSettings }>(
+    'PUT',
+    `/api/v1/orgs/${id}/vulnerability-view`,
+    settings
+  );
 
 export const deleteOrg = (id: string) =>
   req<{ result: string }>('DELETE', `/api/v1/orgs/${id}`).then((result) => {
@@ -28,7 +47,9 @@ export const deleteOrg = (id: string) =>
   });
 
 export const listOrgMembers = (orgId: string) =>
-  req<{ data: OrgMember[] }>('GET', `/api/v1/orgs/${orgId}/members`).then((result) => result.data ?? []);
+  req<{ data: OrgMember[] }>('GET', `/api/v1/orgs/${orgId}/members`).then(
+    (result) => result.data ?? []
+  );
 
 export const updateOrgMemberRole = (orgId: string, userId: string, role: OrgRole) =>
   req<{ result: string }>('PATCH', `/api/v1/orgs/${orgId}/members/${userId}`, { role });
@@ -37,13 +58,18 @@ export const removeOrgMember = (orgId: string, userId: string) =>
   req<{ result: string }>('DELETE', `/api/v1/orgs/${orgId}/members/${userId}`);
 
 export const listOrgInvites = (orgId: string) =>
-  req<{ data: OrgInvite[] }>('GET', `/api/v1/orgs/${orgId}/invites`).then((result) => result.data ?? []);
+  req<{ data: OrgInvite[] }>('GET', `/api/v1/orgs/${orgId}/invites`).then(
+    (result) => result.data ?? []
+  );
 
 export const listMyOrgInvites = () =>
   req<{ data: OrgInvite[] }>('GET', '/api/v1/orgs/invites').then((result) => result.data ?? []);
 
-export const createOrgInvite = (orgId: string, email: string, role: Extract<OrgRole, 'admin' | 'editor' | 'viewer'>) =>
-  req<OrgInvite>('POST', `/api/v1/orgs/${orgId}/invites`, { email, role });
+export const createOrgInvite = (
+  orgId: string,
+  email: string,
+  role: Extract<OrgRole, 'admin' | 'editor' | 'viewer'>
+) => req<OrgInvite>('POST', `/api/v1/orgs/${orgId}/invites`, { email, role });
 
 export const revokeOrgInvite = (orgId: string, inviteId: string) =>
   req<{ result: string }>('DELETE', `/api/v1/orgs/${orgId}/invites/${inviteId}`);
@@ -55,19 +81,27 @@ export const declineOrgInvite = (inviteId: string) =>
   });
 
 export const acceptOrgInvite = (inviteId: string) =>
-  req<{ result: string; org_id: string; org_name?: string; role: OrgRole }>('POST', `/api/v1/orgs/invites/${inviteId}/accept`).then((result) => {
+  req<{ result: string; org_id: string; org_name?: string; role: OrgRole }>(
+    'POST',
+    `/api/v1/orgs/invites/${inviteId}/accept`
+  ).then((result) => {
     notifyOrgMembershipChanged();
     return result;
   });
 
 export const acceptOrgInviteByToken = (token: string) =>
-  req<{ result: string; org_id: string; org_name?: string; role: OrgRole }>('POST', `/api/v1/orgs/invites/by-token/${token}/accept`).then((result) => {
+  req<{ result: string; org_id: string; org_name?: string; role: OrgRole }>(
+    'POST',
+    `/api/v1/orgs/invites/by-token/${token}/accept`
+  ).then((result) => {
     notifyOrgMembershipChanged();
     return result;
   });
 
 export const transferOrgOwnership = (orgId: string, newOwnerUserId: string) =>
-  req<{ result: string }>('POST', `/api/v1/orgs/${orgId}/transfer-ownership`, { new_owner_user_id: newOwnerUserId });
+  req<{ result: string }>('POST', `/api/v1/orgs/${orgId}/transfer-ownership`, {
+    new_owner_user_id: newOwnerUserId,
+  });
 
 export const listOrgAuditLog = (orgId: string, page = 1, limit = 50) => {
   const params = new URLSearchParams({ page: String(page), limit: String(limit) });
@@ -111,14 +145,23 @@ export const removeScanFromOrg = (orgId: string, scanId: string) =>
 export const listOrgScans = (orgId: string) =>
   req<{ data: Scan[] }>('GET', `/api/v1/orgs/${orgId}/scans`).then((result) => result.data ?? []);
 
-export const getScanCompliance = (scanId: string) =>
-  req<{ data: ComplianceResult[] }>('GET', `/api/v1/scans/${scanId}/compliance`).then((result) => result.data ?? []);
+export const getScanCompliance = (scanId: string, options?: ApiRequestOptions) =>
+  req<{ data: ComplianceResult[] }>(
+    'GET',
+    `/api/v1/scans/${scanId}/compliance`,
+    undefined,
+    options
+  ).then((result) => result.data ?? []);
 
 export const reEvaluateCompliance = (scanId: string) =>
-  req<{ data: ComplianceResult[] }>('POST', `/api/v1/scans/${scanId}/compliance/evaluate`).then((result) => result.data ?? []);
+  req<{ data: ComplianceResult[] }>('POST', `/api/v1/scans/${scanId}/compliance/evaluate`).then(
+    (result) => result.data ?? []
+  );
 
 export const getComplianceTrend = (orgId: string, days = 30) =>
-  req<{ data: TrendPoint[] }>('GET', `/api/v1/orgs/${orgId}/compliance/trend?days=${days}`).then((result) => result.data ?? []);
+  req<{ data: TrendPoint[] }>('GET', `/api/v1/orgs/${orgId}/compliance/trend?days=${days}`).then(
+    (result) => result.data ?? []
+  );
 
 export const listPipelineScans = (orgId: string, page = 1, limit = 20) =>
   req<{ data: PipelineScanHistoryItem[]; total: number; page: number; limit: number }>(

--- a/services/frontend/lib/api/scans.ts
+++ b/services/frontend/lib/api/scans.ts
@@ -1,4 +1,4 @@
-import { req, reqForm } from './core';
+import { req, reqForm, type ApiRequestOptions } from './core';
 import { appendScope } from './scope';
 import type {
   ResourceShare,
@@ -41,7 +41,8 @@ export const listScans = (
   to?: string,
   imageTag?: string,
   query?: string,
-  intelligence?: 'changed' | 'confirmation_pending'
+  intelligence?: 'changed' | 'confirmation_pending',
+  options?: ApiRequestOptions
 ) => {
   const params = new URLSearchParams({ page: String(page), limit: String(limit) });
   if (image) params.set('image', image);
@@ -55,7 +56,12 @@ export const listScans = (
   if (query) params.set('q', query);
   if (intelligence) params.set('intelligence', intelligence);
   appendScope(params);
-  return req<{ data: Scan[]; total: number }>('GET', `/api/v1/scans/?${params}`);
+  return req<{ data: Scan[]; total: number }>(
+    'GET',
+    `/api/v1/scans/?${params}`,
+    undefined,
+    options
+  );
 };
 
 export const listScanArtifacts = (
@@ -68,7 +74,8 @@ export const listScanArtifacts = (
   image?: string,
   from?: string,
   to?: string,
-  intelligence?: 'changed' | 'confirmation_pending'
+  intelligence?: 'changed' | 'confirmation_pending',
+  options?: ApiRequestOptions
 ) => {
   const params = new URLSearchParams({ page: String(page), limit: String(limit) });
   if (query) params.set('q', query);
@@ -82,7 +89,9 @@ export const listScanArtifacts = (
   appendScope(params);
   return req<{ data: ArtifactSummary[]; total: number; filters: ArtifactFilterOptions }>(
     'GET',
-    `/api/v1/scans/artifacts?${params}`
+    `/api/v1/scans/artifacts?${params}`,
+    undefined,
+    options
   );
 };
 
@@ -96,7 +105,8 @@ export const listScanImages = (
   from?: string,
   to?: string,
   sort?: string,
-  intelligence?: 'changed' | 'confirmation_pending'
+  intelligence?: 'changed' | 'confirmation_pending',
+  options?: ApiRequestOptions
 ) => {
   const params = new URLSearchParams({ page: String(page), limit: String(limit) });
   if (query) params.set('q', query);
@@ -108,7 +118,12 @@ export const listScanImages = (
   if (sort) params.set('sort', sort);
   if (intelligence) params.set('intelligence', intelligence);
   appendScope(params);
-  return req<{ data: ImageOverview[]; total: number }>('GET', `/api/v1/scans/images?${params}`);
+  return req<{ data: ImageOverview[]; total: number }>(
+    'GET',
+    `/api/v1/scans/images?${params}`,
+    undefined,
+    options
+  );
 };
 
 export const getScanImageStats = (image: string) => {
@@ -136,7 +151,8 @@ export const getScanQueueSummary = () => {
   return req<ScanQueueSummary>('GET', `/api/v1/scans/queue-summary${query ? `?${query}` : ''}`);
 };
 
-export const getScan = (id: string) => req<Scan>('GET', `/api/v1/scans/${id}`);
+export const getScan = (id: string, options?: ApiRequestOptions) =>
+  req<Scan>('GET', `/api/v1/scans/${id}`, undefined, options);
 
 export const getScanIntelligencePolicyImpact = (id: string) =>
   req<ScanIntelligencePolicyImpactResponse>(
@@ -215,7 +231,8 @@ export const listVulnerabilities = (
   minCvss?: number,
   sortBy?: string,
   sortDir?: 'asc' | 'desc',
-  intelligence?: string
+  intelligence?: string,
+  options?: ApiRequestOptions
 ) => {
   const params = new URLSearchParams({ page: String(page), limit: String(limit) });
   if (severity) params.set('severity', severity);
@@ -227,7 +244,9 @@ export const listVulnerabilities = (
   if (intelligence && intelligence !== 'all') params.set('intelligence', intelligence);
   return req<{ data: Vulnerability[]; total: number }>(
     'GET',
-    `/api/v1/scans/${scanId}/vulnerabilities?${params}`
+    `/api/v1/scans/${scanId}/vulnerabilities?${params}`,
+    undefined,
+    options
   );
 };
 
@@ -237,7 +256,8 @@ export const getVulnerabilitySummary = (
   pkg?: string,
   hasFix?: boolean,
   minCvss?: number,
-  intelligence?: string
+  intelligence?: string,
+  options?: ApiRequestOptions
 ) => {
   const params = new URLSearchParams();
   if (severity) params.set('severity', severity);
@@ -248,7 +268,9 @@ export const getVulnerabilitySummary = (
   const query = params.toString();
   return req<VulnerabilitySummary>(
     'GET',
-    `/api/v1/scans/${scanId}/vulnerabilities/summary${query ? `?${query}` : ''}`
+    `/api/v1/scans/${scanId}/vulnerabilities/summary${query ? `?${query}` : ''}`,
+    undefined,
+    options
   );
 };
 

--- a/services/frontend/lib/api/watchlist.ts
+++ b/services/frontend/lib/api/watchlist.ts
@@ -1,15 +1,18 @@
-import { req } from './core';
+import { req, type ApiRequestOptions } from './core';
 import { appendScope } from './scope';
 import type { ResourceShare } from './types/orgs';
 import type { WatchlistItem } from './types/watchlist';
 
-export const listWatchlist = () => {
+export const listWatchlist = (options?: ApiRequestOptions) => {
   const params = new URLSearchParams();
   appendScope(params);
   const qs = params.toString();
-  return req<{ data: WatchlistItem[] }>('GET', `/api/v1/watchlist/${qs ? `?${qs}` : ''}`).then(
-    (result) => result.data ?? []
-  );
+  return req<{ data: WatchlistItem[] }>(
+    'GET',
+    `/api/v1/watchlist/${qs ? `?${qs}` : ''}`,
+    undefined,
+    options
+  ).then((result) => result.data ?? []);
 };
 
 export const createWatchlistItem = (data: Partial<WatchlistItem> & { org_id?: string }) =>


### PR DESCRIPTION
## Summary

- Correct post-scan intelligence confirmation and cleanup based on change-event ingestion time.
- Make archive upload chunk writes and completion resilient to crashes, retries, and partial files.
- Repair duplicate migration identifiers and preserve compatibility for renamed scanner settings.
- Separate backend liveness and readiness health checks.

## Testing

- Added backend unit tests for setting resolution, post-scan predicates, dashboard aggregation, migration uniqueness, archive uploads, and scan cleanup.
- Not run