### PR TITLE
Fix scan history deletion timeouts and mutation locking

### DIFF
--- a/services/backend/database/init.go
+++ b/services/backend/database/init.go
@@ -32,10 +32,11 @@ func StartPostgres(dbServer string, dbPort int, dbUser string, dbPass string, db
 		pgdriver.WithDatabase(dbName),
 		pgdriver.WithApplicationName("exflow"),
 		pgdriver.WithTLSConfig(nil),
-		// pgdriver defaults socket reads to 10 seconds, which is too short for
-		// legitimate bulk history deletion and migrations on larger instances.
-		// A shorter context deadline still takes precedence for bounded callers.
-		pgdriver.WithReadTimeout(2*time.Minute),
+		// A group-history deletion can legitimately hold a transaction while it
+		// removes a large number of findings and their dependents. The handler
+		// applies its own 30-minute context deadline; keep the transport deadline
+		// aligned with it so pgdriver does not abort the operation first.
+		pgdriver.WithReadTimeout(30*time.Minute),
 	)
 
 	sqldb := sql.OpenDB(pgconn)

--- a/services/backend/handlers/helm/runs.go
+++ b/services/backend/handlers/helm/runs.go
@@ -334,7 +334,7 @@ func DeleteRun(db *bun.DB) gin.HandlerFunc {
 		deletedRun := false
 		ctx := c.Request.Context()
 		if err := db.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
-			if err := scanner.LockVulnerabilitiesForUpdate(ctx, tx, scanIDs); err != nil {
+			if err := scanner.LockVulnerabilityMutationScans(ctx, tx, scanIDs); err != nil {
 				return err
 			}
 

--- a/services/backend/handlers/scans/get.go
+++ b/services/backend/handlers/scans/get.go
@@ -161,8 +161,8 @@ func deleteScanRecords(ctx context.Context, db bun.IDB, scanIDs []uuid.UUID) err
 		return nil
 	}
 
-	if err := scanner.LockVulnerabilitiesForUpdate(ctx, db, scanIDs); err != nil {
-		return fmt.Errorf("lock vulnerabilities before scan deletion: %w", err)
+	if err := scanner.LockVulnerabilityMutationScans(ctx, db, scanIDs); err != nil {
+		return fmt.Errorf("lock vulnerability mutations before scan deletion: %w", err)
 	}
 	if err := deleteScanFindingDependents(ctx, db, scanIDs); err != nil {
 		return err

--- a/services/backend/handlers/scans/groups.go
+++ b/services/backend/handlers/scans/groups.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/http"
 	"strings"
+	"time"
 
 	"justscan-backend/functions/audit"
 	"justscan-backend/functions/authz"
@@ -17,6 +18,8 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/uptrace/bun"
 )
+
+const scanGroupDeletionTimeout = 30 * time.Minute
 
 // DeleteScanImageGroup deletes every writable scan for an image in the active scope.
 func DeleteScanImageGroup(db *bun.DB) gin.HandlerFunc {
@@ -76,13 +79,18 @@ func deleteScanGroup(db *bun.DB, requireTag bool) gin.HandlerFunc {
 			return
 		}
 
-		if err := db.RunInTx(c.Request.Context(), nil, func(ctx context.Context, tx bun.Tx) error {
+		deleteCtx, cancelDelete := context.WithTimeout(c.Request.Context(), scanGroupDeletionTimeout)
+		deletionStartedAt := time.Now()
+		err = db.RunInTx(deleteCtx, nil, func(ctx context.Context, tx bun.Tx) error {
 			return deleteScanRecords(ctx, tx, scanIDs)
-		}); err != nil {
+		})
+		cancelDelete()
+		if err != nil {
 			log.WithError(err).Errorf("delete scan group failed for %s", imageName)
 			c.JSON(http.StatusInternalServerError, gin.H{"error": scanGroupDeletionErrorMessage(err)})
 			return
 		}
+		log.WithField("duration", time.Since(deletionStartedAt)).Infof("deleted scan group for %s", imageName)
 		_ = cleanupArchiveUploadSessions(archiveSessions)
 		for index := range scans {
 			_ = cleanupQueuedUploadedArchiveScan(&scans[index])
@@ -101,7 +109,7 @@ func deleteScanGroup(db *bun.DB, requireTag bool) gin.HandlerFunc {
 
 func scanGroupDeletionErrorMessage(err error) string {
 	var networkError net.Error
-	if strings.Contains(err.Error(), "lock vulnerabilities before scan deletion") &&
+	if strings.Contains(err.Error(), "lock vulnerability mutations before scan deletion") &&
 		(errors.Is(err, context.DeadlineExceeded) || (errors.As(err, &networkError) && networkError.Timeout())) {
 		return "database timed out while preparing scan history deletion; please retry"
 	}

--- a/services/backend/handlers/scans/groups_test.go
+++ b/services/backend/handlers/scans/groups_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestScanGroupDeletionErrorExplainsLockTimeout(t *testing.T) {
-	err := fmt.Errorf("lock vulnerabilities before scan deletion: %w", context.DeadlineExceeded)
+	err := fmt.Errorf("lock vulnerability mutations before scan deletion: %w", context.DeadlineExceeded)
 	message := scanGroupDeletionErrorMessage(err)
 	if message != "database timed out while preparing scan history deletion; please retry" {
 		t.Fatalf("unexpected timeout message: %q", message)

--- a/services/backend/scanner/intelligence.go
+++ b/services/backend/scanner/intelligence.go
@@ -128,19 +128,14 @@ func RecordIntelligenceSnapshot(ctx context.Context, db *bun.DB, scan *models.Sc
 			return err
 		}
 
-		// Evidence rows reference vulnerabilities. Lock every historical finding
-		// that the subsequent posture refresh can touch before inserting evidence,
-		// so this transaction never acquires finding locks after a later posture
-		// refresh has already started acquiring them.
+		// Evidence rows reference vulnerabilities. Serialize every affected scan
+		// before inserting evidence so a group deletion cannot interleave with
+		// this refresh.
 		historicalFindings, err := loadHistoricalFindingsForPostureRefresh(ctx, tx, vulnIDs)
 		if err != nil {
 			return fmt.Errorf("load historical findings before evidence insert: %w", err)
 		}
-		historicalFindingIDs := make([]uuid.UUID, 0, len(historicalFindings))
-		for _, finding := range historicalFindings {
-			historicalFindingIDs = append(historicalFindingIDs, finding.ID)
-		}
-		lockedFindingIDs, err := lockHistoricalFindingsForPostureRefresh(ctx, tx, historicalFindingIDs)
+		lockedFindingIDs, err := lockHistoricalFindingsForPostureRefresh(ctx, tx, historicalFindings)
 		if err != nil {
 			return fmt.Errorf("lock historical findings before evidence insert: %w", err)
 		}
@@ -403,11 +398,7 @@ func refreshPosturesWithChanges(ctx context.Context, db bun.IDB, keys []intellig
 	if err != nil {
 		return nil, fmt.Errorf("load historical findings for posture refresh: %w", err)
 	}
-	findingIDs := make([]uuid.UUID, 0, len(findings))
-	for _, finding := range findings {
-		findingIDs = append(findingIDs, finding.ID)
-	}
-	lockedFindingIDs, err := lockHistoricalFindingsForPostureRefresh(ctx, db, findingIDs)
+	lockedFindingIDs, err := lockHistoricalFindingsForPostureRefresh(ctx, db, findings)
 	if err != nil {
 		return nil, fmt.Errorf("lock historical findings for posture refresh: %w", err)
 	}
@@ -428,6 +419,7 @@ func refreshPosturesWithChanges(ctx context.Context, db bun.IDB, keys []intellig
 	}
 
 	identityByFinding := make(map[uuid.UUID]vulnerabilityFindingIdentity, len(findings))
+	findingIDs := make([]uuid.UUID, 0, len(findings))
 	for _, finding := range findings {
 		identityByFinding[finding.ID] = vulnerabilityFindingIdentity{
 			PackageName:      finding.PkgName,
@@ -583,66 +575,66 @@ func currentPostureForUpdateQuery(db bun.IDB, findingID uuid.UUID) *bun.SelectQu
 		For("UPDATE")
 }
 
-// lockHistoricalFindingsForPostureRefresh acquires all finding locks before
-// any posture lock. Scan deletion uses the same parent-before-child order,
-// and sorting the lock query prevents two refresh transactions from taking
-// overlapping finding locks in different orders.
-func lockHistoricalFindingsForPostureRefresh(ctx context.Context, db bun.IDB, findingIDs []uuid.UUID) (map[uuid.UUID]bool, error) {
-	locked := make(map[uuid.UUID]bool, len(findingIDs))
-	if len(findingIDs) == 0 {
+// lockHistoricalFindingsForPostureRefresh serializes vulnerability mutations
+// per scan before any posture row is read or written. Using scan-scoped
+// advisory locks avoids materializing and row-locking an entire historical
+// image group just to coordinate it with scan deletion.
+func lockHistoricalFindingsForPostureRefresh(ctx context.Context, db bun.IDB, findings []models.Vulnerability) (map[uuid.UUID]bool, error) {
+	locked := make(map[uuid.UUID]bool, len(findings))
+	if len(findings) == 0 {
 		return locked, nil
 	}
 
-	var lockedIDs []uuid.UUID
-	err := findingForPostureRefreshQuery(db, findingIDs).Scan(ctx, &lockedIDs)
-	if err != nil {
+	scanIDs := make([]uuid.UUID, 0, len(findings))
+	for _, finding := range findings {
+		scanIDs = append(scanIDs, finding.ScanID)
+	}
+	if err := LockVulnerabilityMutationScans(ctx, db, scanIDs); err != nil {
 		return nil, err
 	}
-	for _, findingID := range lockedIDs {
-		locked[findingID] = true
+	for _, finding := range findings {
+		locked[finding.ID] = true
 	}
 	return locked, nil
 }
 
-func findingForPostureRefreshQuery(db bun.IDB, findingIDs []uuid.UUID) *bun.SelectQuery {
-	return db.NewSelect().
-		TableExpr("vulnerabilities").
-		ColumnExpr("id").
-		Where("id IN (?)", bun.In(findingIDs)).
-		OrderExpr("id ASC").
-		For("UPDATE")
-}
+const vulnerabilityMutationLockNamespace = 1_741_311
 
-// LockVulnerabilitiesForUpdate acquires all vulnerability rows belonging to
-// the given scans in the same order used by posture refreshes. Scan deletion
-// calls this inside its transaction before deleting any dependent rows, which
-// keeps the parent-before-child lock order consistent across both workflows.
-func LockVulnerabilitiesForUpdate(ctx context.Context, db bun.IDB, scanIDs []uuid.UUID) error {
-	if len(scanIDs) == 0 {
-		return nil
-	}
-
-	// The rows stay locked until the surrounding transaction completes. Count
-	// them inside PostgreSQL so large history groups return one value instead of
-	// streaming every finding UUID over the database connection.
-	var lockedCount int
-	if err := vulnerabilitiesForScanUpdateQuery(db, scanIDs).Scan(ctx, &lockedCount); err != nil {
-		return err
+// LockVulnerabilityMutationScans acquires transaction-scoped PostgreSQL
+// advisory locks in a deterministic order. Every flow that changes
+// vulnerabilities or their postures uses this helper, so a group deletion and
+// CVE refresh cannot interleave. Unlike SELECT ... FOR UPDATE across every
+// finding, this has constant memory and does not wait one row at a time.
+// Call it only from within a transaction; PostgreSQL releases xact locks when
+// that transaction completes.
+func LockVulnerabilityMutationScans(ctx context.Context, db bun.IDB, scanIDs []uuid.UUID) error {
+	for _, scanID := range sortedUniqueScanIDs(scanIDs) {
+		var acquired int
+		if err := db.NewRaw(`
+			SELECT 1
+			FROM (SELECT pg_advisory_xact_lock(hashtext(?), ?)) AS vulnerability_lock
+		`, scanID.String(), vulnerabilityMutationLockNamespace).Scan(ctx, &acquired); err != nil {
+			return fmt.Errorf("acquire vulnerability mutation lock for scan %s: %w", scanID, err)
+		}
 	}
 	return nil
 }
 
-func vulnerabilitiesForScanUpdateQuery(db bun.IDB, scanIDs []uuid.UUID) *bun.RawQuery {
-	return db.NewRaw(`
-		WITH locked_vulnerabilities AS MATERIALIZED (
-			SELECT id
-			FROM vulnerabilities
-			WHERE scan_id IN (?)
-			ORDER BY id ASC
-			FOR UPDATE
-		)
-		SELECT COUNT(*) FROM locked_vulnerabilities
-	`, bun.In(scanIDs))
+func sortedUniqueScanIDs(scanIDs []uuid.UUID) []uuid.UUID {
+	unique := make(map[uuid.UUID]struct{}, len(scanIDs))
+	for _, scanID := range scanIDs {
+		if scanID != uuid.Nil {
+			unique[scanID] = struct{}{}
+		}
+	}
+	ordered := make([]uuid.UUID, 0, len(unique))
+	for scanID := range unique {
+		ordered = append(ordered, scanID)
+	}
+	sort.Slice(ordered, func(left, right int) bool {
+		return ordered[left].String() < ordered[right].String()
+	})
+	return ordered
 }
 
 func upsertVulnerabilityPostureQuery(db bun.IDB, posture *models.VulnerabilityPosture) *bun.InsertQuery {

--- a/services/backend/scanner/intelligence_test.go
+++ b/services/backend/scanner/intelligence_test.go
@@ -187,20 +187,9 @@ func TestPostureInsertUsesAtomicFindingUpsert(t *testing.T) {
 	if !strings.Contains(lockQuery, "FOR UPDATE") {
 		t.Fatalf("posture lookup does not lock the current row: %s", lockQuery)
 	}
-	findingLockQuery := findingForPostureRefreshQuery(db, []uuid.UUID{uuid.New(), uuid.New()}).String()
-	if !strings.Contains(findingLockQuery, "FOR UPDATE") || !strings.Contains(findingLockQuery, "ORDER BY id ASC") {
-		t.Fatalf("finding lookup does not use deterministic parent-row locking: %s", findingLockQuery)
-	}
-	scanFindingLockQuery := vulnerabilitiesForScanUpdateQuery(db, []uuid.UUID{uuid.New(), uuid.New()}).String()
-	if !strings.Contains(scanFindingLockQuery, "FOR UPDATE") || !strings.Contains(scanFindingLockQuery, "ORDER BY id ASC") {
-		t.Fatalf("scan deletion lookup does not use deterministic parent-row locking: %s", scanFindingLockQuery)
-	}
-	if !strings.Contains(scanFindingLockQuery, "SELECT COUNT(*) FROM locked_vulnerabilities") {
-		t.Fatalf("scan deletion lookup streams finding IDs instead of returning one aggregate: %s", scanFindingLockQuery)
-	}
 }
 
-func TestLockVulnerabilitiesForLargeScanGroupReturnsOneAggregate(t *testing.T) {
+func TestLockVulnerabilityMutationScansUsesOneAdvisoryLockPerScan(t *testing.T) {
 	sqldb, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("failed to create mock database: %v", err)
@@ -214,14 +203,25 @@ func TestLockVulnerabilitiesForLargeScanGroupReturnsOneAggregate(t *testing.T) {
 	for index := range scanIDs {
 		scanIDs[index] = uuid.New()
 	}
-	mock.ExpectQuery("WITH locked_vulnerabilities AS MATERIALIZED").
-		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(250_000))
+	for range scanIDs {
+		mock.ExpectQuery("pg_advisory_xact_lock").
+			WillReturnRows(sqlmock.NewRows([]string{"lock_acquired"}).AddRow(1))
+	}
 
-	if err := LockVulnerabilitiesForUpdate(context.Background(), db, scanIDs); err != nil {
-		t.Fatalf("lock vulnerabilities for large scan group: %v", err)
+	if err := LockVulnerabilityMutationScans(context.Background(), db, scanIDs); err != nil {
+		t.Fatalf("lock vulnerability mutation scans: %v", err)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestSortedUniqueScanIDsIsDeterministic(t *testing.T) {
+	first := uuid.MustParse("00000000-0000-0000-0000-000000000002")
+	second := uuid.MustParse("00000000-0000-0000-0000-000000000001")
+	ordered := sortedUniqueScanIDs([]uuid.UUID{first, uuid.Nil, second, first})
+	if len(ordered) != 2 || ordered[0] != second || ordered[1] != first {
+		t.Fatalf("unexpected scan lock order: %v", ordered)
 	}
 }
 

--- a/services/frontend/app/(app)/scans/images/[...image]/page.tsx
+++ b/services/frontend/app/(app)/scans/images/[...image]/page.tsx
@@ -36,6 +36,7 @@ import {
   SearchField,
   Select,
   Skeleton,
+  Spinner,
 } from '@heroui/react';
 import {
   ArrowLeft01Icon,
@@ -88,6 +89,13 @@ function visiblePageNumbers(totalPages: number, currentPage: number) {
   const start = Math.max(1, currentPage - 2);
   const end = Math.min(totalPages, currentPage + 2);
   return Array.from({ length: Math.max(0, end - start + 1) }, (_, index) => start + index);
+}
+
+function pendingDeleteScanCount(pendingDelete: PendingDelete | null, imageScanCount: number | undefined) {
+  if (!pendingDelete) return 0;
+  if (pendingDelete.kind === 'scan') return 1;
+  if (pendingDelete.kind === 'tag') return pendingDelete.artifact.scan_count;
+  return imageScanCount ?? 0;
 }
 
 function Metric({
@@ -146,6 +154,7 @@ export default function ImageScansPage() {
   const filterCount = [policy, range].filter(Boolean).length;
   const hasFilters = Boolean(query || status || critical || policy || range);
   const artifactTotalPages = Math.max(1, Math.ceil(total / ARTIFACT_PAGE_SIZE));
+  const pendingScanCount = pendingDeleteScanCount(pendingDelete, stats?.total_scans);
 
   useEffect(
     () =>
@@ -310,47 +319,76 @@ export default function ImageScansPage() {
         <AlertDialog.Backdrop variant="blur">
           <AlertDialog.Container placement="center">
             <AlertDialog.Dialog className="sm:max-w-[440px]">
-              <AlertDialog.CloseTrigger />
+              {!deleting ? <AlertDialog.CloseTrigger /> : null}
               <AlertDialog.Header>
                 <AlertDialog.Icon status="danger" />
                 <AlertDialog.Heading>
-                  {pendingDelete?.kind === 'image'
-                    ? 'Delete image scan group?'
-                    : pendingDelete?.kind === 'tag'
-                      ? 'Delete tag scan history?'
-                      : 'Delete scan history item?'}
+                  {deleting
+                    ? 'Deleting scan history…'
+                    : pendingDelete?.kind === 'image'
+                      ? 'Delete image scan group?'
+                      : pendingDelete?.kind === 'tag'
+                        ? 'Delete tag scan history?'
+                        : 'Delete scan history item?'}
                 </AlertDialog.Heading>
               </AlertDialog.Header>
               <AlertDialog.Body>
-                <p className="text-sm leading-6 text-muted">
-                  {pendingDelete?.kind === 'image' ? (
-                    <>
-                      This removes <strong>{imageName}</strong>, including every tag and scan run in
-                      this workspace. This cannot be undone.
-                    </>
-                  ) : pendingDelete?.kind === 'tag' ? (
-                    <>
-                      This removes <strong>{pendingDelete?.artifact.image_tag}</strong> and all{' '}
-                      {pendingDelete?.artifact.scan_count ?? 0} of its historical scan runs. This
-                      cannot be undone.
-                    </>
-                  ) : (
-                    <>
-                      This removes scan <strong>{pendingDelete?.scan.id.slice(0, 8)}…</strong> from{' '}
-                      <strong>
-                        {imageName}:{pendingDelete?.scan.image_tag}
-                      </strong>
-                      . This cannot be undone.
-                    </>
-                  )}
-                </p>
+                {deleting ? (
+                  <div
+                    aria-busy="true"
+                    aria-live="polite"
+                    className="flex items-start gap-3 rounded-xl border border-danger/20 bg-danger/5 p-3"
+                    role="status"
+                  >
+                    <Spinner aria-label="Deleting scan history" color="danger" size="md" />
+                    <div className="min-w-0 space-y-1">
+                      <p className="text-sm font-medium text-foreground">
+                        Deleting {pendingScanCount} scan {pendingScanCount === 1 ? 'run' : 'runs'}…
+                      </p>
+                      <p className="text-sm leading-6 text-muted">
+                        Large histories can take a little while. Keep this window open until the
+                        deletion finishes.
+                      </p>
+                    </div>
+                  </div>
+                ) : (
+                  <p className="text-sm leading-6 text-muted">
+                    {pendingDelete?.kind === 'image' ? (
+                      <>
+                        This removes <strong>{imageName}</strong>, including every tag and scan run
+                        in this workspace. This cannot be undone.
+                      </>
+                    ) : pendingDelete?.kind === 'tag' ? (
+                      <>
+                        This removes <strong>{pendingDelete?.artifact.image_tag}</strong> and all{' '}
+                        {pendingDelete?.artifact.scan_count ?? 0} of its historical scan runs. This
+                        cannot be undone.
+                      </>
+                    ) : (
+                      <>
+                        This removes scan <strong>{pendingDelete?.scan.id.slice(0, 8)}…</strong> from{' '}
+                        <strong>
+                          {imageName}:{pendingDelete?.scan.image_tag}
+                        </strong>
+                        . This cannot be undone.
+                      </>
+                    )}
+                  </p>
+                )}
               </AlertDialog.Body>
               <AlertDialog.Footer>
-                <Button isDisabled={deleting} slot="close" variant="tertiary">
-                  Cancel
-                </Button>
-                <Button isPending={deleting} onPress={() => void confirmDelete()} variant="danger">
-                  Delete
+                {!deleting ? (
+                  <Button slot="close" variant="tertiary">
+                    Cancel
+                  </Button>
+                ) : null}
+                <Button
+                  isDisabled={deleting}
+                  isPending={deleting}
+                  onPress={() => void confirmDelete()}
+                  variant="danger"
+                >
+                  {deleting ? 'Deleting scan history…' : 'Delete'}
                 </Button>
               </AlertDialog.Footer>
             </AlertDialog.Dialog>

--- a/services/frontend/app/(app)/scans/page.tsx
+++ b/services/frontend/app/(app)/scans/page.tsx
@@ -31,6 +31,7 @@ import {
   RangeCalendar,
   SearchField,
   Select,
+  Spinner,
 } from '@heroui/react';
 import { Clock01Icon, GitCompareIcon, PlusSignIcon, Shield01Icon } from 'hugeicons-react';
 import { useRouter, useSearchParams } from 'next/navigation';
@@ -311,28 +312,54 @@ function ScansPageContent() {
         <AlertDialog.Backdrop variant="blur">
           <AlertDialog.Container placement="center">
             <AlertDialog.Dialog className="sm:max-w-[440px]">
-              <AlertDialog.CloseTrigger />
+              {!deleting ? <AlertDialog.CloseTrigger /> : null}
               <AlertDialog.Header>
                 <AlertDialog.Icon status="danger" />
-                <AlertDialog.Heading>Delete image scan group?</AlertDialog.Heading>
+                <AlertDialog.Heading>
+                  {deleting ? 'Deleting image scan group…' : 'Delete image scan group?'}
+                </AlertDialog.Heading>
               </AlertDialog.Header>
               <AlertDialog.Body>
-                <p className="text-sm leading-6 text-muted">
-                  This removes <strong>{pendingDelete?.image_name}</strong>, including all{' '}
-                  {pendingDelete?.tag_count ?? 0} tags and {pendingDelete?.scan_count ?? 0} scan
-                  runs in this workspace. This cannot be undone.
-                </p>
+                {deleting ? (
+                  <div
+                    aria-busy="true"
+                    aria-live="polite"
+                    className="flex items-start gap-3 rounded-xl border border-danger/20 bg-danger/5 p-3"
+                    role="status"
+                  >
+                    <Spinner aria-label="Deleting image scan history" color="danger" size="md" />
+                    <div className="min-w-0 space-y-1">
+                      <p className="text-sm font-medium text-foreground">
+                        Deleting {pendingDelete?.scan_count ?? 0} scan{' '}
+                        {(pendingDelete?.scan_count ?? 0) === 1 ? 'run' : 'runs'}…
+                      </p>
+                      <p className="text-sm leading-6 text-muted">
+                        Large histories can take a little while. Keep this window open until the
+                        deletion finishes.
+                      </p>
+                    </div>
+                  </div>
+                ) : (
+                  <p className="text-sm leading-6 text-muted">
+                    This removes <strong>{pendingDelete?.image_name}</strong>, including all{' '}
+                    {pendingDelete?.tag_count ?? 0} tags and {pendingDelete?.scan_count ?? 0} scan
+                    runs in this workspace. This cannot be undone.
+                  </p>
+                )}
               </AlertDialog.Body>
               <AlertDialog.Footer>
-                <Button isDisabled={deleting} slot="close" variant="tertiary">
-                  Cancel
-                </Button>
+                {!deleting ? (
+                  <Button slot="close" variant="tertiary">
+                    Cancel
+                  </Button>
+                ) : null}
                 <Button
+                  isDisabled={deleting}
                   isPending={deleting}
                   onPress={() => void confirmDeleteImage()}
                   variant="danger"
                 >
-                  Delete image group
+                  {deleting ? 'Deleting scan history…' : 'Delete image group'}
                 </Button>
               </AlertDialog.Footer>
             </AlertDialog.Dialog>


### PR DESCRIPTION
## Summary

- Extend scan history deletion timeout to 30 minutes.
- Coordinate scan deletions and vulnerability posture refreshes with deterministic advisory locks.
- Improve deletion progress feedback and prevent closing the dialog while deletion is in progress.
- Add coverage for advisory locking and deterministic scan ordering.

## Testing

- Not run (change request generated from the provided commit and diff).