### PR TITLE
Fix legacy scan deletion and dropdown trigger layout

### DIFF
--- a/services/backend/handlers/scans/archive_uploads.go
+++ b/services/backend/handlers/scans/archive_uploads.go
@@ -548,7 +548,7 @@ func loadArchiveUploadSessionsForScans(ctx context.Context, db bun.IDB, scanIDs 
 	if len(scanIDs) == 0 {
 		return nil, nil
 	}
-	exists, err := scanDeletionTableExists(ctx, db, "archive_upload_sessions")
+	exists, err := scanDeletionColumnExists(ctx, db, "archive_upload_sessions", "scan_id")
 	if err != nil {
 		return nil, err
 	}
@@ -583,7 +583,7 @@ func deleteArchiveUploadSessionsForScans(ctx context.Context, db bun.IDB, scanID
 	if len(scanIDs) == 0 {
 		return nil
 	}
-	exists, err := scanDeletionTableExists(ctx, db, "archive_upload_sessions")
+	exists, err := scanDeletionColumnExists(ctx, db, "archive_upload_sessions", "scan_id")
 	if err != nil {
 		return err
 	}

--- a/services/backend/handlers/scans/deletion_test.go
+++ b/services/backend/handlers/scans/deletion_test.go
@@ -14,7 +14,7 @@ import (
 	"justscan-backend/pkg/models"
 )
 
-func TestScanDeletionExplicitlyRemovesFindingAndSBOMDependents(t *testing.T) {
+func TestScanDeletionExplicitlyRemovesCurrentAndLegacyDependents(t *testing.T) {
 	sqldb, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("failed to create mock database: %v", err)
@@ -23,12 +23,12 @@ func TestScanDeletionExplicitlyRemovesFindingAndSBOMDependents(t *testing.T) {
 	db := bun.NewDB(sqldb, pgdialect.New())
 	defer db.Close()
 
-	for range 4 {
-		mock.ExpectQuery("SELECT to_regclass").
+	for range 5 {
+		mock.ExpectQuery("SELECT EXISTS").
 			WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(true))
 		mock.ExpectExec("DELETE FROM").WillReturnResult(sqlmock.NewResult(0, 1))
 	}
-	mock.ExpectQuery("SELECT to_regclass").
+	mock.ExpectQuery("SELECT EXISTS").
 		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(true))
 	mock.ExpectExec("DELETE FROM").WillReturnResult(sqlmock.NewResult(0, 1))
 
@@ -38,6 +38,30 @@ func TestScanDeletionExplicitlyRemovesFindingAndSBOMDependents(t *testing.T) {
 	}
 	if err := deleteScanSBOMDependents(context.Background(), db, scanIDs); err != nil {
 		t.Fatalf("delete SBOM dependents: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestClearScanReferencesSkipsMissingLegacyColumns(t *testing.T) {
+	sqldb, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create mock database: %v", err)
+	}
+	defer sqldb.Close()
+	db := bun.NewDB(sqldb, pgdialect.New())
+	defer db.Close()
+
+	mock.ExpectQuery("SELECT EXISTS").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(false))
+	mock.ExpectQuery("SELECT EXISTS").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(true))
+	mock.ExpectExec("UPDATE git_repository_run_images").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	if err := clearScanReferences(context.Background(), db, []uuid.UUID{uuid.New()}); err != nil {
+		t.Fatalf("clear scan references: %v", err)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatal(err)

--- a/services/backend/handlers/scans/get.go
+++ b/services/backend/handlers/scans/get.go
@@ -170,6 +170,9 @@ func deleteScanRecords(ctx context.Context, db bun.IDB, scanIDs []uuid.UUID) err
 	if err := deleteScanSBOMDependents(ctx, db, scanIDs); err != nil {
 		return err
 	}
+	if err := clearScanReferences(ctx, db, scanIDs); err != nil {
+		return err
+	}
 
 	for _, table := range []string{
 		"archive_upload_sessions",
@@ -188,9 +191,9 @@ func deleteScanRecords(ctx context.Context, db bun.IDB, scanIDs []uuid.UUID) err
 		"xray_request_logs",
 		"pipeline_scan_requests",
 	} {
-		exists, err := scanDeletionTableExists(ctx, db, table)
+		exists, err := scanDeletionColumnExists(ctx, db, table, "scan_id")
 		if err != nil {
-			return fmt.Errorf("check %s: %w", table, err)
+			return fmt.Errorf("check %s.scan_id: %w", table, err)
 		}
 		if !exists {
 			continue
@@ -220,9 +223,9 @@ func deleteScanFindingDependents(ctx context.Context, db bun.IDB, scanIDs []uuid
 		{table: "vulnerability_intelligence_evidence", column: "finding_id"},
 		{table: "vulnerability_component_links", column: "vulnerability_id"},
 	} {
-		exists, err := scanDeletionTableExists(ctx, db, relation.table)
+		exists, err := scanDeletionColumnExists(ctx, db, relation.table, relation.column)
 		if err != nil {
-			return fmt.Errorf("check %s: %w", relation.table, err)
+			return fmt.Errorf("check %s.%s: %w", relation.table, relation.column, err)
 		}
 		if !exists {
 			continue
@@ -234,15 +237,31 @@ func deleteScanFindingDependents(ctx context.Context, db bun.IDB, scanIDs []uuid
 			return fmt.Errorf("delete %s: %w", relation.table, err)
 		}
 	}
+
+	// Early versions of vulnerability intelligence stored the scan reference
+	// directly on posture rows, while finding references could be absent. Delete
+	// those rows explicitly so their legacy foreign key cannot block the scan.
+	postureScanIDExists, err := scanDeletionColumnExists(ctx, db, "vulnerability_postures", "scan_id")
+	if err != nil {
+		return fmt.Errorf("check vulnerability_postures.scan_id: %w", err)
+	}
+	if postureScanIDExists {
+		if _, err := db.NewDelete().
+			TableExpr("vulnerability_postures").
+			Where("scan_id IN (?)", bun.In(scanIDs)).
+			Exec(ctx); err != nil {
+			return fmt.Errorf("delete vulnerability_postures by scan: %w", err)
+		}
+	}
 	return nil
 }
 
 // deleteScanSBOMDependents handles installations created before all SBOM graph
 // foreign keys consistently cascaded.
 func deleteScanSBOMDependents(ctx context.Context, db bun.IDB, scanIDs []uuid.UUID) error {
-	exists, err := scanDeletionTableExists(ctx, db, "sbom_dependencies")
+	exists, err := scanDeletionColumnExists(ctx, db, "sbom_dependencies", "document_id")
 	if err != nil {
-		return fmt.Errorf("check sbom_dependencies: %w", err)
+		return fmt.Errorf("check sbom_dependencies.document_id: %w", err)
 	}
 	if !exists {
 		return nil
@@ -258,13 +277,49 @@ func deleteScanSBOMDependents(ctx context.Context, db bun.IDB, scanIDs []uuid.UU
 	return nil
 }
 
-// scanDeletionTableExists keeps scan deletion compatible with installations that
-// are upgraded from an older schema. Tables introduced after a scan was created
-// cannot contain rows for it, so they are safe to skip until the corresponding
-// migration has run.
-func scanDeletionTableExists(ctx context.Context, db bun.IDB, table string) (bool, error) {
+// clearScanReferences preserves records that outlive an individual scan while
+// preventing legacy NO ACTION foreign keys from blocking deletion.
+func clearScanReferences(ctx context.Context, db bun.IDB, scanIDs []uuid.UUID) error {
+	for _, relation := range []struct {
+		table  string
+		column string
+	}{
+		{table: "watchlist_items", column: "last_scan_id"},
+		{table: "git_repository_run_images", column: "scan_id"},
+	} {
+		exists, err := scanDeletionColumnExists(ctx, db, relation.table, relation.column)
+		if err != nil {
+			return fmt.Errorf("check %s.%s: %w", relation.table, relation.column, err)
+		}
+		if !exists {
+			continue
+		}
+		if _, err := db.NewUpdate().
+			TableExpr(relation.table).
+			Set(relation.column+" = NULL").
+			Where(relation.column+" IN (?)", bun.In(scanIDs)).
+			Exec(ctx); err != nil {
+			return fmt.Errorf("clear %s.%s: %w", relation.table, relation.column, err)
+		}
+	}
+	return nil
+}
+
+// scanDeletionColumnExists keeps scan deletion compatible with installations
+// upgraded from older schemas. CREATE TABLE IF NOT EXISTS migrations can leave
+// a legacy table without a column added by a later model, so checking only the
+// table is not sufficient before issuing a cleanup statement.
+func scanDeletionColumnExists(ctx context.Context, db bun.IDB, table, column string) (bool, error) {
 	var exists bool
-	if err := db.NewRaw("SELECT to_regclass(?) IS NOT NULL", table).Scan(ctx, &exists); err != nil {
+	if err := db.NewRaw(`
+		SELECT EXISTS (
+			SELECT 1
+			FROM information_schema.columns
+			WHERE table_schema = current_schema()
+			  AND table_name = ?
+			  AND column_name = ?
+		)
+	`, table, column).Scan(ctx, &exists); err != nil {
 		return false, err
 	}
 	return exists, nil

--- a/services/frontend/app/globals.css
+++ b/services/frontend/app/globals.css
@@ -5,6 +5,13 @@
 @import './auth-aurora.css';
 
 @layer components {
+  /* HeroUI's dropdown trigger defaults to inline-block. When it also uses the
+     button variants, keep the button's flex layout so icon-only triggers stay
+     centered and text/icon triggers retain their intended gap. */
+  .dropdown__trigger.button {
+    display: inline-flex;
+  }
+
   .react-flow__controls {
     overflow: hidden;
     border: 1px solid var(--divider);


### PR DESCRIPTION
## Summary

- Make scan cleanup compatible with legacy schemas missing newer columns.
- Clear retained scan references before deleting scan records.
- Remove legacy vulnerability posture rows that can block deletion.
- Preserve dropdown trigger flex alignment for icons and text.

## Testing

- Updated scan deletion tests for legacy/current dependency cleanup.
- Added coverage for missing legacy columns.
- Not run: full backend and frontend test suites.