### PR TITLE
Add user-specific Process Center job dismissal

### DIFF
--- a/services/backend/backgroundjobs/jobs.go
+++ b/services/backend/backgroundjobs/jobs.go
@@ -41,6 +41,8 @@ const (
 // monopolizing the executable worker pool while an external process runs.
 var ErrRequeue = errors.New("background job requeue")
 
+var ErrJobNotFinished = errors.New("background job is still active")
+
 // Processor performs one durable job. It should update progress after each
 // bounded unit and return a SafeError when a user-facing error can be stated
 // more precisely than the generic failure message.
@@ -254,7 +256,9 @@ func ListAuthorized(ctx context.Context, db *bun.DB, userID uuid.UUID, isAdmin b
 		return nil, err
 	}
 
-	query := db.NewSelect().Model((*models.BackgroundJob)(nil)).OrderExpr("created_at DESC").Limit(limit)
+	query := db.NewSelect().Model((*models.BackgroundJob)(nil)).
+		Where("NOT EXISTS (SELECT 1 FROM background_job_dismissals AS dismissal WHERE dismissal.job_id = background_job.id AND dismissal.user_id = ?)", userID).
+		OrderExpr("created_at DESC").Limit(limit)
 	if !isAdmin {
 		query = query.WhereGroup(" AND ", func(q *bun.SelectQuery) *bun.SelectQuery {
 			q = q.Where("user_id = ?", userID)
@@ -295,6 +299,51 @@ func GetAuthorized(ctx context.Context, db *bun.DB, id, userID uuid.UUID, isAdmi
 		return nil, sql.ErrNoRows
 	}
 	return job, nil
+}
+
+// DismissAuthorized hides a terminal job from one user's Process Center. It
+// never deletes the underlying job, which may be shared with an organization
+// or needed for operational diagnostics.
+func DismissAuthorized(ctx context.Context, db *bun.DB, id, userID uuid.UUID, isAdmin bool) error {
+	job, err := GetAuthorized(ctx, db, id, userID, isAdmin)
+	if err != nil {
+		return err
+	}
+	if job.Status != models.BackgroundJobStatusSucceeded && job.Status != models.BackgroundJobStatusFailed &&
+		job.Status != "completed" && job.Status != "cancelled" {
+		return ErrJobNotFinished
+	}
+	_, err = db.NewInsert().Model(&models.BackgroundJobDismissal{
+		JobID:     job.ID,
+		UserID:    userID,
+		CreatedAt: time.Now().UTC(),
+	}).On("CONFLICT (job_id, user_id) DO NOTHING").Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("dismiss background job: %w", err)
+	}
+	return nil
+}
+
+// DismissManyAuthorized is intentionally a per-job authorization check: a
+// Process Center can include personal and organization jobs, and a dismissal
+// must remain private to the current user in either case.
+func DismissManyAuthorized(ctx context.Context, db *bun.DB, ids []uuid.UUID, userID uuid.UUID, isAdmin bool) (int, error) {
+	seen := make(map[uuid.UUID]struct{}, len(ids))
+	dismissed := 0
+	for _, id := range ids {
+		if id == uuid.Nil {
+			return dismissed, errors.New("background job id is required")
+		}
+		if _, duplicate := seen[id]; duplicate {
+			continue
+		}
+		seen[id] = struct{}{}
+		if err := DismissAuthorized(ctx, db, id, userID, isAdmin); err != nil {
+			return dismissed, err
+		}
+		dismissed++
+	}
+	return dismissed, nil
 }
 
 func IsAuthorized(ctx context.Context, db *bun.DB, job *models.BackgroundJob, userID uuid.UUID, isAdmin bool) bool {

--- a/services/backend/backgroundjobs/jobs_test.go
+++ b/services/backend/backgroundjobs/jobs_test.go
@@ -88,6 +88,79 @@ func TestClaimExcludesPassiveJobsAndUsesSkipLocked(t *testing.T) {
 	}
 }
 
+func TestDismissAuthorizedStoresAUserSpecificDismissal(t *testing.T) {
+	sqldb, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("create sqlmock: %v", err)
+	}
+	defer sqldb.Close()
+	db := bun.NewDB(sqldb, pgdialect.New())
+	defer db.Close()
+
+	jobID := uuid.New()
+	userID := uuid.New()
+	mock.ExpectQuery(`SELECT .*FROM "background_jobs" AS "background_job" WHERE \(id =`).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "user_id", "status"}).
+			AddRow(jobID, userID, models.BackgroundJobStatusSucceeded))
+	mock.ExpectExec(`INSERT INTO "background_job_dismissals"`).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	if err := DismissAuthorized(context.Background(), db, jobID, userID, false); err != nil {
+		t.Fatalf("dismiss authorized job: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet SQL expectations: %v", err)
+	}
+}
+
+func TestDismissAuthorizedRejectsActiveJobs(t *testing.T) {
+	sqldb, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("create sqlmock: %v", err)
+	}
+	defer sqldb.Close()
+	db := bun.NewDB(sqldb, pgdialect.New())
+	defer db.Close()
+
+	jobID := uuid.New()
+	userID := uuid.New()
+	mock.ExpectQuery(`SELECT .*FROM "background_jobs" AS "background_job" WHERE \(id =`).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "user_id", "status"}).
+			AddRow(jobID, userID, models.BackgroundJobStatusRunning))
+
+	err = DismissAuthorized(context.Background(), db, jobID, userID, false)
+	if !errors.Is(err, ErrJobNotFinished) {
+		t.Fatalf("dismiss active job error = %v, want ErrJobNotFinished", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet SQL expectations: %v", err)
+	}
+}
+
+func TestListAuthorizedExcludesTheCurrentUsersDismissedJobs(t *testing.T) {
+	sqldb, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("create sqlmock: %v", err)
+	}
+	defer sqldb.Close()
+	db := bun.NewDB(sqldb, pgdialect.New())
+	defer db.Close()
+
+	mock.ExpectQuery(`SELECT .*FROM "background_jobs" AS "background_job" WHERE \(NOT EXISTS \(SELECT 1 FROM background_job_dismissals AS dismissal WHERE dismissal.job_id = background_job.id AND dismissal.user_id =`).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "user_id", "status"}))
+
+	jobs, err := ListAuthorized(context.Background(), db, uuid.New(), true, "", 10)
+	if err != nil {
+		t.Fatalf("list authorized jobs: %v", err)
+	}
+	if len(jobs) != 0 {
+		t.Fatalf("jobs = %d, want 0", len(jobs))
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet SQL expectations: %v", err)
+	}
+}
+
 type timeoutTestError struct{}
 
 func (timeoutTestError) Error() string   { return "read tcp: i/o timeout" }

--- a/services/backend/database/migrations/110_background_job_dismissals.go
+++ b/services/backend/database/migrations/110_background_job_dismissals.go
@@ -1,0 +1,40 @@
+package migrations
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/uptrace/bun"
+)
+
+// Migration 110 stores Process Center removals per user. Deleting a job row
+// would remove shared organization history and operational diagnostics for
+// everyone, so dismissals are intentionally user-specific instead.
+func init() {
+	Migrations.MustRegister(func(ctx context.Context, db *bun.DB) error {
+		for _, statement := range []string{
+			`CREATE TABLE IF NOT EXISTS background_job_dismissals (
+				job_id UUID NOT NULL REFERENCES background_jobs(id) ON DELETE CASCADE,
+				user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+				created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+				PRIMARY KEY (job_id, user_id)
+			)`,
+			`CREATE INDEX IF NOT EXISTS idx_background_job_dismissals_user_job ON background_job_dismissals (user_id, job_id)`,
+		} {
+			if _, err := db.NewRaw(statement).Exec(ctx); err != nil {
+				return fmt.Errorf("migration 110 background job dismissals: %w", err)
+			}
+		}
+		return nil
+	}, func(ctx context.Context, db *bun.DB) error {
+		for _, statement := range []string{
+			`DROP INDEX IF EXISTS idx_background_job_dismissals_user_job`,
+			`DROP TABLE IF EXISTS background_job_dismissals`,
+		} {
+			if _, err := db.NewRaw(statement).Exec(ctx); err != nil {
+				return fmt.Errorf("migration 110 background job dismissals rollback: %w", err)
+			}
+		}
+		return nil
+	})
+}

--- a/services/backend/handlers/backgroundjobs/background_jobs.go
+++ b/services/backend/handlers/backgroundjobs/background_jobs.go
@@ -74,3 +74,66 @@ func Get(db *bun.DB) gin.HandlerFunc {
 		c.JSON(http.StatusOK, gin.H{"job": job})
 	}
 }
+
+// Dismiss hides a completed or failed job from the current user's Process
+// Center. The job record itself remains available for operations and other
+// authorized organization members.
+func Dismiss(db *bun.DB) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		jobID, err := uuid.Parse(strings.TrimSpace(c.Param("id")))
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid job id"})
+			return
+		}
+		userID, isAdmin, ok := authz.RequireRequestUser(c, db)
+		if !ok {
+			return
+		}
+		if err := workerjobs.DismissAuthorized(c.Request.Context(), db, jobID, userID, isAdmin); err != nil {
+			switch {
+			case errors.Is(err, sql.ErrNoRows):
+				c.JSON(http.StatusNotFound, gin.H{"error": "background job not found"})
+			case errors.Is(err, workerjobs.ErrJobNotFinished):
+				c.JSON(http.StatusConflict, gin.H{"error": "active background jobs cannot be removed"})
+			default:
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to remove background job"})
+			}
+			return
+		}
+		c.Status(http.StatusNoContent)
+	}
+}
+
+type dismissManyRequest struct {
+	IDs []uuid.UUID `json:"ids"`
+}
+
+// DismissMany performs the same user-specific dismissal for the selected
+// completed or failed jobs. The client supplies the currently displayed IDs,
+// keeping the bulk action explicit and scope-safe.
+func DismissMany(db *bun.DB) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		var request dismissManyRequest
+		if err := c.ShouldBindJSON(&request); err != nil || len(request.IDs) == 0 || len(request.IDs) > 100 {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "provide between 1 and 100 background job ids"})
+			return
+		}
+		userID, isAdmin, ok := authz.RequireRequestUser(c, db)
+		if !ok {
+			return
+		}
+		dismissed, err := workerjobs.DismissManyAuthorized(c.Request.Context(), db, request.IDs, userID, isAdmin)
+		if err != nil {
+			switch {
+			case errors.Is(err, sql.ErrNoRows):
+				c.JSON(http.StatusNotFound, gin.H{"error": "background job not found"})
+			case errors.Is(err, workerjobs.ErrJobNotFinished):
+				c.JSON(http.StatusConflict, gin.H{"error": "active background jobs cannot be removed"})
+			default:
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to remove background jobs"})
+			}
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"dismissed": dismissed})
+	}
+}

--- a/services/backend/handlers/dashboard/trends.go
+++ b/services/backend/handlers/dashboard/trends.go
@@ -91,6 +91,7 @@ func GetTrends(db *bun.DB) gin.HandlerFunc {
 		pendingArgs := append([]interface{}{models.ScanStatusPending}, orgPolicyFailureArgs...)
 		cancelledArgs := append([]interface{}{models.ScanStatusCancelled}, orgPolicyFailureArgs...)
 		otherArgs := append([]interface{}{bun.In([]string{models.ScanStatusCompleted, models.ScanStatusFailed, models.ScanStatusRunning, models.ScanStatusPending, models.ScanStatusCancelled}), models.ScanExternalStatusBlockedByXrayPolicy}, orgPolicyFailureArgs...)
+		orgPolicyFailedColumn := "SUM(CASE WHEN " + orgPolicyFailure + " THEN 1 ELSE 0 END) AS org_policy_failed"
 
 		var rows []scanTrendRow
 		query := db.NewSelect().
@@ -102,8 +103,13 @@ func GetTrends(db *bun.DB) gin.HandlerFunc {
 			ColumnExpr("SUM(CASE WHEN external_status = ? AND NOT ("+orgPolicyFailure+") THEN 1 ELSE 0 END) AS policy_blocked", policyBlockedArgs...).
 			ColumnExpr("SUM(CASE WHEN status = ? AND NOT ("+orgPolicyFailure+") THEN 1 ELSE 0 END) AS running", runningArgs...).
 			ColumnExpr("SUM(CASE WHEN status = ? AND NOT ("+orgPolicyFailure+") THEN 1 ELSE 0 END) AS pending", pendingArgs...).
-			ColumnExpr("SUM(CASE WHEN status = ? AND NOT ("+orgPolicyFailure+") THEN 1 ELSE 0 END) AS cancelled", cancelledArgs...).
-			ColumnExpr("SUM(CASE WHEN "+orgPolicyFailure+" THEN 1 ELSE 0 END) AS org_policy_failed", orgPolicyFailureArgs...).
+			ColumnExpr("SUM(CASE WHEN status = ? AND NOT ("+orgPolicyFailure+") THEN 1 ELSE 0 END) AS cancelled", cancelledArgs...)
+		if len(orgPolicyFailureArgs) == 0 {
+			query = query.ColumnExpr(orgPolicyFailedColumn)
+		} else {
+			query = query.ColumnExpr(orgPolicyFailedColumn, orgPolicyFailureArgs...)
+		}
+		query = query.
 			ColumnExpr("SUM(CASE WHEN status NOT IN (?) AND COALESCE(external_status, '') <> ? AND NOT ("+orgPolicyFailure+") THEN 1 ELSE 0 END) AS other", otherArgs...).
 			Where("created_at >= ?", cutoff).
 			GroupExpr("date").

--- a/services/backend/handlers/scans/artifacts.go
+++ b/services/backend/handlers/scans/artifacts.go
@@ -258,7 +258,10 @@ SELECT
     l.low_count
 FROM latest l
 WHERE ` + latestStatusWhere + ` AND ` + criticalWhere + ` AND ` + policyWhere + ` AND ` + intelligenceWhere + `
-ORDER BY l.latest_scan_at DESC, l.latest_scan_id DESC
+ORDER BY
+    CASE WHEN l.latest_status IN ('pending', 'queued', 'running') THEN 0 ELSE 1 END,
+    l.latest_scan_at DESC,
+    l.latest_scan_id DESC
 LIMIT ? OFFSET ?`
 		dataArgs := append([]interface{}{}, baseArgs...)
 		dataArgs = append(dataArgs, latestStatusArgs...)

--- a/services/backend/handlers/scans/image_overview.go
+++ b/services/backend/handlers/scans/image_overview.go
@@ -63,13 +63,13 @@ func parseImageOverviewTime(c *gin.Context) (string, []interface{}) {
 func imageOverviewOrder(raw string) string {
 	switch raw {
 	case "image_asc":
-		return "image_name ASC"
+		return "active_rank DESC, image_name ASC"
 	case "scan_count_desc":
-		return "scan_count DESC, latest_scan_at DESC"
+		return "active_rank DESC, scan_count DESC, latest_scan_at DESC"
 	case "risk_desc":
-		return "health_rank DESC, latest_scan_at DESC"
+		return "active_rank DESC, health_rank DESC, latest_scan_at DESC"
 	default:
-		return "latest_scan_at DESC"
+		return "active_rank DESC, latest_scan_at DESC"
 	}
 }
 
@@ -164,6 +164,8 @@ WITH visible AS (
     SELECT
         h.image_name, c.scan_count,
         COUNT(*) OVER (PARTITION BY h.image_name) AS tag_count,
+        MAX(CASE WHEN h.status IN ('pending', 'queued', 'running') THEN 1 ELSE 0 END)
+            OVER (PARTITION BY h.image_name) AS active_rank,
         MAX(h.health_rank) OVER (PARTITION BY h.image_name) AS health_rank,
         MAX(h.created_at) OVER (PARTITION BY h.image_name) AS latest_scan_at,
         MAX(h.scan_id::text) FILTER (WHERE h.latest_rank = 1) OVER (PARTITION BY h.image_name) AS latest_scan_id,

--- a/services/backend/handlers/scans/list.go
+++ b/services/backend/handlers/scans/list.go
@@ -34,7 +34,7 @@ func ListScans(db *bun.DB) gin.HandlerFunc {
 
 		scans := make([]models.Scan, 0)
 		q := db.NewSelect().Model(&scans).
-			OrderExpr("created_at DESC").
+			OrderExpr("CASE WHEN status IN ('pending', 'queued', 'running') THEN 0 ELSE 1 END, created_at DESC, id DESC").
 			Limit(limit).
 			Offset(offset)
 		q = authz.ApplyOwnershipVisibility(q, "scan", "user_id", "owner_user_id", "owner_org_id", "org_scans", "scan_id", userID, isAdmin, accessibleOrgIDs)

--- a/services/backend/handlers/watchlist/watchlist.go
+++ b/services/backend/handlers/watchlist/watchlist.go
@@ -434,6 +434,7 @@ func TriggerScan(db *bun.DB) gin.HandlerFunc {
 			OwnerType:   item.OwnerType,
 			OwnerUserID: item.OwnerUserID,
 			OwnerOrgID:  item.OwnerOrgID,
+			WatchlistID: &item.ID,
 			CreatedAt:   time.Now(),
 		}
 		registry, envVars, err := scanner.ResolveRegistryForScan(c.Request.Context(), db, item.ImageName, item.RegistryID)

--- a/services/backend/mcp/actions.go
+++ b/services/backend/mcp/actions.go
@@ -300,6 +300,7 @@ func (s *server) createWatchlistScan(ctx context.Context, itemID uuid.UUID) (*mo
 		OwnerType:   item.OwnerType,
 		OwnerUserID: item.OwnerUserID,
 		OwnerOrgID:  item.OwnerOrgID,
+		WatchlistID: &item.ID,
 		CreatedAt:   time.Now().UTC(),
 	}
 	registry, envVars, err := scanner.ResolveRegistryForScan(ctx, s.db, item.ImageName, item.RegistryID)

--- a/services/backend/pkg/models/background_jobs.go
+++ b/services/backend/pkg/models/background_jobs.go
@@ -56,3 +56,14 @@ type BackgroundJob struct {
 	ErrorLog   string     `bun:"error_log,type:text,notnull,default:''" json:"-"`
 	DedupeKey  string     `bun:"dedupe_key,type:text,notnull,default:''" json:"-"`
 }
+
+// BackgroundJobDismissal is a user-specific removal from the Process Center.
+// Jobs remain available for operational diagnostics and to other authorized
+// organization members; only the dismissing user's process list is affected.
+type BackgroundJobDismissal struct {
+	bun.BaseModel `bun:"table:background_job_dismissals"`
+
+	JobID     uuid.UUID `bun:"job_id,type:uuid,pk"`
+	UserID    uuid.UUID `bun:"user_id,type:uuid,pk"`
+	CreatedAt time.Time `bun:"created_at,type:timestamptz,notnull,default:now()"`
+}

--- a/services/backend/pkg/models/scans.go
+++ b/services/backend/pkg/models/scans.go
@@ -62,6 +62,10 @@ type Scan struct {
 	ComplianceSummary       *ScanComplianceSummary `bun:"-" json:"compliance_summary,omitempty"`
 	IntelligenceSummary     *IntelligenceSummary   `bun:"-" json:"intelligence_summary,omitempty"`
 	PipelineInitiator       *PipelineInitiator     `bun:"-" json:"pipeline_initiator,omitempty"`
+	// WatchlistID is transient provenance used when creating the Process Center
+	// mirror for a watchlist-triggered scan. It is intentionally not persisted
+	// on the scan row because watchlist_items.last_scan_id owns that relationship.
+	WatchlistID *uuid.UUID `bun:"-" json:"-"`
 
 	// Relations (not stored in DB, populated on join)
 	Tags                 []Tag                              `bun:"m2m:scan_tags,join:Scan=Tag" json:"tags,omitempty"`

--- a/services/backend/router/background_jobs.go
+++ b/services/backend/router/background_jobs.go
@@ -13,6 +13,9 @@ func BackgroundJobs(router *gin.RouterGroup, db *bun.DB) {
 	{
 		jobs.GET("", jobhandlers.List(db))
 		jobs.GET("/", jobhandlers.List(db))
+		jobs.DELETE("", jobhandlers.DismissMany(db))
+		jobs.DELETE("/", jobhandlers.DismissMany(db))
 		jobs.GET("/:id", jobhandlers.Get(db))
+		jobs.DELETE("/:id", jobhandlers.Dismiss(db))
 	}
 }

--- a/services/backend/scanner/background_jobs.go
+++ b/services/backend/scanner/background_jobs.go
@@ -35,6 +35,22 @@ func init() {
 	backgroundjobs.RegisterPassive(ScanBackgroundJobType)
 }
 
+func scanBackgroundMetadata(scan *models.Scan) models.JSONObject {
+	metadata := models.JSONObject{
+		"resource_type": "scan",
+		"resource_id":   scan.ID.String(),
+		"scan_id":       scan.ID.String(),
+		"image_name":    scan.ImageName,
+		"image_tag":     scan.ImageTag,
+		"scan_provider": scan.ScanProvider,
+	}
+	if scan.WatchlistID != nil && *scan.WatchlistID != uuid.Nil {
+		metadata["trigger_source"] = "watchlist"
+		metadata["watchlist_id"] = scan.WatchlistID.String()
+	}
+	return metadata
+}
+
 func enqueueScanBackgroundJob(ctx context.Context, db *bun.DB, scan *models.Scan) error {
 	if db == nil || scan == nil || scan.ID == uuid.Nil {
 		return nil
@@ -62,14 +78,6 @@ func enqueueScanBackgroundJob(ctx context.Context, db *bun.DB, scan *models.Scan
 	if phase == "" {
 		phase = models.ScanStepQueued
 	}
-	metadata := models.JSONObject{
-		"resource_type": "scan",
-		"resource_id":   scan.ID.String(),
-		"scan_id":       scan.ID.String(),
-		"image_name":    scan.ImageName,
-		"image_tag":     scan.ImageTag,
-		"scan_provider": scan.ScanProvider,
-	}
 	_, err := backgroundjobs.Enqueue(ctx, db, backgroundjobs.EnqueueRequest{
 		UserID:      *userID,
 		ScopeType:   scopeType,
@@ -78,7 +86,7 @@ func enqueueScanBackgroundJob(ctx context.Context, db *bun.DB, scan *models.Scan
 		Title:       fmt.Sprintf("Scan %s:%s", scan.ImageName, scan.ImageTag),
 		Description: "Container image scan",
 		Phase:       phase,
-		Metadata:    metadata,
+		Metadata:    scanBackgroundMetadata(scan),
 		DedupeKey:   "scan:" + scan.ID.String(),
 	})
 	if err != nil {

--- a/services/backend/scanner/background_jobs_test.go
+++ b/services/backend/scanner/background_jobs_test.go
@@ -18,6 +18,26 @@ func TestEnqueueScanBackgroundJobSkipsAnonymousScan(t *testing.T) {
 	}
 }
 
+func TestScanBackgroundMetadataMarksWatchlistTrigger(t *testing.T) {
+	scanID := uuid.New()
+	watchlistID := uuid.New()
+	metadata := scanBackgroundMetadata(&models.Scan{
+		ID:          scanID,
+		ImageName:   "alpine",
+		ImageTag:    "latest",
+		WatchlistID: &watchlistID,
+	})
+	if metadata["scan_id"] != scanID.String() {
+		t.Fatalf("scan_id = %v, want %s", metadata["scan_id"], scanID)
+	}
+	if metadata["trigger_source"] != "watchlist" {
+		t.Fatalf("trigger_source = %v, want watchlist", metadata["trigger_source"])
+	}
+	if metadata["watchlist_id"] != watchlistID.String() {
+		t.Fatalf("watchlist_id = %v, want %s", metadata["watchlist_id"], watchlistID)
+	}
+}
+
 func TestEnqueueScanBackgroundJobUsesOrganizationScope(t *testing.T) {
 	db, mock, cleanup := newMockBunDB(t)
 	defer cleanup()

--- a/services/backend/scheduler/scheduler.go
+++ b/services/backend/scheduler/scheduler.go
@@ -215,6 +215,7 @@ func newScheduledScan(item models.WatchlistItem, imageName string, imageTag stri
 		OwnerType:    ownerType,
 		OwnerUserID:  ownerUserID,
 		OwnerOrgID:   ownerOrgID,
+		WatchlistID:  &item.ID,
 		CreatedAt:    createdAt,
 	}
 }

--- a/services/docs/content/docs/operate/observability-and-maintenance.mdx
+++ b/services/docs/content/docs/operate/observability-and-maintenance.mdx
@@ -17,7 +17,7 @@ Treat JustScan as a release-decision service once CI depends on policy outcomes.
 
 The admin scanner settings API applies engine toggles, command timeout, scanner database age, and OSV Java enrichment on subsequent work. Worker concurrency is fixed when the backend starts and is reported as restart-required; pending durable scans are requeued during startup and by the recovery dispatcher. The Process Center reconciles its linked records from persisted scan status and phase, so a process entry should be checked together with the scan detail when diagnosing a restart or stale worker.
 
-The Process Center list shows recent process records for operational history; those records are not a second copy of findings or SBOM data. Deleting the linked scan removes the process entry. There is no Process Center retry action: correct credentials, registry access, scanner data, or input errors before submitting a fresh scan, and use a fresh scan when the original input or policy decision must be replaced.
+The Process Center list shows recent process records for operational history; those records are not a second copy of findings or SBOM data. Completed and failed entries can be removed individually or in bulk from one user's Process Center view without deleting shared organization history or backend diagnostics. Deleting the linked scan removes the process entry. There is no Process Center retry action: correct credentials, registry access, scanner data, or input errors before submitting a fresh scan, and use a fresh scan when the original input or policy decision must be replaced.
 
 ## CVE Intelligence health
 

--- a/services/docs/content/docs/scan-and-analyze/scan-lifecycle.mdx
+++ b/services/docs/content/docs/scan-and-analyze/scan-lifecycle.mdx
@@ -35,7 +35,7 @@ The process status describes execution, not the release verdict:
 
 Phases are sourced from real scan steps such as preparing the image, scanning, processing results, or finalizing the report. A phase may be shown without a percentage: JustScan does not invent a determinate percent when the scanner has not supplied a meaningful total. Use the scan's step output and terminal error for detail.
 
-Deleting a scan also removes its linked process record and any queued process-center entry; it does not retain a separate copy of scan evidence. The Process Center currently has no retry action: correct the recorded execution cause and submit a new scan when a fresh attempt is needed. A restart recovery or fresh submission must not be confused with a policy result; the scan record remains the source of truth.
+Deleting a scan also removes its linked process record and any queued process-center entry; it does not retain a separate copy of scan evidence. Completed and failed entries can be removed individually or in bulk from the Process Center. This only clears them from your own Process Center view; it does not delete shared organization history or backend diagnostics. The Process Center currently has no retry action: correct the recorded execution cause and submit a new scan when a fresh attempt is needed. A restart recovery or fresh submission must not be confused with a policy result; the scan record remains the source of truth.
 
 ## Choose the source deliberately
 

--- a/services/frontend/app/(app)/scans/images/[...image]/page.tsx
+++ b/services/frontend/app/(app)/scans/images/[...image]/page.tsx
@@ -33,6 +33,7 @@ import {
 } from '@/lib/api';
 import { deferEffect } from '@/lib/defer-effect';
 import {
+  Alert,
   AlertDialog,
   Button,
   Card,
@@ -486,20 +487,29 @@ export default function ImageScansPage() {
         </AlertDialog.Backdrop>
       </AlertDialog>
       {queuedDeletions.size > 0 ? (
-        <Card className="flex flex-wrap items-center justify-between gap-3 border-warning/30 bg-warning/5 p-4">
-          <div className="flex min-w-0 items-start gap-3">
-            <Spinner aria-hidden className="mt-0.5 shrink-0" color="warning" size="sm" />
-            <div className="min-w-0">
-              <p className="text-sm font-medium">Deletion queued</p>
-              <p className="mt-1 text-xs leading-5 text-muted">
-                This page stays available while cleanup runs. The row will refresh when it finishes.
-              </p>
+        <Alert className="items-center gap-3 py-3" status="warning">
+          <Alert.Indicator>
+            <Spinner aria-label="Deletion in progress" color="warning" size="sm" />
+          </Alert.Indicator>
+          <Alert.Content className="min-w-0 flex-1 gap-0">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <div className="min-w-0">
+                <Alert.Title>Deletion queued</Alert.Title>
+                <Alert.Description className="mt-0.5">
+                  Cleanup is running in the background. This page will refresh when it finishes.
+                </Alert.Description>
+              </div>
+              <Button
+                className="shrink-0 self-start sm:self-auto"
+                onPress={openBackgroundProcessCenter}
+                size="sm"
+                variant="secondary"
+              >
+                View progress
+              </Button>
             </div>
-          </div>
-          <Button onPress={openBackgroundProcessCenter} size="sm" variant="secondary">
-            View progress
-          </Button>
-        </Card>
+          </Alert.Content>
+        </Alert>
       ) : null}
       {statsLoading ? (
         <div className="grid gap-2 sm:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">

--- a/services/frontend/components/background-process-center.tsx
+++ b/services/frontend/components/background-process-center.tsx
@@ -3,6 +3,8 @@
 import {
   BACKGROUND_JOB_ENQUEUED_EVENT,
   announceBackgroundJobFinished,
+  dismissBackgroundJob,
+  dismissBackgroundJobs,
   isBackgroundJobActive,
   isBackgroundJobFinished,
   listBackgroundJobs,
@@ -14,7 +16,13 @@ import { timeAgo } from '@/lib/time';
 import { useToast } from '@/components/toast';
 import { useWorkScope } from '@/hooks/use-work-scope';
 import { Badge, Button, Chip, Drawer, ProgressBar, Spinner } from '@heroui/react';
-import { Activity01Icon, Alert02Icon, CheckmarkCircle02Icon, Refresh01Icon } from 'hugeicons-react';
+import {
+  Activity01Icon,
+  Alert02Icon,
+  Cancel01Icon,
+  CheckmarkCircle02Icon,
+  Refresh01Icon,
+} from 'hugeicons-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 const JOB_LIMIT = 50;
@@ -70,6 +78,16 @@ function formatPhase(phase: string | null | undefined) {
   return normalized.charAt(0).toUpperCase() + normalized.slice(1);
 }
 
+function jobDisplayPriority(job: BackgroundJob) {
+  if (isBackgroundJobActive(job)) return 0;
+  if (job.status === 'failed') return 1;
+  return 2;
+}
+
+function jobDisplayTime(job: BackgroundJob) {
+  return Date.parse(job.finished_at ?? job.started_at ?? job.created_at) || 0;
+}
+
 function mergeJobs(current: BackgroundJob[], incoming: BackgroundJob[]) {
   const nextById = new Map(incoming.map((job) => [job.id, job]));
 
@@ -84,9 +102,9 @@ function mergeJobs(current: BackgroundJob[], incoming: BackgroundJob[]) {
 
   return Array.from(nextById.values())
     .sort((a, b) => {
-      const aTime = Date.parse(a.created_at) || 0;
-      const bTime = Date.parse(b.created_at) || 0;
-      return bTime - aTime;
+      const priorityDifference = jobDisplayPriority(a) - jobDisplayPriority(b);
+      if (priorityDifference !== 0) return priorityDifference;
+      return jobDisplayTime(b) - jobDisplayTime(a);
     })
     .slice(0, JOB_LIMIT);
 }
@@ -102,7 +120,15 @@ function announceFinishedJob(job: BackgroundJob, setAnnouncement: (value: string
   }
 }
 
-function BackgroundJobCard({ job }: { job: BackgroundJob }) {
+function BackgroundJobCard({
+  job,
+  isDismissing,
+  onDismiss,
+}: {
+  job: BackgroundJob;
+  isDismissing: boolean;
+  onDismiss: (id: string) => void;
+}) {
   const active = isBackgroundJobActive(job);
   const progressCurrent = Math.max(0, job.progress_current ?? 0);
   const progressTotal = Math.max(1, job.progress_total ?? 1);
@@ -121,18 +147,20 @@ function BackgroundJobCard({ job }: { job: BackgroundJob }) {
             <p className="mt-1 text-xs leading-5 text-muted">{job.description}</p>
           ) : null}
         </div>
-        <Chip color={color} size="sm" variant="soft">
-          <span className="inline-flex items-center gap-1.5">
-            {active ? (
-              <Spinner aria-label={`${jobStatusLabel(job.status)} process`} size="sm" />
-            ) : null}
-            {!active && (job.status === 'succeeded' || job.status === 'completed') ? (
-              <CheckmarkCircle02Icon aria-hidden size={13} />
-            ) : null}
-            {!active && job.status === 'failed' ? <Alert02Icon aria-hidden size={13} /> : null}
-            {jobStatusLabel(job.status)}
-          </span>
-        </Chip>
+        <div className="flex shrink-0 items-center gap-1">
+          <Chip color={color} size="sm" variant="soft">
+            <span className="inline-flex items-center gap-1.5">
+              {active ? (
+                <Spinner aria-label={`${jobStatusLabel(job.status)} process`} size="sm" />
+              ) : null}
+              {!active && (job.status === 'succeeded' || job.status === 'completed') ? (
+                <CheckmarkCircle02Icon aria-hidden size={13} />
+              ) : null}
+              {!active && job.status === 'failed' ? <Alert02Icon aria-hidden size={13} /> : null}
+              {jobStatusLabel(job.status)}
+            </span>
+          </Chip>
+        </div>
       </div>
 
       {hasProgress(job) ? (
@@ -169,11 +197,24 @@ function BackgroundJobCard({ job }: { job: BackgroundJob }) {
         </p>
       ) : null}
       {!active ? (
-        <p className="text-[11px] text-muted">
-          {job.finished_at
-            ? `${jobStatusLabel(job.status)} ${timeAgo(job.finished_at)}`
-            : 'Finished'}
-        </p>
+        <div className="flex flex-wrap items-center justify-between gap-2 pt-0.5">
+          <p className="text-[11px] text-muted">
+            {job.finished_at
+              ? `${jobStatusLabel(job.status)} ${timeAgo(job.finished_at)}`
+              : 'Finished'}
+          </p>
+          <Button
+            aria-label={`Remove ${job.title || 'background process'} from the process center`}
+            className="shrink-0"
+            isPending={isDismissing}
+            onPress={() => onDismiss(job.id)}
+            size="sm"
+            variant="tertiary"
+          >
+            <Cancel01Icon aria-hidden size={15} />
+            Remove
+          </Button>
+        </div>
       ) : null}
     </article>
   );
@@ -192,6 +233,7 @@ export function BackgroundProcessCenter() {
   const [error, setError] = useState('');
   const [errorScopeKey, setErrorScopeKey] = useState(scopeKey);
   const [announcement, setAnnouncement] = useState('');
+  const [dismissingJobIDs, setDismissingJobIDs] = useState<Set<string>>(() => new Set());
   const toast = useToast();
   const inFlightRef = useRef(false);
   const abortRef = useRef<AbortController | null>(null);
@@ -210,6 +252,7 @@ export function BackgroundProcessCenter() {
   );
   const scopedError = errorScopeKey === scopeKey ? error : '';
   const activeJobs = useMemo(() => scopedJobs.filter(isBackgroundJobActive), [scopedJobs]);
+  const finishedJobs = useMemo(() => scopedJobs.filter(isBackgroundJobFinished), [scopedJobs]);
   const activeCount = activeJobs.length;
 
   const loadJobs = useCallback(async () => {
@@ -323,6 +366,32 @@ export function BackgroundProcessCenter() {
     return () => window.clearTimeout(timeout);
   }, [announcement]);
 
+  const dismissJobs = useCallback(async (ids: string[]) => {
+    const uniqueIDs = Array.from(new Set(ids));
+    if (uniqueIDs.length === 0) return;
+    setDismissingJobIDs((current) => new Set([...current, ...uniqueIDs]));
+    try {
+      if (uniqueIDs.length === 1) {
+        await dismissBackgroundJob(uniqueIDs[0]);
+      } else {
+        await dismissBackgroundJobs(uniqueIDs);
+      }
+      const removed = new Set(uniqueIDs);
+      setJobs((current) => current.filter((job) => !removed.has(job.id)));
+      for (const id of removed) previousStatusesRef.current.delete(id);
+    } catch (reason) {
+      toastRef.current.error('Couldn’t remove process history', {
+        description: reason instanceof Error ? reason.message : 'Please try again.',
+      });
+    } finally {
+      setDismissingJobIDs((current) => {
+        const next = new Set(current);
+        for (const id of uniqueIDs) next.delete(id);
+        return next;
+      });
+    }
+  }, []);
+
   return (
     <>
       <Badge.Anchor className="shrink-0">
@@ -403,13 +472,30 @@ export function BackgroundProcessCenter() {
                   ) : null}
                   <div className="space-y-3">
                     {scopedJobs.map((job) => (
-                      <BackgroundJobCard key={job.id} job={job} />
+                      <BackgroundJobCard
+                        isDismissing={dismissingJobIDs.has(job.id)}
+                        job={job}
+                        key={job.id}
+                        onDismiss={(id) => void dismissJobs([id])}
+                      />
                     ))}
                   </div>
                 </>
               )}
             </Drawer.Body>
-            <Drawer.Footer className="border-t border-border p-4">
+            <Drawer.Footer className="flex flex-col gap-2 border-t border-border p-4">
+              {finishedJobs.length > 0 ? (
+                <Button
+                  className="w-full"
+                  isDisabled={dismissingJobIDs.size > 0}
+                  isPending={dismissingJobIDs.size === finishedJobs.length}
+                  onPress={() => void dismissJobs(finishedJobs.map((job) => job.id))}
+                  variant="tertiary"
+                >
+                  <Cancel01Icon aria-hidden size={15} />
+                  Remove completed &amp; failed ({finishedJobs.length})
+                </Button>
+              ) : null}
               <Button slot="close" className="w-full" variant="secondary">
                 Close
               </Button>

--- a/services/frontend/components/background-process-center.tsx
+++ b/services/frontend/components/background-process-center.tsx
@@ -15,10 +15,11 @@ import type { BackgroundJob } from '@/lib/api/types/background-jobs';
 import { timeAgo } from '@/lib/time';
 import { useToast } from '@/components/toast';
 import { useWorkScope } from '@/hooks/use-work-scope';
-import { Badge, Button, Chip, Drawer, ProgressBar, Spinner } from '@heroui/react';
+import { Badge, Button, ButtonGroup, Chip, Drawer, ProgressBar, Spinner } from '@heroui/react';
 import {
   Activity01Icon,
   Alert02Icon,
+  ArrowRight01Icon,
   Cancel01Icon,
   CheckmarkCircle02Icon,
   Refresh01Icon,
@@ -88,6 +89,20 @@ function jobDisplayTime(job: BackgroundJob) {
   return Date.parse(job.finished_at ?? job.started_at ?? job.created_at) || 0;
 }
 
+function scanDetailsHref(job: BackgroundJob) {
+  if (job.type !== 'scan') return null;
+  const scanID = job.metadata?.scan_id ?? job.metadata?.resource_id;
+  if (typeof scanID !== 'string' || !scanID.trim()) return null;
+  return `/scans/details/${encodeURIComponent(scanID)}`;
+}
+
+function isWatchlistScanJob(job: BackgroundJob) {
+  return (
+    job.type === 'scan' &&
+    (job.metadata?.trigger_source === 'watchlist' || typeof job.metadata?.watchlist_id === 'string')
+  );
+}
+
 function mergeJobs(current: BackgroundJob[], incoming: BackgroundJob[]) {
   const nextById = new Map(incoming.map((job) => [job.id, job]));
 
@@ -134,86 +149,125 @@ function BackgroundJobCard({
   const progressTotal = Math.max(1, job.progress_total ?? 1);
   const progressPercent = Math.min(100, (progressCurrent / progressTotal) * 100);
   const color = jobStatusColor(job.status);
+  const scanHref = scanDetailsHref(job);
 
   return (
     <article
       aria-label={`${job.title}, ${jobStatusLabel(job.status)}`}
-      className="space-y-3 rounded-xl border border-border bg-surface-secondary/60 p-3"
+      className="overflow-hidden rounded-xl border border-border bg-surface-secondary/60"
     >
-      <div className="flex items-start gap-3">
-        <div className="min-w-0 flex-1">
-          <p className="text-sm font-medium text-foreground">{job.title}</p>
-          {job.description ? (
-            <p className="mt-1 text-xs leading-5 text-muted">{job.description}</p>
-          ) : null}
-        </div>
-        <div className="flex shrink-0 items-center gap-1">
-          <Chip color={color} size="sm" variant="soft">
-            <span className="inline-flex items-center gap-1.5">
-              {active ? (
-                <Spinner aria-label={`${jobStatusLabel(job.status)} process`} size="sm" />
-              ) : null}
-              {!active && (job.status === 'succeeded' || job.status === 'completed') ? (
-                <CheckmarkCircle02Icon aria-hidden size={13} />
-              ) : null}
-              {!active && job.status === 'failed' ? <Alert02Icon aria-hidden size={13} /> : null}
-              {jobStatusLabel(job.status)}
-            </span>
-          </Chip>
-        </div>
-      </div>
-
-      {hasProgress(job) ? (
-        <div className="space-y-1.5">
-          <ProgressBar
-            aria-label={`${job.title} progress`}
-            color={color === 'default' ? 'accent' : color}
-            maxValue={progressTotal}
-            size="sm"
-            value={progressCurrent}
-          >
-            <ProgressBar.Track>
-              <ProgressBar.Fill />
-            </ProgressBar.Track>
-          </ProgressBar>
-          <div className="flex items-center justify-between gap-2 text-[11px] text-muted">
-            <span>{formatPhase(job.phase) || (active ? 'Working…' : jobStatusLabel(job.status))}</span>
-            <span className="tabular-nums">
-              {progressCurrent.toLocaleString()} / {progressTotal.toLocaleString()} (
-              {Math.round(progressPercent)}%)
-            </span>
+      <div className="space-y-3 p-3">
+        <div className="flex items-start gap-3">
+          <div className="min-w-0 flex-1">
+            <p className="text-sm font-medium text-foreground">{job.title}</p>
+            {job.description ? (
+              <p className="mt-1 text-xs leading-5 text-muted">{job.description}</p>
+            ) : null}
+          </div>
+          <div className="flex shrink-0 items-center gap-1">
+            <Chip color={color} size="sm" variant="soft">
+              <span className="inline-flex items-center gap-1.5">
+                {active ? (
+                  <Spinner aria-label={`${jobStatusLabel(job.status)} process`} size="sm" />
+                ) : null}
+                {!active && (job.status === 'succeeded' || job.status === 'completed') ? (
+                  <CheckmarkCircle02Icon aria-hidden size={13} />
+                ) : null}
+                {!active && job.status === 'failed' ? <Alert02Icon aria-hidden size={13} /> : null}
+                {jobStatusLabel(job.status)}
+              </span>
+            </Chip>
+            {isWatchlistScanJob(job) ? (
+              <Chip color="accent" size="sm" variant="soft">
+                Watchlist
+              </Chip>
+            ) : null}
           </div>
         </div>
-      ) : active ? (
-        <div className="flex items-center gap-2 text-xs text-muted">
-          <Spinner aria-hidden size="sm" />
-          <span>{formatPhase(job.phase) || 'Working in the background…'}</span>
-        </div>
-      ) : null}
 
-      {job.status === 'failed' && job.error ? (
-        <p className="rounded-lg bg-danger/10 px-2.5 py-2 text-xs leading-5 text-danger">
-          {job.error}
-        </p>
-      ) : null}
-      {!active ? (
-        <div className="flex flex-wrap items-center justify-between gap-2 pt-0.5">
-          <p className="text-[11px] text-muted">
-            {job.finished_at
-              ? `${jobStatusLabel(job.status)} ${timeAgo(job.finished_at)}`
-              : 'Finished'}
+        {hasProgress(job) ? (
+          <div className="space-y-1.5">
+            <ProgressBar
+              aria-label={`${job.title} progress`}
+              color={color === 'default' ? 'accent' : color}
+              maxValue={progressTotal}
+              size="sm"
+              value={progressCurrent}
+            >
+              <ProgressBar.Track>
+                <ProgressBar.Fill />
+              </ProgressBar.Track>
+            </ProgressBar>
+            <div className="flex items-center justify-between gap-2 text-[11px] text-muted">
+              <span>{formatPhase(job.phase) || (active ? 'Working…' : jobStatusLabel(job.status))}</span>
+              <span className="tabular-nums">
+                {progressCurrent.toLocaleString()} / {progressTotal.toLocaleString()} (
+                {Math.round(progressPercent)}%)
+              </span>
+            </div>
+          </div>
+        ) : active ? (
+          <div className="flex items-center gap-2 text-xs text-muted">
+            <Spinner aria-hidden size="sm" />
+            <span>{formatPhase(job.phase) || 'Working in the background…'}</span>
+          </div>
+        ) : null}
+
+        {job.status === 'failed' && job.error ? (
+          <p className="rounded-lg bg-danger/10 px-2.5 py-2 text-xs leading-5 text-danger">
+            {job.error}
           </p>
-          <Button
-            aria-label={`Remove ${job.title || 'background process'} from the process center`}
-            className="shrink-0"
-            isPending={isDismissing}
-            onPress={() => onDismiss(job.id)}
-            size="sm"
-            variant="tertiary"
-          >
-            <Cancel01Icon aria-hidden size={15} />
-            Remove
-          </Button>
+        ) : null}
+        {!active ? (
+          <p className="text-[11px] text-muted">
+            {job.finished_at ? `${jobStatusLabel(job.status)} ${timeAgo(job.finished_at)}` : 'Finished'}
+          </p>
+        ) : null}
+      </div>
+
+      {scanHref || !active ? (
+        <div className="border-t border-border bg-surface-tertiary/30 p-2.5">
+          {scanHref && !active ? (
+            <ButtonGroup fullWidth size="sm" variant="secondary">
+              <Button
+                render={(props: any) => <a {...props} href={scanHref} />}
+              >
+                View scan
+                <ArrowRight01Icon aria-hidden size={15} />
+              </Button>
+              <Button
+                aria-label={`Remove ${job.title || 'background process'} from the process center`}
+                isPending={isDismissing}
+                onPress={() => onDismiss(job.id)}
+              >
+                <ButtonGroup.Separator />
+                <Cancel01Icon aria-hidden size={15} />
+                Remove
+              </Button>
+            </ButtonGroup>
+          ) : scanHref ? (
+            <Button
+              fullWidth
+              render={(props: any) => <a {...props} href={scanHref} />}
+              size="sm"
+              variant="secondary"
+            >
+              View scan
+              <ArrowRight01Icon aria-hidden size={15} />
+            </Button>
+          ) : (
+            <Button
+              aria-label={`Remove ${job.title || 'background process'} from the process center`}
+              fullWidth
+              isPending={isDismissing}
+              onPress={() => onDismiss(job.id)}
+              size="sm"
+              variant="tertiary"
+            >
+              <Cancel01Icon aria-hidden size={15} />
+              Remove
+            </Button>
+          )}
         </div>
       ) : null}
     </article>

--- a/services/frontend/components/scans/intelligence-policy-impact-banner.tsx
+++ b/services/frontend/components/scans/intelligence-policy-impact-banner.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import type { ScanIntelligencePolicyImpactResponse } from '@/lib/api';
-import { Alert, Button, Chip, Disclosure, Link as HeroLink } from '@heroui/react';
+import { Accordion, Alert, Button, Chip, Link as HeroLink } from '@heroui/react';
 import { Refresh01Icon, ShieldKeyIcon } from 'hugeicons-react';
 
 interface IntelligencePolicyImpactBannerProps {
@@ -97,18 +97,19 @@ export function IntelligencePolicyImpactBanner({
   );
 
   return (
-    <Alert className="items-start gap-3" status={meta.status}>
+    <Alert className="items-start gap-3 py-4" status={meta.status}>
       <Alert.Indicator>
         <ShieldKeyIcon size={18} />
       </Alert.Indicator>
-      <Alert.Content className="min-w-0 flex-1 gap-3">
-        <div className="flex flex-wrap items-start justify-between gap-3">
-          <div className="min-w-0">
+      <Alert.Content className="min-w-0 flex-1 gap-4">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div className="min-w-0 flex-1">
             <Alert.Title>Policy result pending confirmation</Alert.Title>
             <Alert.Description className="mt-1 max-w-4xl">{meta.description}</Alert.Description>
           </div>
           {canRescan ? (
             <Button
+              className="shrink-0 self-start"
               isDisabled={rescanPending}
               isPending={rescanPending}
               onPress={onRescan}
@@ -134,52 +135,59 @@ export function IntelligencePolicyImpactBanner({
           <span className="text-xs text-muted">Stored result preserved</span>
         </div>
 
-        <Disclosure className="border-t border-divider/60 pt-2">
-          <Disclosure.Heading>
-            <Disclosure.Trigger className="w-full justify-between text-left text-xs font-medium text-muted hover:text-foreground">
-              Review policy impact
-              <Disclosure.Indicator />
-            </Disclosure.Trigger>
-          </Disclosure.Heading>
-          <Disclosure.Content>
-            <Disclosure.Body className="space-y-3 pt-3">
-              <div className="space-y-2">
-                {impact.policies.map((policy) => (
-                  <div
-                    className="border-l-2 border-divider pl-3"
-                    key={`${policy.org_id}-${policy.policy_id}`}
-                  >
-                    <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs">
-                      <span className="font-medium text-foreground">{policy.policy_name}</span>
-                      <span className="text-muted">
-                        {formatStatus(policy.historical_status)} →{' '}
-                        {formatStatus(policy.current_status)}
-                      </span>
-                    </div>
-                    <p className="mt-1 text-xs text-muted">{policy.reason}</p>
-                  </div>
-                ))}
-              </div>
-
-              {cves.length > 0 ? (
-                <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted">
-                  <span>Changed CVEs:</span>
-                  {cves.map((cve) => (
-                    <HeroLink
-                      key={cve}
-                      className="font-mono text-accent underline-offset-2"
-                      href={`/vulnkb/${encodeURIComponent(cve)}`}
+        <Accordion className="w-full overflow-hidden rounded-lg border border-divider/70 bg-surface/40" hideSeparator>
+          <Accordion.Item id="policy-impact">
+            <Accordion.Heading>
+              <Accordion.Trigger className="group flex min-h-10 w-full items-center gap-3 px-3 text-left hover:bg-surface-secondary/70">
+                <span className="min-w-0 flex-1 text-sm font-medium text-foreground">
+                  Review policy impact
+                </span>
+                <span className="hidden text-xs text-muted sm:inline">
+                  {policyNames.length} {policyNames.length === 1 ? 'policy' : 'policies'} affected
+                </span>
+                <Accordion.Indicator className="shrink-0 text-muted group-hover:text-foreground [&>svg]:size-4" />
+              </Accordion.Trigger>
+            </Accordion.Heading>
+            <Accordion.Panel className="border-t border-divider/70">
+              <Accordion.Body className="space-y-3 px-3 pb-3 pt-3">
+                <div className="space-y-2">
+                  {impact.policies.map((policy) => (
+                    <div
+                      className="border-l-2 border-divider pl-3"
+                      key={`${policy.org_id}-${policy.policy_id}`}
                     >
-                      {cve}
-                    </HeroLink>
+                      <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs">
+                        <span className="font-medium text-foreground">{policy.policy_name}</span>
+                        <span className="text-muted">
+                          {formatStatus(policy.historical_status)} →{' '}
+                          {formatStatus(policy.current_status)}
+                        </span>
+                      </div>
+                      <p className="mt-1 text-xs text-muted">{policy.reason}</p>
+                    </div>
                   ))}
                 </div>
-              ) : null}
 
-              <p className="text-xs text-muted">Policies: {policyNames.join(', ')}</p>
-            </Disclosure.Body>
-          </Disclosure.Content>
-        </Disclosure>
+                {cves.length > 0 ? (
+                  <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-muted">
+                    <span>Changed CVEs:</span>
+                    {cves.map((cve) => (
+                      <HeroLink
+                        key={cve}
+                        className="font-mono text-accent underline-offset-2"
+                        href={`/vulnkb/${encodeURIComponent(cve)}`}
+                      >
+                        {cve}
+                      </HeroLink>
+                    ))}
+                  </div>
+                ) : null}
+
+                <p className="text-xs text-muted">Policies: {policyNames.join(', ')}</p>
+              </Accordion.Body>
+            </Accordion.Panel>
+          </Accordion.Item>
+        </Accordion>
 
         {!canRescan && rescanDisabledReason ? (
           <p className="text-xs text-muted">{rescanDisabledReason}</p>

--- a/services/frontend/lib/api/background-jobs.ts
+++ b/services/frontend/lib/api/background-jobs.ts
@@ -21,6 +21,14 @@ export function listBackgroundJobs(limit = 50, options?: ApiRequestOptions) {
   );
 }
 
+export function dismissBackgroundJob(id: string, options?: ApiRequestOptions) {
+  return req<void>('DELETE', `/api/v1/background-jobs/${encodeURIComponent(id)}`, undefined, options);
+}
+
+export function dismissBackgroundJobs(ids: string[], options?: ApiRequestOptions) {
+  return req<{ dismissed: number }>('DELETE', '/api/v1/background-jobs', { ids }, options);
+}
+
 export function openBackgroundProcessCenter() {
   if (typeof window === 'undefined') return;
   window.dispatchEvent(new Event(OPEN_BACKGROUND_PROCESS_CENTER_EVENT));


### PR DESCRIPTION
## Summary

- Allow users to remove completed or failed jobs from their own Process Center view without deleting shared job history.
- Add bulk dismissal support with authorization checks and database migration.
- Prioritize active scans and link Process Center scan jobs to their source and scan details.
- Update frontend controls and documentation for job dismissal and progress navigation.

## Testing

- Added backend tests for user-specific dismissals, active-job rejection, filtered listings, and watchlist metadata.
- Run `go test ./...` in `services/backend`.
- Run frontend lint and build checks in `services/frontend`.