### PR TITLE
Fix scan history deletion timeouts

### DIFF
--- a/services/backend/database/init.go
+++ b/services/backend/database/init.go
@@ -32,6 +32,10 @@ func StartPostgres(dbServer string, dbPort int, dbUser string, dbPass string, db
 		pgdriver.WithDatabase(dbName),
 		pgdriver.WithApplicationName("exflow"),
 		pgdriver.WithTLSConfig(nil),
+		// pgdriver defaults socket reads to 10 seconds, which is too short for
+		// legitimate bulk history deletion and migrations on larger instances.
+		// A shorter context deadline still takes precedence for bounded callers.
+		pgdriver.WithReadTimeout(2*time.Minute),
 	)
 
 	sqldb := sql.OpenDB(pgconn)

--- a/services/backend/handlers/scans/groups.go
+++ b/services/backend/handlers/scans/groups.go
@@ -2,7 +2,9 @@ package scans
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"strings"
 
@@ -78,7 +80,7 @@ func deleteScanGroup(db *bun.DB, requireTag bool) gin.HandlerFunc {
 			return deleteScanRecords(ctx, tx, scanIDs)
 		}); err != nil {
 			log.WithError(err).Errorf("delete scan group failed for %s", imageName)
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to delete scan group"})
+			c.JSON(http.StatusInternalServerError, gin.H{"error": scanGroupDeletionErrorMessage(err)})
 			return
 		}
 		_ = cleanupArchiveUploadSessions(archiveSessions)
@@ -95,4 +97,13 @@ func deleteScanGroup(db *bun.DB, requireTag bool) gin.HandlerFunc {
 
 		c.JSON(http.StatusOK, gin.H{"deleted": len(scanIDs)})
 	}
+}
+
+func scanGroupDeletionErrorMessage(err error) string {
+	var networkError net.Error
+	if strings.Contains(err.Error(), "lock vulnerabilities before scan deletion") &&
+		(errors.Is(err, context.DeadlineExceeded) || (errors.As(err, &networkError) && networkError.Timeout())) {
+		return "database timed out while preparing scan history deletion; please retry"
+	}
+	return "failed to delete scan group"
 }

--- a/services/backend/handlers/scans/groups_test.go
+++ b/services/backend/handlers/scans/groups_test.go
@@ -1,0 +1,22 @@
+package scans
+
+import (
+	"context"
+	"fmt"
+	"testing"
+)
+
+func TestScanGroupDeletionErrorExplainsLockTimeout(t *testing.T) {
+	err := fmt.Errorf("lock vulnerabilities before scan deletion: %w", context.DeadlineExceeded)
+	message := scanGroupDeletionErrorMessage(err)
+	if message != "database timed out while preparing scan history deletion; please retry" {
+		t.Fatalf("unexpected timeout message: %q", message)
+	}
+}
+
+func TestScanGroupDeletionErrorDoesNotExposeDatabaseDetails(t *testing.T) {
+	err := fmt.Errorf("delete scans: constraint secret_internal_fk failed")
+	if message := scanGroupDeletionErrorMessage(err); message != "failed to delete scan group" {
+		t.Fatalf("unexpected database detail exposure: %q", message)
+	}
+}

--- a/services/backend/scanner/intelligence.go
+++ b/services/backend/scanner/intelligence.go
@@ -622,20 +622,27 @@ func LockVulnerabilitiesForUpdate(ctx context.Context, db bun.IDB, scanIDs []uui
 		return nil
 	}
 
-	var findingIDs []uuid.UUID
-	if err := vulnerabilitiesForScanUpdateQuery(db, scanIDs).Scan(ctx, &findingIDs); err != nil {
+	// The rows stay locked until the surrounding transaction completes. Count
+	// them inside PostgreSQL so large history groups return one value instead of
+	// streaming every finding UUID over the database connection.
+	var lockedCount int
+	if err := vulnerabilitiesForScanUpdateQuery(db, scanIDs).Scan(ctx, &lockedCount); err != nil {
 		return err
 	}
 	return nil
 }
 
-func vulnerabilitiesForScanUpdateQuery(db bun.IDB, scanIDs []uuid.UUID) *bun.SelectQuery {
-	return db.NewSelect().
-		TableExpr("vulnerabilities").
-		ColumnExpr("id").
-		Where("scan_id IN (?)", bun.In(scanIDs)).
-		OrderExpr("id ASC").
-		For("UPDATE")
+func vulnerabilitiesForScanUpdateQuery(db bun.IDB, scanIDs []uuid.UUID) *bun.RawQuery {
+	return db.NewRaw(`
+		WITH locked_vulnerabilities AS MATERIALIZED (
+			SELECT id
+			FROM vulnerabilities
+			WHERE scan_id IN (?)
+			ORDER BY id ASC
+			FOR UPDATE
+		)
+		SELECT COUNT(*) FROM locked_vulnerabilities
+	`, bun.In(scanIDs))
 }
 
 func upsertVulnerabilityPostureQuery(db bun.IDB, posture *models.VulnerabilityPosture) *bun.InsertQuery {

--- a/services/backend/scanner/intelligence_test.go
+++ b/services/backend/scanner/intelligence_test.go
@@ -1,6 +1,7 @@
 package scanner
 
 import (
+	"context"
 	"strings"
 	"testing"
 	"time"
@@ -193,6 +194,34 @@ func TestPostureInsertUsesAtomicFindingUpsert(t *testing.T) {
 	scanFindingLockQuery := vulnerabilitiesForScanUpdateQuery(db, []uuid.UUID{uuid.New(), uuid.New()}).String()
 	if !strings.Contains(scanFindingLockQuery, "FOR UPDATE") || !strings.Contains(scanFindingLockQuery, "ORDER BY id ASC") {
 		t.Fatalf("scan deletion lookup does not use deterministic parent-row locking: %s", scanFindingLockQuery)
+	}
+	if !strings.Contains(scanFindingLockQuery, "SELECT COUNT(*) FROM locked_vulnerabilities") {
+		t.Fatalf("scan deletion lookup streams finding IDs instead of returning one aggregate: %s", scanFindingLockQuery)
+	}
+}
+
+func TestLockVulnerabilitiesForLargeScanGroupReturnsOneAggregate(t *testing.T) {
+	sqldb, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("failed to create mock database: %v", err)
+	}
+	defer sqldb.Close()
+
+	db := bun.NewDB(sqldb, pgdialect.New())
+	defer db.Close()
+
+	scanIDs := make([]uuid.UUID, 87)
+	for index := range scanIDs {
+		scanIDs[index] = uuid.New()
+	}
+	mock.ExpectQuery("WITH locked_vulnerabilities AS MATERIALIZED").
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(250_000))
+
+	if err := LockVulnerabilitiesForUpdate(context.Background(), db, scanIDs); err != nil {
+		t.Fatalf("lock vulnerabilities for large scan group: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatal(err)
 	}
 }
 


### PR DESCRIPTION
- Extend PostgreSQL read timeout for large deletions
- Aggregate vulnerability row locking in the database
- Return actionable timeout errors without exposing database details