### PR TITLE
Add Git repository image discovery

### DIFF
--- a/services/backend/database/migrations/111_git_repository_registry_discovery.go
+++ b/services/backend/database/migrations/111_git_repository_registry_discovery.go
@@ -1,0 +1,37 @@
+package migrations
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/uptrace/bun"
+)
+
+func init() {
+	Migrations.MustRegister(func(ctx context.Context, db *bun.DB) error {
+		for _, statement := range []string{
+			`ALTER TABLE git_repositories
+				ADD COLUMN IF NOT EXISTS discovery_registry_id UUID NULL REFERENCES registries(id) ON DELETE SET NULL`,
+			`ALTER TABLE git_repositories
+				ADD COLUMN IF NOT EXISTS discovery_registry TEXT NOT NULL DEFAULT ''`,
+			`CREATE INDEX IF NOT EXISTS idx_git_repositories_discovery_registry
+				ON git_repositories(discovery_registry_id)`,
+		} {
+			if _, err := db.NewRaw(statement).Exec(ctx); err != nil {
+				return fmt.Errorf("migration 111 Git repository registry discovery: %w", err)
+			}
+		}
+		return nil
+	}, func(ctx context.Context, db *bun.DB) error {
+		for _, statement := range []string{
+			`DROP INDEX IF EXISTS idx_git_repositories_discovery_registry`,
+			`ALTER TABLE git_repositories DROP COLUMN IF EXISTS discovery_registry`,
+			`ALTER TABLE git_repositories DROP COLUMN IF EXISTS discovery_registry_id`,
+		} {
+			if _, err := db.NewRaw(statement).Exec(ctx); err != nil {
+				return fmt.Errorf("migration 111 Git repository registry discovery rollback: %w", err)
+			}
+		}
+		return nil
+	})
+}

--- a/services/backend/functions/gitrepositories/gitlab_ci.go
+++ b/services/backend/functions/gitrepositories/gitlab_ci.go
@@ -1,0 +1,420 @@
+package gitrepositories
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"justscan-backend/scanner"
+
+	"sigs.k8s.io/yaml"
+)
+
+const (
+	gitLabCIFileName        = ".gitlab-ci.yml"
+	gitLabCIAltFileName     = ".gitlab-ci.yaml"
+	gitLabCIMaxIncludeDepth = 16
+)
+
+var (
+	gitLabCIVariablePattern  = regexp.MustCompile(`\$(?:\{([A-Za-z_][A-Za-z0-9_]*)\}|([A-Za-z_][A-Za-z0-9_]*))`)
+	gitLabCIDocumentBoundary = regexp.MustCompile(`(?m)^---[ \t]*(?:#.*)?\r?$`)
+)
+
+// discoverGitLabCI extracts concrete container image references from one or
+// more GitLab CI configuration files. If paths is empty, the conventional
+// root .gitlab-ci.yml/.gitlab-ci.yaml files are used. Explicit paths may be
+// files, directories, or filepath globs; all paths are resolved below root.
+func discoverGitLabCI(root string, paths []string) ([]DiscoveredImage, error) {
+	files, err := gitLabCIConfigFiles(root, paths)
+	if err != nil {
+		return nil, err
+	}
+	byRef := map[string]*DiscoveredImage{}
+	visited := map[string]bool{}
+	for _, file := range files {
+		if err := appendGitLabCIFile(root, file, byRef, visited, 0); err != nil {
+			return nil, err
+		}
+	}
+	return sortedDiscoveredImages(byRef), nil
+}
+
+func gitLabCIConfigFiles(root string, paths []string) ([]string, error) {
+	if len(paths) == 0 {
+		paths = []string{gitLabCIFileName, gitLabCIAltFileName}
+	}
+	files := make([]string, 0, len(paths))
+	seen := map[string]bool{}
+	for _, raw := range paths {
+		raw = strings.TrimSpace(raw)
+		if raw == "" {
+			continue
+		}
+		matches, err := gitLabCIPathMatches(root, raw)
+		if err != nil {
+			return nil, err
+		}
+		for _, match := range matches {
+			match = filepath.Clean(match)
+			if !seen[match] {
+				seen[match] = true
+				files = append(files, match)
+			}
+		}
+	}
+	sort.Strings(files)
+	return files, nil
+}
+
+func gitLabCIPathMatches(root, raw string) ([]string, error) {
+	if !hasGitLabCIGlob(raw) {
+		path, err := resolveRepositoryPath(root, raw)
+		if err != nil {
+			return nil, err
+		}
+		info, err := os.Stat(path)
+		if os.IsNotExist(err) && (raw == gitLabCIFileName || raw == gitLabCIAltFileName) {
+			// A repository may use either spelling. Missing conventional files
+			// are therefore an empty discovery result, not a failed scan.
+			return nil, nil
+		}
+		if err != nil {
+			return nil, fmt.Errorf("stat GitLab CI config %q: %w", raw, err)
+		}
+		if info.IsDir() {
+			return gitLabCIWalkFiles(root, path)
+		}
+		return []string{path}, nil
+	}
+
+	clean := filepath.Clean(raw)
+	if filepath.IsAbs(raw) || strings.HasPrefix(clean, ".."+string(filepath.Separator)) || clean == ".." {
+		return nil, fmt.Errorf("GitLab CI config path %q is outside the repository", raw)
+	}
+	matches, err := filepath.Glob(filepath.Join(root, clean))
+	if err != nil {
+		return nil, fmt.Errorf("invalid GitLab CI config pattern %q: %w", raw, err)
+	}
+	result := make([]string, 0, len(matches))
+	for _, match := range matches {
+		if !pathWithin(root, match) {
+			return nil, fmt.Errorf("GitLab CI config path %q is outside the repository", raw)
+		}
+		info, statErr := os.Stat(match)
+		if statErr != nil {
+			return nil, fmt.Errorf("stat GitLab CI config %q: %w", raw, statErr)
+		}
+		if info.IsDir() {
+			walked, walkErr := gitLabCIWalkFiles(root, match)
+			if walkErr != nil {
+				return nil, walkErr
+			}
+			result = append(result, walked...)
+		} else if isYAMLFile(match) {
+			result = append(result, match)
+		}
+	}
+	sort.Strings(result)
+	return result, nil
+}
+
+func gitLabCIWalkFiles(root, directory string) ([]string, error) {
+	files := []string{}
+	err := filepath.WalkDir(directory, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() {
+			if entry.Name() == ".git" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if isYAMLFile(path) {
+			files = append(files, filepath.Clean(path))
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("walk GitLab CI config directory %q: %w", relativePath(root, directory), err)
+	}
+	sort.Strings(files)
+	return files, nil
+}
+
+func appendGitLabCIFile(root, file string, byRef map[string]*DiscoveredImage, visited map[string]bool, depth int) error {
+	file = filepath.Clean(file)
+	if visited[file] {
+		return nil
+	}
+	if depth > gitLabCIMaxIncludeDepth {
+		return fmt.Errorf("GitLab CI config include depth exceeds %d", gitLabCIMaxIncludeDepth)
+	}
+	visited[file] = true
+	info, err := os.Stat(file)
+	if err != nil {
+		return fmt.Errorf("stat GitLab CI config %q: %w", relativePath(root, file), err)
+	}
+	if info.IsDir() {
+		return fmt.Errorf("GitLab CI config %q is a directory", relativePath(root, file))
+	}
+	if info.Size() > maxManifestBytes {
+		return fmt.Errorf("GitLab CI config %q exceeds %d bytes", relativePath(root, file), maxManifestBytes)
+	}
+	content, err := os.ReadFile(file)
+	if err != nil {
+		return fmt.Errorf("read GitLab CI config %q: %w", relativePath(root, file), err)
+	}
+
+	var globalVariables map[string]string
+	for document, raw := range gitLabCIDocuments(content) {
+		var configuration map[string]any
+		if err := yaml.Unmarshal(raw, &configuration); err != nil {
+			return fmt.Errorf("parse GitLab CI config %q: %w", relativePath(root, file), err)
+		}
+		if configuration == nil {
+			continue
+		}
+		variables := gitLabCIStringVariables(configuration["variables"])
+		if len(variables) > 0 {
+			if globalVariables == nil {
+				globalVariables = map[string]string{}
+			}
+			for key, value := range variables {
+				globalVariables[key] = value
+			}
+		}
+		appendGitLabCIImageValue(root, byRef, configuration["image"], file, document, "", "image", globalVariables)
+
+		if defaultConfig, ok := configuration["default"].(map[string]any); ok {
+			appendGitLabCIImageValue(root, byRef, defaultConfig["image"], file, document, "default", "default.image", globalVariables)
+			appendGitLabCIServices(root, byRef, defaultConfig["services"], file, document, "default", "default.services", globalVariables)
+		}
+		appendGitLabCIServices(root, byRef, configuration["services"], file, document, "", "services", globalVariables)
+
+		for key, value := range configuration {
+			if gitLabCIReservedKey(key) {
+				continue
+			}
+			job, ok := value.(map[string]any)
+			if !ok {
+				continue
+			}
+			jobVariables := cloneGitLabCIVariables(globalVariables)
+			for variable, variableValue := range gitLabCIStringVariables(job["variables"]) {
+				jobVariables[variable] = variableValue
+			}
+			appendGitLabCIImageValue(root, byRef, job["image"], file, document, key, key+".image", jobVariables)
+			appendGitLabCIServices(root, byRef, job["services"], file, document, key, key+".services", jobVariables)
+		}
+
+		for _, include := range gitLabCILocalIncludes(configuration["include"]) {
+			includePath, includeErr := resolveGitLabCILocalInclude(root, file, include)
+			if includeErr != nil {
+				return includeErr
+			}
+			if includePath == "" {
+				continue
+			}
+			if err := appendGitLabCIFile(root, includePath, byRef, visited, depth+1); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func gitLabCIDocuments(content []byte) [][]byte {
+	// GitLab's optional `spec` header uses YAML's document separator. Parsing
+	// each document keeps image declarations in the actual pipeline document
+	// discoverable while remaining tolerant of ordinary single-document files.
+	parts := gitLabCIDocumentBoundary.Split(string(content), -1)
+	result := make([][]byte, 0, len(parts))
+	for _, part := range parts {
+		if strings.TrimSpace(part) != "" {
+			result = append(result, []byte(part))
+		}
+	}
+	if len(result) == 0 {
+		return [][]byte{content}
+	}
+	return result
+}
+
+func appendGitLabCIImageValue(root string, byRef map[string]*DiscoveredImage, value any, file string, document int, job, path string, variables map[string]string) {
+	image := gitLabCIImageName(value)
+	if image == "" {
+		return
+	}
+	image = expandGitLabCIValue(image, variables)
+	if !isConcreteGitLabCIImage(image) {
+		return
+	}
+	fullRef, imageName, imageTag := scanner.NormalizeHelmImageRef(image)
+	if fullRef == "" || imageName == "" {
+		return
+	}
+	item := byRef[fullRef]
+	if item == nil {
+		item = &DiscoveredImage{FullRef: fullRef, ImageName: imageName, ImageTag: imageTag}
+		byRef[fullRef] = item
+	}
+	item.Locations = append(item.Locations, ImageLocation{
+		File: relativePath(root, file), Document: document + 1, Kind: "GitLabCI", Name: job, Path: path,
+	})
+}
+
+func appendGitLabCIServices(root string, byRef map[string]*DiscoveredImage, value any, file string, document int, job, path string, variables map[string]string) {
+	items, ok := value.([]any)
+	if !ok {
+		return
+	}
+	for index, item := range items {
+		servicePath := fmt.Sprintf("%s[%d]", path, index)
+		appendGitLabCIImageValue(root, byRef, item, file, document, job, servicePath, variables)
+	}
+}
+
+func gitLabCIImageName(value any) string {
+	switch image := value.(type) {
+	case string:
+		return strings.TrimSpace(image)
+	case map[string]any:
+		name, _ := image["name"].(string)
+		return strings.TrimSpace(name)
+	default:
+		return ""
+	}
+}
+
+func gitLabCIStringVariables(value any) map[string]string {
+	variables := map[string]string{}
+	items, ok := value.(map[string]any)
+	if !ok {
+		return variables
+	}
+	for key, value := range items {
+		switch typed := value.(type) {
+		case string:
+			variables[key] = typed
+		case fmt.Stringer:
+			variables[key] = typed.String()
+		case int, int64, float64, bool:
+			variables[key] = fmt.Sprint(typed)
+		}
+	}
+	return variables
+}
+
+func cloneGitLabCIVariables(source map[string]string) map[string]string {
+	result := map[string]string{}
+	for key, value := range source {
+		result[key] = value
+	}
+	return result
+}
+
+func expandGitLabCIValue(value string, variables map[string]string) string {
+	result := strings.TrimSpace(value)
+	for iteration := 0; iteration < 8; iteration++ {
+		changed := false
+		result = gitLabCIVariablePattern.ReplaceAllStringFunc(result, func(match string) string {
+			parts := gitLabCIVariablePattern.FindStringSubmatch(match)
+			name := parts[1]
+			if name == "" {
+				name = parts[2]
+			}
+			replacement, ok := variables[name]
+			if !ok {
+				return match
+			}
+			changed = true
+			return replacement
+		})
+		if !changed {
+			break
+		}
+	}
+	return strings.TrimSpace(result)
+}
+
+func isConcreteGitLabCIImage(value string) bool {
+	if value == "" || strings.ContainsAny(value, " \t\r\n") {
+		return false
+	}
+	if gitLabCIVariablePattern.MatchString(value) || strings.ContainsAny(value, "*?") {
+		return false
+	}
+	// GitLab permits image names with a digest and tags, but not arbitrary URL
+	// schemes. Keeping this check narrow avoids treating include URLs or script
+	// values as image declarations if the config shape changes.
+	return !strings.Contains(value, "://")
+}
+
+func gitLabCIReservedKey(key string) bool {
+	switch key {
+	case "default", "include", "stages", "variables", "workflow", "image", "services", "before_script", "after_script", "cache", "pages", "schedules", "spec":
+		return true
+	default:
+		// Dot-prefixed entries are hidden jobs/templates in GitLab CI. They can
+		// still declare image or services and must be inspected like any other
+		// job; do not treat their names as reserved YAML keys.
+		return false
+	}
+}
+
+func gitLabCILocalIncludes(value any) []string {
+	result := []string{}
+	switch include := value.(type) {
+	case string:
+		result = append(result, include)
+	case []any:
+		for _, item := range include {
+			result = append(result, gitLabCILocalIncludes(item)...)
+		}
+	case map[string]any:
+		if local, ok := include["local"].(string); ok {
+			result = append(result, local)
+		}
+	}
+	return result
+}
+
+func resolveGitLabCILocalInclude(root, includingFile, include string) (string, error) {
+	include = strings.TrimSpace(include)
+	if include == "" || strings.HasPrefix(include, "http://") || strings.HasPrefix(include, "https://") {
+		return "", nil
+	}
+	include = strings.TrimPrefix(include, "/")
+	path, err := resolveRepositoryPath(root, include)
+	if err != nil {
+		return "", fmt.Errorf("resolve GitLab CI local include %q: %w", include, err)
+	}
+	if _, err := os.Stat(path); err == nil {
+		return path, nil
+	} else if !os.IsNotExist(err) {
+		return "", fmt.Errorf("stat GitLab CI local include %q: %w", include, err)
+	}
+	// A relative fallback is useful for hand-authored nested configs while the
+	// root-relative path remains the GitLab-defined interpretation.
+	nested := filepath.Join(filepath.Dir(includingFile), include)
+	if pathWithin(root, nested) {
+		if _, err := os.Stat(nested); err == nil {
+			return filepath.Clean(nested), nil
+		}
+	}
+	return "", fmt.Errorf("GitLab CI local include %q not found", include)
+}
+
+func hasGitLabCIGlob(value string) bool {
+	return strings.ContainsAny(value, "*?[")
+}
+
+func isYAMLFile(path string) bool {
+	ext := strings.ToLower(filepath.Ext(path))
+	return ext == ".yaml" || ext == ".yml"
+}

--- a/services/backend/functions/gitrepositories/gitlab_ci_test.go
+++ b/services/backend/functions/gitrepositories/gitlab_ci_test.go
@@ -1,0 +1,162 @@
+package gitrepositories
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"justscan-backend/pkg/models"
+)
+
+func TestDiscoverGitLabCIExtractsDeclaredImagesAcrossConfigFiles(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "ci"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	configs := map[string]string{
+		filepath.Join(root, ".gitlab-ci.yml"): `variables:
+  REGISTRY: registry.example.com
+image: alpine:3.20
+default:
+  image:
+    name: ${REGISTRY}/base:1.0
+  services:
+    - name: docker:27-dind
+build:
+  image: ${REGISTRY}/team/build:2.0
+  services:
+    - postgres:16
+    - name: ${REGISTRY}/team/cache:3.0
+  variables:
+    JOB_REGISTRY: jobs.example.com
+  script:
+    - echo this is not an image declaration
+not-a-job:
+  description: this mapping intentionally has no image
+`,
+		filepath.Join(root, "ci", "release.yml"): `release:
+  image: jobs.example.com/release:latest
+  services:
+    - name: redis:7
+variables:
+  EXAMPLE: https://docs.example.com/image:1
+`,
+	}
+	for path, content := range configs {
+		if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	images, err := discoverGitLabCI(root, []string{".gitlab-ci.yml", "ci/release.yml"})
+	if err != nil {
+		t.Fatalf("discoverGitLabCI() error = %v", err)
+	}
+	refs := map[string]DiscoveredImage{}
+	for _, image := range images {
+		refs[image.FullRef] = image
+	}
+	for _, want := range []string{
+		"alpine:3.20",
+		"registry.example.com/base:1.0",
+		"docker:27-dind",
+		"registry.example.com/team/build:2.0",
+		"postgres:16",
+		"registry.example.com/team/cache:3.0",
+		"jobs.example.com/release:latest",
+		"redis:7",
+	} {
+		if _, ok := refs[want]; !ok {
+			t.Errorf("missing discovered image %q; got %#v", want, images)
+		}
+	}
+	if len(images) != 8 {
+		t.Fatalf("discovered %d images, want 8: %#v", len(images), images)
+	}
+	build := refs["registry.example.com/team/build:2.0"]
+	if len(build.Locations) != 1 || build.Locations[0].File != ".gitlab-ci.yml" || build.Locations[0].Path != "build.image" || build.Locations[0].Name != "build" {
+		t.Fatalf("unexpected build image location: %#v", build.Locations)
+	}
+	release := refs["jobs.example.com/release:latest"]
+	if len(release.Locations) != 1 || release.Locations[0].File != "ci/release.yml" || release.Locations[0].Path != "release.image" {
+		t.Fatalf("unexpected release image location: %#v", release.Locations)
+	}
+}
+
+func TestDiscoverGitLabCIFollowsLocalIncludesAndSkipsUnresolvedImages(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, ".gitlab-ci.yml"), []byte(`include:
+  - local: ci/jobs.yml
+  - remote: https://example.com/remote.yml
+image: $CI_REGISTRY_IMAGE:$CI_COMMIT_SHA
+`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, "ci"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "ci", "jobs.yml"), []byte(`test:
+  image: ${REGISTRY}/test:1.0
+variables:
+  REGISTRY: custom.example.com
+`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	images, err := discoverGitLabCI(root, nil)
+	if err != nil {
+		t.Fatalf("discoverGitLabCI() error = %v", err)
+	}
+	if len(images) != 1 || images[0].FullRef != "custom.example.com/test:1.0" {
+		t.Fatalf("unexpected included images: %#v", images)
+	}
+	if got := images[0].Locations[0].File; got != "ci/jobs.yml" {
+		t.Fatalf("include location file = %q, want ci/jobs.yml", got)
+	}
+}
+
+func TestDiscoverGitLabCISupportsCRLFDocumentBoundaries(t *testing.T) {
+	root := t.TempDir()
+	content := "spec:\r\n  inputs: {}\r\n--- # pipeline\r\nbuild:\r\n  image: registry.example.com/team/app:1.0\r\n"
+	if err := os.WriteFile(filepath.Join(root, ".gitlab-ci.yml"), []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	images, err := discoverGitLabCI(root, nil)
+	if err != nil {
+		t.Fatalf("discoverGitLabCI() error = %v", err)
+	}
+	if len(images) != 1 || images[0].FullRef != "registry.example.com/team/app:1.0" {
+		t.Fatalf("unexpected multi-document images: %#v", images)
+	}
+	if got := images[0].Locations[0].Document; got != 2 {
+		t.Fatalf("document = %d, want 2", got)
+	}
+}
+
+func TestDiscoverRepositoryGitLabCIModeUsesEntrypoints(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "pipeline.yml"), []byte(`build:
+  image: custom.example.com/app:latest
+`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	images, err := discoverRepository(context.Background(), root, models.GitRepository{
+		DiscoveryMode: models.GitRepositoryDiscoveryGitLabCI,
+		Entrypoints:   []string{"pipeline.yml"},
+	})
+	if err != nil {
+		t.Fatalf("discoverRepository() error = %v", err)
+	}
+	if len(images) != 1 || images[0].FullRef != "custom.example.com/app:latest" {
+		t.Fatalf("unexpected GitLab CI images: %#v", images)
+	}
+}
+
+func TestDiscoverGitLabCIRejectsOutsidePaths(t *testing.T) {
+	root := t.TempDir()
+	if _, err := discoverGitLabCI(root, []string{"../pipeline.yml"}); err == nil {
+		t.Fatal("discoverGitLabCI accepted a path outside the repository")
+	}
+}

--- a/services/backend/functions/gitrepositories/registry_discovery.go
+++ b/services/backend/functions/gitrepositories/registry_discovery.go
@@ -1,0 +1,395 @@
+package gitrepositories
+
+import (
+	"bytes"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"unicode/utf8"
+
+	"justscan-backend/scanner"
+)
+
+const (
+	// Registry discovery intentionally has its own limits. A repository can
+	// contain generated artifacts that are much larger than the deployment
+	// manifests we normally inspect, and an unbounded text walk is an easy way
+	// to turn a discovery request into a memory/CPU exhaustion vector.
+	maxRegistryDiscoveryFileBytes  int64 = 5 * 1024 * 1024
+	maxRegistryDiscoveryTotalBytes int64 = 64 * 1024 * 1024
+	maxRegistryDiscoveryPrefixLen        = 512
+)
+
+var (
+	// This tokeniser deliberately excludes shell/YAML punctuation while
+	// retaining the punctuation used by OCI references (slashes, ports, tags,
+	// and digests). Candidate validation below is stricter than this expression.
+	registryDiscoveryTokenPattern  = regexp.MustCompile(`[A-Za-z0-9][A-Za-z0-9._:/@+\-]*`)
+	registryDiscoveryNamePattern   = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._\-]*$`)
+	registryDiscoveryHostPattern   = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9.\-]*[A-Za-z0-9]$|^[A-Za-z0-9]$`)
+	registryDiscoveryPortPattern   = regexp.MustCompile(`^[0-9]{1,5}$`)
+	registryDiscoveryTagPattern    = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._+\-]{0,127}$`)
+	registryDiscoveryDigestPattern = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9+._-]*:[A-Za-z0-9=_+.-]+$`)
+)
+
+var registryDiscoveryExcludedDirectories = map[string]struct{}{
+	".git": {}, ".hg": {}, ".svn": {},
+	"node_modules": {}, "vendor": {}, "third_party": {}, "third-party": {},
+	"deps": {}, "dependency": {}, "dependencies": {},
+	"dist": {}, "build": {}, "out": {}, "target": {},
+	"coverage": {}, ".coverage": {},
+	"generated": {}, "gen": {}, "__generated__": {}, "__pycache__": {},
+	".next": {}, ".nuxt": {}, ".gradle": {}, ".terraform": {},
+}
+
+var registryDiscoveryTextExtensions = map[string]struct{}{
+	".bash": {}, ".c": {}, ".cc": {}, ".cfg": {}, ".conf": {}, ".cpp": {},
+	".cs": {}, ".css": {}, ".dockerfile": {}, ".env": {}, ".fish": {},
+	".go": {}, ".gradle": {}, ".h": {}, ".hcl": {}, ".hpp": {},
+	".html": {}, ".ini": {}, ".java": {}, ".js": {}, ".json": {},
+	".jsx": {}, ".kt": {}, ".kts": {}, ".lock": {}, ".lua": {},
+	".md": {}, ".mjs": {}, ".php": {}, ".pl": {}, ".properties": {},
+	".proto": {}, ".py": {}, ".rb": {}, ".rs": {}, ".scala": {},
+	".sh": {}, ".sql": {}, ".swift": {}, ".tf": {}, ".toml": {},
+	".ts": {}, ".tsx": {}, ".txt": {}, ".xml": {}, ".yaml": {},
+	".yml": {},
+}
+
+// NormalizeRegistryDiscoveryPrefix validates and canonicalizes the host/path
+// prefix accepted by registry-reference discovery. It intentionally accepts a
+// bare host (for example, an internal DNS name) but never accepts URL schemes,
+// credentials, queries, fragments, traversal, or wildcard syntax.
+func NormalizeRegistryDiscoveryPrefix(value string) (string, error) {
+	raw := strings.TrimSpace(value)
+	if raw == "" {
+		return "", fmt.Errorf("registry discovery prefix is required")
+	}
+	if len(raw) > maxRegistryDiscoveryPrefixLen {
+		return "", fmt.Errorf("registry discovery prefix must be at most %d characters", maxRegistryDiscoveryPrefixLen)
+	}
+	if strings.ContainsAny(raw, "\x00\r\n\t \"") || strings.ContainsAny(raw, "?#@\\") {
+		return "", fmt.Errorf("registry discovery prefix must be a host/path without credentials or URL punctuation")
+	}
+	if strings.Contains(raw, "://") {
+		return "", fmt.Errorf("registry discovery prefix must omit the URL scheme")
+	}
+	if strings.HasPrefix(raw, "/") {
+		return "", fmt.Errorf("registry discovery prefix must not start with /")
+	}
+	raw = strings.TrimRight(raw, "/")
+	if raw == "" {
+		return "", fmt.Errorf("registry discovery prefix is required")
+	}
+
+	parts := strings.Split(raw, "/")
+	for index, part := range parts {
+		if part == "" || part == "." || part == ".." {
+			return "", fmt.Errorf("registry discovery prefix contains an unsafe path segment")
+		}
+		part = strings.ToLower(part)
+		if index > 0 {
+			if !registryDiscoveryNamePattern.MatchString(part) {
+				return "", fmt.Errorf("registry discovery prefix contains an invalid path segment")
+			}
+			parts[index] = part
+		}
+	}
+	if err := validateRegistryDiscoveryHost(parts[0]); err != nil {
+		return "", err
+	}
+	parts[0] = strings.ToLower(parts[0])
+	return strings.Join(parts, "/"), nil
+}
+
+func validateRegistryDiscoveryHost(host string) error {
+	if host == "" {
+		return fmt.Errorf("registry discovery prefix must include a host")
+	}
+	if strings.HasPrefix(host, "[") {
+		closing := strings.IndexByte(host, ']')
+		if closing < 0 {
+			return fmt.Errorf("registry discovery prefix contains an invalid IPv6 host")
+		}
+		if net.ParseIP(host[1:closing]) == nil {
+			return fmt.Errorf("registry discovery prefix contains an invalid IPv6 host")
+		}
+		if closing+1 < len(host) {
+			if host[closing+1] != ':' || !validRegistryDiscoveryPort(host[closing+2:]) {
+				return fmt.Errorf("registry discovery prefix contains an invalid port")
+			}
+		}
+		return nil
+	}
+
+	hostname, port := host, ""
+	if colon := strings.LastIndexByte(host, ':'); colon >= 0 {
+		if strings.Contains(host[:colon], ":") {
+			return fmt.Errorf("registry discovery prefix contains an invalid host")
+		}
+		hostname, port = host[:colon], host[colon+1:]
+		if !validRegistryDiscoveryPort(port) {
+			return fmt.Errorf("registry discovery prefix contains an invalid port")
+		}
+	}
+	if hostname == "" || strings.Contains(hostname, "..") || !registryDiscoveryHostPattern.MatchString(hostname) {
+		return fmt.Errorf("registry discovery prefix contains an invalid host")
+	}
+	if net.ParseIP(hostname) != nil {
+		return nil
+	}
+	for _, label := range strings.Split(hostname, ".") {
+		if label == "" || strings.HasPrefix(label, "-") || strings.HasSuffix(label, "-") {
+			return fmt.Errorf("registry discovery prefix contains an invalid host")
+		}
+	}
+	return nil
+}
+
+func validRegistryDiscoveryPort(port string) bool {
+	if !registryDiscoveryPortPattern.MatchString(port) {
+		return false
+	}
+	value, err := strconv.Atoi(port)
+	return err == nil && value > 0 && value <= 65535
+}
+
+// normalizeConfiguredRegistryPrefix accepts the URL form stored by the
+// registry model and converts it to the same host/path representation used by
+// manually entered prefixes.
+func normalizeConfiguredRegistryPrefix(value string) (string, error) {
+	raw := strings.TrimSpace(value)
+	if strings.Contains(raw, "://") {
+		parts := strings.SplitN(raw, "://", 2)
+		if len(parts) != 2 || (strings.ToLower(parts[0]) != "http" && strings.ToLower(parts[0]) != "https") {
+			return "", fmt.Errorf("configured registry URL must use http:// or https://")
+		}
+		raw = parts[1]
+	}
+	return NormalizeRegistryDiscoveryPrefix(raw)
+}
+
+// NormalizeConfiguredRegistryDiscoveryPrefix validates a configured registry
+// URL and returns the host/path prefix used by repository discovery.
+func NormalizeConfiguredRegistryDiscoveryPrefix(value string) (string, error) {
+	return normalizeConfiguredRegistryPrefix(value)
+}
+
+// discoverRegistry scans bounded text/code files for concrete image refs
+// addressed to prefix. It never follows symlinked files and skips common
+// generated/dependency trees before reading file contents.
+func discoverRegistry(root, prefix string) ([]DiscoveredImage, error) {
+	normalizedPrefix, err := NormalizeRegistryDiscoveryPrefix(prefix)
+	if err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(root) == "" {
+		return nil, fmt.Errorf("repository root is required")
+	}
+
+	byRef := map[string]*DiscoveredImage{}
+	seenLocations := map[string]map[string]bool{}
+	var totalBytes int64
+	err = filepath.WalkDir(root, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry == nil {
+			return nil
+		}
+		if entry.IsDir() {
+			if path != root && registryDiscoveryExcludedDirectory(entry.Name()) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if totalBytes >= maxRegistryDiscoveryTotalBytes || entry.Type()&os.ModeSymlink != 0 || !entry.Type().IsRegular() {
+			return nil
+		}
+		if !registryDiscoveryTextFile(entry.Name()) {
+			return nil
+		}
+		info, infoErr := entry.Info()
+		if infoErr != nil {
+			return infoErr
+		}
+		if info.Size() < 0 || info.Size() > maxRegistryDiscoveryFileBytes || info.Size() > maxRegistryDiscoveryTotalBytes-totalBytes {
+			return nil
+		}
+		content, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		totalBytes += int64(len(content))
+		if len(content) == 0 || bytes.IndexByte(content, 0) >= 0 || !utf8.Valid(content) {
+			return nil
+		}
+		appendRegistryDiscoveryImages(root, path, content, normalizedPrefix, byRef, seenLocations)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return sortedDiscoveredImages(byRef), nil
+}
+
+// discoverRegistryImages is kept as a descriptive alias for callers/tests
+// that use the method name rather than the shorter internal helper.
+func discoverRegistryImages(root, prefix string) ([]DiscoveredImage, error) {
+	return discoverRegistry(root, prefix)
+}
+
+func registryDiscoveryExcludedDirectory(name string) bool {
+	_, ok := registryDiscoveryExcludedDirectories[strings.ToLower(strings.TrimSpace(name))]
+	return ok
+}
+
+func registryDiscoveryTextFile(name string) bool {
+	lower := strings.ToLower(name)
+	if strings.Contains(lower, ".generated.") || strings.HasSuffix(lower, ".generated") ||
+		strings.Contains(lower, "_generated.") || strings.Contains(lower, ".gen.") ||
+		strings.HasSuffix(lower, "_gen.go") || strings.HasSuffix(lower, ".map") {
+		return false
+	}
+	if lower == "dockerfile" || lower == "containerfile" || lower == "makefile" || lower == ".env" {
+		return true
+	}
+	_, ok := registryDiscoveryTextExtensions[filepath.Ext(lower)]
+	if ok {
+		return true
+	}
+	// Extensionless executable/configuration files are often where image refs
+	// live (for example, a checked-in deploy script). Binary detection still
+	// runs after reading, so this does not admit binary payloads.
+	return filepath.Ext(lower) == ""
+}
+
+func appendRegistryDiscoveryImages(root, path string, content []byte, prefix string, byRef map[string]*DiscoveredImage, seenLocations map[string]map[string]bool) {
+	text := string(content)
+	relative := relativePath(root, path)
+	for _, bounds := range registryDiscoveryTokenPattern.FindAllStringIndex(text, -1) {
+		start, end := bounds[0], bounds[1]
+		token := text[start:end]
+		if strings.Contains(token, "://") || (start >= 3 && text[start-3:start] == "://") {
+			continue
+		}
+		if strings.HasSuffix(token, "/") || strings.HasSuffix(token, ":") || strings.HasSuffix(token, "@") {
+			continue
+		}
+		if !registryDiscoveryRefMatchesPrefix(token, prefix) {
+			continue
+		}
+		// A repository reference without an explicit selector would be
+		// normalized by NormalizeHelmImageRef as an implicit :latest. Registry
+		// discovery deliberately only reports concrete refs, so reject those
+		// before normalization. The colon in a host:port prefix is not a tag:
+		// only a colon after the last slash qualifies as an explicit tag.
+		if !hasExplicitRegistryImageSelector(token) {
+			continue
+		}
+		fullRef, imageName, imageTag := scanner.NormalizeHelmImageRef(token)
+		if !validRegistryDiscoveryImage(fullRef, imageName, imageTag) {
+			continue
+		}
+		line := 1 + strings.Count(text[:start], "\n")
+		location := ImageLocation{File: relative, Document: 1, Kind: "Registry", Path: fmt.Sprintf("line %d", line)}
+		locationKey := relative + "\x00" + location.Path
+		item := byRef[fullRef]
+		if item == nil {
+			item = &DiscoveredImage{FullRef: fullRef, ImageName: imageName, ImageTag: imageTag}
+			byRef[fullRef] = item
+		}
+		locations := seenLocations[fullRef]
+		if locations == nil {
+			locations = map[string]bool{}
+			seenLocations[fullRef] = locations
+		}
+		if locations[locationKey] {
+			continue
+		}
+		locations[locationKey] = true
+		item.Locations = append(item.Locations, location)
+	}
+	for _, image := range byRef {
+		sort.Slice(image.Locations, func(i, j int) bool {
+			if image.Locations[i].File != image.Locations[j].File {
+				return image.Locations[i].File < image.Locations[j].File
+			}
+			return image.Locations[i].Path < image.Locations[j].Path
+		})
+	}
+}
+
+func hasExplicitRegistryImageSelector(ref string) bool {
+	ref = strings.TrimSpace(ref)
+	if ref == "" {
+		return false
+	}
+	if at := strings.LastIndexByte(ref, '@'); at >= 0 {
+		return at > 0 && at < len(ref)-1
+	}
+	lastSlash := strings.LastIndexByte(ref, '/')
+	lastColon := strings.LastIndexByte(ref, ':')
+	return lastColon > lastSlash && lastColon < len(ref)-1
+}
+
+func registryDiscoveryRefMatchesPrefix(ref, prefix string) bool {
+	ref = strings.ToLower(strings.Trim(strings.TrimSpace(ref), "/"))
+	prefix = strings.ToLower(strings.Trim(strings.TrimSpace(prefix), "/"))
+	if ref == "" || prefix == "" || ref == prefix {
+		return ref == prefix && strings.Contains(ref, "/")
+	}
+	if !strings.HasPrefix(ref, prefix) {
+		return false
+	}
+	remainder := ref[len(prefix):]
+	return len(remainder) > 0 && (remainder[0] == '/' || remainder[0] == ':' || remainder[0] == '@')
+}
+
+func validRegistryDiscoveryImage(fullRef, imageName, imageTag string) bool {
+	if fullRef == "" || imageName == "" || strings.ContainsAny(fullRef, "\r\n\t \"") || strings.Contains(fullRef, "://") {
+		return false
+	}
+	if !hasExplicitRegistryImageSelector(fullRef) {
+		return false
+	}
+	parts := strings.Split(imageName, "/")
+	if len(parts) < 2 {
+		return false
+	}
+	for index, part := range parts {
+		if part == "" {
+			return false
+		}
+		if index == 0 {
+			if colon := strings.LastIndexByte(part, ':'); colon >= 0 {
+				if strings.Contains(part[:colon], ":") || !validRegistryDiscoveryPort(part[colon+1:]) {
+					return false
+				}
+				part = part[:colon]
+			}
+			if strings.HasPrefix(part, "[") {
+				if strings.TrimSpace(part) == "" || !strings.HasSuffix(part, "]") || net.ParseIP(strings.Trim(part, "[]")) == nil {
+					return false
+				}
+			} else if !registryDiscoveryHostPattern.MatchString(part) {
+				return false
+			}
+			continue
+		}
+		if !registryDiscoveryNamePattern.MatchString(part) {
+			return false
+		}
+	}
+	if strings.Contains(imageTag, "/") || strings.HasSuffix(imageTag, ":") {
+		return false
+	}
+	if strings.HasPrefix(imageTag, "sha256:") || strings.Contains(imageTag, ":") {
+		return registryDiscoveryDigestPattern.MatchString(imageTag)
+	}
+	return registryDiscoveryTagPattern.MatchString(imageTag)
+}

--- a/services/backend/functions/gitrepositories/registry_discovery_test.go
+++ b/services/backend/functions/gitrepositories/registry_discovery_test.go
@@ -1,0 +1,160 @@
+package gitrepositories
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"justscan-backend/pkg/models"
+)
+
+func TestNormalizeRegistryDiscoveryPrefix(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{name: "host and path", input: " Registry.Example.com/Team/ ", want: "registry.example.com/team"},
+		{name: "port", input: "localhost:5000/apps", want: "localhost:5000/apps"},
+		{name: "scheme", input: "https://registry.example.com/team", wantErr: true},
+		{name: "traversal", input: "registry.example.com/../team", wantErr: true},
+		{name: "wildcard", input: "registry.example.com/team/*", wantErr: true},
+		{name: "leading slash", input: "/registry.example.com/team", wantErr: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := NormalizeRegistryDiscoveryPrefix(test.input)
+			if test.wantErr {
+				if err == nil {
+					t.Fatalf("NormalizeRegistryDiscoveryPrefix(%q) accepted unsafe input as %q", test.input, got)
+				}
+				return
+			}
+			if err != nil || got != test.want {
+				t.Fatalf("NormalizeRegistryDiscoveryPrefix(%q) = %q, %v; want %q", test.input, got, err, test.want)
+			}
+		})
+	}
+}
+
+func TestDiscoverRegistryScansTextWithBoundedLocationsAndExclusions(t *testing.T) {
+	root := t.TempDir()
+	files := map[string]string{
+		"src/config.yaml":  "image: registry.example.com/team/api:1.0\nagain: registry.example.com/team/api:1.0\nother: registry.example.com/team/worker@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n",
+		"src/app.go":       `const image = "registry.example.com/team/api:1.0"` + "\n",
+		"vendor/deps.go":   `var image = "registry.example.com/team/vendor:1.0"`,
+		"generated/out.go": `var image = "registry.example.com/team/generated:1.0"`,
+		"src/other.txt":    `image: registry.example.com/team-evil/app:1.0`,
+	}
+	for name, content := range files {
+		path := filepath.Join(root, name)
+		if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(root, "src", "payload.bin"), []byte{0, 'r', 'e', 'g'}, 0600); err != nil {
+		t.Fatal(err)
+	}
+	images, err := discoverRegistry(root, "registry.example.com/team/")
+	if err != nil {
+		t.Fatalf("discoverRegistry() error = %v", err)
+	}
+	if len(images) != 2 {
+		t.Fatalf("discoverRegistry() returned %d images: %#v", len(images), images)
+	}
+	if images[0].FullRef != "registry.example.com/team/api:1.0" {
+		t.Fatalf("first image = %q", images[0].FullRef)
+	}
+	if len(images[0].Locations) != 3 {
+		t.Fatalf("api locations = %#v; want one per source line", images[0].Locations)
+	}
+	if images[0].Locations[0].File != "src/app.go" || images[0].Locations[1].File != "src/config.yaml" || images[0].Locations[2].File != "src/config.yaml" {
+		t.Fatalf("api locations = %#v", images[0].Locations)
+	}
+	if !strings.Contains(images[1].FullRef, "@sha256:") {
+		t.Fatalf("digest image = %q", images[1].FullRef)
+	}
+}
+
+func TestDiscoverRegistryRequiresExplicitTagOrDigest(t *testing.T) {
+	root := t.TempDir()
+	content := strings.Join([]string{
+		"tagged: registry.example.com/team/app:1.2.3",
+		"digest: registry.example.com/team/app@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		"tagless: registry.example.com/team/tagless",
+		"port tagged: registry.example.com:5000/team/app:1.2.3",
+		"port digest: registry.example.com:5000/team/app@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		"port tagless: registry.example.com:5000/team/tagless",
+	}, "\n")
+	if err := os.WriteFile(filepath.Join(root, "images.txt"), []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		prefix string
+		want   []string
+	}{
+		{
+			prefix: "registry.example.com/team",
+			want: []string{
+				"registry.example.com/team/app:1.2.3",
+				"registry.example.com/team/app@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			},
+		},
+		{
+			prefix: "registry.example.com:5000/team",
+			want: []string{
+				"registry.example.com:5000/team/app:1.2.3",
+				"registry.example.com:5000/team/app@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.prefix, func(t *testing.T) {
+			images, err := discoverRegistry(root, test.prefix)
+			if err != nil {
+				t.Fatalf("discoverRegistry() error = %v", err)
+			}
+			got := make(map[string]bool, len(images))
+			for _, image := range images {
+				got[image.FullRef] = true
+			}
+			if len(got) != len(test.want) {
+				t.Fatalf("discoverRegistry() found %d images: %#v; want %#v", len(got), got, test.want)
+			}
+			for _, want := range test.want {
+				if !got[want] {
+					t.Errorf("discoverRegistry() missing explicit reference %q; got %#v", want, got)
+				}
+			}
+			for ref := range got {
+				if strings.HasSuffix(ref, "/tagless") {
+					t.Errorf("discoverRegistry() accepted tagless reference %q", ref)
+				}
+			}
+		})
+	}
+}
+
+func TestDiscoverRepositoryRegistryModeDoesNotNeedEntrypoints(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "README.md"), []byte("registry.example.com/team/app:latest\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	images, err := discoverRepository(t.Context(), root, models.GitRepository{
+		DiscoveryMode:     models.GitRepositoryDiscoveryRegistry,
+		DiscoveryRegistry: "registry.example.com/team",
+		Entrypoints:       nil,
+	})
+	if err != nil {
+		t.Fatalf("discoverRepository() error = %v", err)
+	}
+	if len(images) != 1 || images[0].FullRef != "registry.example.com/team/app:latest" {
+		t.Fatalf("registry discovery images = %#v", images)
+	}
+}

--- a/services/backend/functions/gitrepositories/service.go
+++ b/services/backend/functions/gitrepositories/service.go
@@ -50,10 +50,11 @@ type ImageLocation struct {
 }
 
 type DiscoveredImage struct {
-	FullRef   string          `json:"full_ref"`
-	ImageName string          `json:"image_name"`
-	ImageTag  string          `json:"image_tag"`
-	Locations []ImageLocation `json:"locations"`
+	FullRef    string          `json:"full_ref"`
+	ImageName  string          `json:"image_name"`
+	ImageTag   string          `json:"image_tag"`
+	Locations  []ImageLocation `json:"locations"`
+	RegistryID *uuid.UUID      `json:"registry_id,omitempty"`
 }
 
 type DiscoveryCandidate struct {
@@ -334,7 +335,7 @@ func CreateDiscovery(ctx context.Context, repositoryID uuid.UUID) (*models.GitRe
 		for _, image := range images {
 			row := &models.GitRepositoryRunImage{
 				RunID: run.ID, FullRef: image.FullRef, ImageName: image.ImageName, ImageTag: image.ImageTag,
-				Locations: models.JSONObject{"items": image.Locations}, State: "discovered", CreatedAt: completedAt,
+				Locations: models.JSONObject{"items": image.Locations}, State: "discovered", RegistryID: image.RegistryID, CreatedAt: completedAt,
 			}
 			if _, err := tx.NewInsert().Model(row).Exec(ctx); err != nil {
 				return err
@@ -428,14 +429,22 @@ func processRun(runID uuid.UUID) {
 		}
 	}
 	registryOverrides := imageRegistryOverrides(ctx, db, repository.ID)
-	previous := previousRefs(ctx, db, repository.ID, run.ID, registryOverrides)
+	currentRegistryIDs := make(map[string]*uuid.UUID, len(images))
+	for _, image := range images {
+		registryID := image.RegistryID
+		if override, ok := registryOverrides[image.FullRef]; ok {
+			registryID = &override
+		}
+		currentRegistryIDs[image.FullRef] = registryID
+	}
+	previous := previousRefs(ctx, db, repository.ID, run.ID, registryOverrides, currentRegistryIDs)
 	excluded := excludedImageRefs(ctx, db, repository.ID)
 	created := 0
 	for _, image := range images {
 		if runCancelled(ctx, db, run.ID) {
 			return
 		}
-		var registryID *uuid.UUID
+		registryID := image.RegistryID
 		if override, ok := registryOverrides[image.FullRef]; ok {
 			registryID = &override
 		}
@@ -524,9 +533,27 @@ func cancelRepositoryRunScan(ctx context.Context, db *bun.DB, scanID uuid.UUID) 
 }
 
 func createScan(ctx context.Context, db *bun.DB, repository models.GitRepository, runID uuid.UUID, image DiscoveredImage, registryID *uuid.UUID) (*models.Scan, []string, error) {
-	registry, envVars, err := scanner.ResolveRegistryForScan(ctx, db, image.ImageName, registryID)
-	if err != nil {
-		return nil, nil, err
+	var registry *models.Registry
+	var envVars []string
+	if registryID != nil {
+		if db == nil {
+			return nil, nil, fmt.Errorf("selected registry is unavailable")
+		}
+		var selected models.Registry
+		if err := db.NewSelect().Model(&selected).Where("id = ?", *registryID).Scan(ctx); err != nil {
+			return nil, nil, fmt.Errorf("selected registry is unavailable")
+		}
+		allowed, err := registryBelongsToRepository(ctx, db, &selected, repository)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to check selected registry access: %w", err)
+		}
+		if !allowed {
+			return nil, nil, fmt.Errorf("selected registry is not available to this workspace")
+		}
+		registry, envVars, err = scanner.ResolveRegistryForScan(ctx, db, image.ImageName, registryID)
+		if err != nil {
+			return nil, nil, err
+		}
 	}
 	provider, err := scanner.ProviderForRegistry(registry)
 	if err != nil {
@@ -565,7 +592,7 @@ func failRun(ctx context.Context, db *bun.DB, run *models.GitRepositoryRun, err 
 		Exec(ctx)
 }
 
-func previousRefs(ctx context.Context, db *bun.DB, repositoryID, currentRunID uuid.UUID, registryOverrides map[string]uuid.UUID) map[string]bool {
+func previousRefs(ctx context.Context, db *bun.DB, repositoryID, currentRunID uuid.UUID, registryOverrides map[string]uuid.UUID, detectedRegistryIDs ...map[string]*uuid.UUID) map[string]bool {
 	var previous models.GitRepositoryRun
 	if err := db.NewSelect().Model(&previous).Where("repository_id = ?", repositoryID).Where("id != ?", currentRunID).Where("trigger != ?", "dry_run").Where("status IN (?)", bun.In([]string{models.GitRepositoryRunCompleted, models.GitRepositoryRunPartial})).OrderExpr("created_at DESC").Limit(1).Scan(ctx); err != nil {
 		return map[string]bool{}
@@ -578,7 +605,19 @@ func previousRefs(ctx context.Context, db *bun.DB, repositoryID, currentRunID uu
 		return map[string]bool{}
 	}
 	result := make(map[string]bool, len(refs))
+	currentRegistries := map[string]*uuid.UUID(nil)
+	if len(detectedRegistryIDs) > 0 {
+		currentRegistries = detectedRegistryIDs[0]
+	}
 	for _, ref := range refs {
+		if currentRegistries != nil {
+			currentRegistryID, present := currentRegistries[ref.FullRef]
+			if !present || !sameRegistryID(ref.RegistryID, currentRegistryID) {
+				continue
+			}
+			result[ref.FullRef] = true
+			continue
+		}
 		if override, ok := registryOverrides[ref.FullRef]; ok {
 			if ref.RegistryID == nil || *ref.RegistryID != override {
 				continue
@@ -589,6 +628,13 @@ func previousRefs(ctx context.Context, db *bun.DB, repositoryID, currentRunID uu
 		result[ref.FullRef] = true
 	}
 	return result
+}
+
+func sameRegistryID(left, right *uuid.UUID) bool {
+	if left == nil || right == nil {
+		return left == nil && right == nil
+	}
+	return *left == *right
 }
 
 func imageRegistryOverrides(ctx context.Context, db *bun.DB, repositoryID uuid.UUID) map[string]uuid.UUID {
@@ -697,6 +743,93 @@ func Discover(ctx context.Context, repository models.GitRepository) ([]Discovere
 	return images, commit, err
 }
 
+// registryDiscoverySelection resolves the prefix used by registry-reference
+// discovery. A configured registry is loaded and authorized against the
+// repository owner before its URL is used; a manually entered prefix never
+// implicitly selects a credential-bearing registry record.
+func registryDiscoverySelection(ctx context.Context, repository models.GitRepository) (string, *uuid.UUID, error) {
+	if repository.DiscoveryRegistryID != nil {
+		if strings.TrimSpace(repository.DiscoveryRegistry) != "" {
+			return "", nil, fmt.Errorf("choose a configured registry or a custom registry prefix, not both")
+		}
+		state.Lock()
+		db := state.db
+		state.Unlock()
+		if db == nil {
+			return "", nil, fmt.Errorf("selected registry is unavailable")
+		}
+		var registry models.Registry
+		if err := db.NewSelect().Model(&registry).Where("id = ?", *repository.DiscoveryRegistryID).Scan(ctx); err != nil {
+			return "", nil, fmt.Errorf("selected registry is unavailable")
+		}
+		allowed, err := registryBelongsToRepository(ctx, db, &registry, repository)
+		if err != nil {
+			return "", nil, fmt.Errorf("failed to check selected registry access: %w", err)
+		}
+		if !allowed {
+			return "", nil, fmt.Errorf("selected registry is not available to this workspace")
+		}
+		prefix, err := normalizeConfiguredRegistryPrefix(registry.URL)
+		if err != nil {
+			return "", nil, fmt.Errorf("selected registry URL: %w", err)
+		}
+		registryID := registry.ID
+		return prefix, &registryID, nil
+	}
+	prefix, err := NormalizeRegistryDiscoveryPrefix(repository.DiscoveryRegistry)
+	if err != nil {
+		return "", nil, err
+	}
+	return prefix, nil, nil
+}
+
+// detectImageRegistries annotates discovered images with the configured
+// registry entry that would be used for an automatic scan. Only registries
+// visible in the repository's workspace are considered; an otherwise matching
+// registry owned by another user or organization must never become an
+// implicit credential choice. Unknown hosts remain unannotated so callers can
+// preserve and, where supported, scan their original fully-qualified ref.
+func detectImageRegistries(ctx context.Context, repository models.GitRepository, images []DiscoveredImage) []DiscoveredImage {
+	state.Lock()
+	db := state.db
+	state.Unlock()
+	if db == nil || len(images) == 0 || repository.DiscoveryMode == models.GitRepositoryDiscoveryRegistry {
+		return images
+	}
+
+	var registries []models.Registry
+	if err := db.NewSelect().Model(&registries).OrderExpr("created_at DESC").Scan(ctx); err != nil {
+		log.Warnf("Git repository registry detection: list registries: %v", err)
+		return images
+	}
+	available := make([]models.Registry, 0, len(registries))
+	for index := range registries {
+		registry := &registries[index]
+		allowed, err := registryBelongsToRepository(ctx, db, registry, repository)
+		if err != nil {
+			log.Warnf("Git repository registry detection: check registry %s: %v", registry.ID, err)
+			continue
+		}
+		if allowed {
+			available = append(available, *registry)
+		}
+	}
+
+	for index := range images {
+		if images[index].RegistryID != nil {
+			continue
+		}
+		for registryIndex := range available {
+			if scanner.RegistryMatchesImage(images[index].ImageName, &available[registryIndex]) {
+				registryID := available[registryIndex].ID
+				images[index].RegistryID = &registryID
+				break
+			}
+		}
+	}
+	return images
+}
+
 // DiscoverReview returns proven deployment images plus paths which need an
 // operator decision before JustScan can safely treat them as deployments.
 func DiscoverReview(ctx context.Context, repository models.GitRepository) ([]DiscoveredImage, []DiscoveryCandidate, string, error) {
@@ -743,6 +876,7 @@ func DiscoverReview(ctx context.Context, repository models.GitRepository) ([]Dis
 	if configured {
 		rules = nil // A committed repository configuration takes precedence over UI rules.
 	}
+	images = detectImageRegistries(ctx, repository, images)
 	return images, findDiscoveryCandidates(dir, rules, configuration, managedSources), strings.TrimSpace(commit), nil
 }
 
@@ -1137,6 +1271,25 @@ func discoverRepository(ctx context.Context, root string, repository models.GitR
 	if mode == models.GitRepositoryDiscoveryManifests {
 		return discoverYAML(root)
 	}
+	if mode == models.GitRepositoryDiscoveryRegistry {
+		prefix, registryID, err := registryDiscoverySelection(ctx, repository)
+		if err != nil {
+			return nil, err
+		}
+		images, err := discoverRegistry(root, prefix)
+		if err != nil {
+			return nil, err
+		}
+		if registryID != nil {
+			for index := range images {
+				images[index].RegistryID = registryID
+			}
+		}
+		return images, nil
+	}
+	if mode == models.GitRepositoryDiscoveryGitLabCI {
+		return discoverGitLabCI(root, repository.Entrypoints)
+	}
 	roots, err := findKustomizationRoots(root, repository.Entrypoints)
 	if err != nil {
 		return nil, err
@@ -1179,7 +1332,7 @@ func discoverConfiguredSources(ctx context.Context, root string, configuration j
 	sources := append([]justScanSource{}, configuration.Discovery.Sources...)
 	for _, rule := range configuration.Discovery.Rules {
 		source := justScanSource{Type: rule.Type, Chart: rule.Chart, Values: rule.Values, ReleaseName: rule.ReleaseName, Paths: rule.Paths}
-		if len(source.Paths) == 0 && rule.Match != "" && (rule.Type == "kustomize" || rule.Type == "manifests") {
+		if len(source.Paths) == 0 && rule.Match != "" && (rule.Type == "kustomize" || rule.Type == "manifests" || rule.Type == "gitlab_ci") {
 			source.Paths = []string{rule.Match}
 		}
 		if rule.Type != "ignore" {
@@ -1217,6 +1370,25 @@ func discoverConfiguredSources(ctx context.Context, root string, configuration j
 			}
 			if err := appendManifestPaths(root, byRef, source.Paths); err != nil {
 				return nil, fmt.Errorf(".justscan.yaml source %d (manifests): %w", index+1, err)
+			}
+		case "gitlab_ci", "gitlab-ci", "gitlab":
+			paths := source.Paths
+			if len(paths) == 0 && strings.TrimSpace(source.Root) != "" {
+				paths = []string{source.Root}
+			}
+			images, err := discoverGitLabCI(root, paths)
+			if err != nil {
+				return nil, fmt.Errorf(".justscan.yaml source %d (gitlab_ci): %w", index+1, err)
+			}
+			for _, image := range images {
+				item := image
+				item.Locations = nil
+				if existing := byRef[image.FullRef]; existing != nil {
+					existing.Locations = append(existing.Locations, image.Locations...)
+					continue
+				}
+				item.Locations = append(item.Locations, image.Locations...)
+				byRef[image.FullRef] = &item
 			}
 		case "helm":
 			if err := appendHelmChartFromRoots(ctx, root, root, byRef, source, "", repository, nil, nil); err != nil {

--- a/services/backend/functions/gitrepositories/service_test.go
+++ b/services/backend/functions/gitrepositories/service_test.go
@@ -15,6 +15,8 @@ import (
 	"justscan-backend/config"
 	"justscan-backend/pkg/crypto"
 	"justscan-backend/pkg/models"
+
+	"github.com/google/uuid"
 )
 
 func TestDiscoverYAMLExtractsAndDeduplicatesWorkloadImages(t *testing.T) {
@@ -58,6 +60,36 @@ data:
 	}
 	if images[1].ImageTag != "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" {
 		t.Fatalf("digest tag = %q", images[1].ImageTag)
+	}
+}
+
+func TestCreateScanWithoutDetectedRegistryKeepsCustomHostAnonymous(t *testing.T) {
+	previousConfig := config.Config
+	config.Config = &config.RestfulConf{Scanner: config.ScannerConf{EnableTrivy: true}}
+	defer func() { config.Config = previousConfig }()
+
+	runID := uuid.New()
+	ownerID := uuid.New()
+	scan, envVars, err := createScan(context.Background(), nil, models.GitRepository{
+		CreatedByID: ownerID,
+		OwnerType:   models.OwnerTypeUser,
+		OwnerUserID: &ownerID,
+	}, runID, DiscoveredImage{
+		FullRef:   "custom.example.com/team/app:1.0",
+		ImageName: "custom.example.com/team/app",
+		ImageTag:  "1.0",
+	}, nil)
+	if err != nil {
+		t.Fatalf("createScan() error = %v", err)
+	}
+	if scan.RegistryID != nil {
+		t.Fatalf("registry ID = %v, want nil", scan.RegistryID)
+	}
+	if scan.ImageName != "custom.example.com/team/app" || scan.ImageTag != "1.0" {
+		t.Fatalf("scan target = %s:%s", scan.ImageName, scan.ImageTag)
+	}
+	if len(envVars) != 0 {
+		t.Fatalf("registry environment = %#v, want empty", envVars)
 	}
 }
 

--- a/services/backend/handlers/gitrepositories/gitrepositories.go
+++ b/services/backend/handlers/gitrepositories/gitrepositories.go
@@ -1,6 +1,7 @@
 package gitrepositories
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"path/filepath"
@@ -22,20 +23,22 @@ import (
 )
 
 type repositoryRequest struct {
-	Name          string   `json:"name"`
-	CloneURL      string   `json:"clone_url" binding:"required"`
-	Ref           string   `json:"ref"`
-	AuthType      string   `json:"auth_type"`
-	Username      string   `json:"username"`
-	Credential    string   `json:"credential"`
-	Schedule      string   `json:"schedule"`
-	Timezone      string   `json:"timezone"`
-	Enabled       bool     `json:"enabled"`
-	RescanPolicy  string   `json:"rescan_policy"`
-	DiscoveryMode string   `json:"discovery_mode"`
-	Entrypoints   []string `json:"entrypoints"`
-	TagIDs        []string `json:"tag_ids"`
-	OrgID         string   `json:"org_id"`
+	Name                string   `json:"name"`
+	CloneURL            string   `json:"clone_url" binding:"required"`
+	Ref                 string   `json:"ref"`
+	AuthType            string   `json:"auth_type"`
+	Username            string   `json:"username"`
+	Credential          string   `json:"credential"`
+	Schedule            string   `json:"schedule"`
+	Timezone            string   `json:"timezone"`
+	Enabled             bool     `json:"enabled"`
+	RescanPolicy        string   `json:"rescan_policy"`
+	DiscoveryMode       string   `json:"discovery_mode"`
+	DiscoveryRegistryID string   `json:"discovery_registry_id"`
+	DiscoveryRegistry   string   `json:"discovery_registry"`
+	Entrypoints         []string `json:"entrypoints"`
+	TagIDs              []string `json:"tag_ids"`
+	OrgID               string   `json:"org_id"`
 }
 
 type helmSourceRequest struct {
@@ -545,7 +548,7 @@ func CreateRule(db *bun.DB) gin.HandlerFunc {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "path_pattern must be a relative repository path"})
 			return
 		}
-		if body.Resolution != "kustomize" && body.Resolution != "helm" && body.Resolution != "manifests" && body.Resolution != "ignore" {
+		if body.Resolution != "kustomize" && body.Resolution != "helm" && body.Resolution != "manifests" && body.Resolution != "gitlab_ci" && body.Resolution != "ignore" {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid resolution"})
 			return
 		}
@@ -840,13 +843,26 @@ func buildHelmSource(c *gin.Context, db *bun.DB, repository *models.GitRepositor
 }
 
 func registryAvailableToRepository(c *gin.Context, db *bun.DB, repository *models.GitRepository, registry *models.Registry) (bool, error) {
+	if repository == nil || registry == nil {
+		return false, nil
+	}
 	if registry.OwnerType == models.OwnerTypeSystem {
 		return true, nil
 	}
 	if repository.OwnerOrgID != nil {
-		return authz.CanOrgAccessRegistry(c.Request.Context(), db, *repository.OwnerOrgID, registry)
+		if db == nil {
+			return false, nil
+		}
+		return authz.CanOrgAccessRegistry(gitRepositoryRequestContext(c), db, *repository.OwnerOrgID, registry)
 	}
 	return repository.OwnerUserID != nil && registry.OwnerUserID != nil && *repository.OwnerUserID == *registry.OwnerUserID, nil
+}
+
+func gitRepositoryRequestContext(c *gin.Context) context.Context {
+	if c != nil && c.Request != nil {
+		return c.Request.Context()
+	}
+	return context.Background()
 }
 
 func relativeRepositoryPath(value, field string) (string, error) {
@@ -972,7 +988,7 @@ func build(c *gin.Context, db *bun.DB, body repositoryRequest, userID uuid.UUID,
 	if discoveryMode == "" {
 		discoveryMode = models.GitRepositoryDiscoveryAuto
 	}
-	if discoveryMode != models.GitRepositoryDiscoveryAuto && discoveryMode != models.GitRepositoryDiscoveryKustomize && discoveryMode != models.GitRepositoryDiscoveryManifests {
+	if discoveryMode != models.GitRepositoryDiscoveryAuto && discoveryMode != models.GitRepositoryDiscoveryKustomize && discoveryMode != models.GitRepositoryDiscoveryManifests && discoveryMode != models.GitRepositoryDiscoveryRegistry && discoveryMode != models.GitRepositoryDiscoveryGitLabCI {
 		return nil, fmt.Errorf("invalid discovery mode")
 	}
 	entrypoints := make([]string, 0, len(body.Entrypoints))
@@ -1009,6 +1025,53 @@ func build(c *gin.Context, db *bun.DB, body repositoryRequest, userID uuid.UUID,
 			return nil, fmt.Errorf("not allowed to use this organization")
 		}
 		item.OwnerType, item.OwnerUserID, item.OwnerOrgID = models.OwnerTypeOrg, nil, &orgID
+	}
+	selectedRegistryID := strings.TrimSpace(body.DiscoveryRegistryID)
+	customRegistryPrefix := strings.TrimSpace(body.DiscoveryRegistry)
+	if discoveryMode == models.GitRepositoryDiscoveryRegistry && selectedRegistryID == "" && customRegistryPrefix == "" && previous != nil && previous.DiscoveryMode == models.GitRepositoryDiscoveryRegistry {
+		if previous.DiscoveryRegistryID != nil {
+			selectedRegistryID = previous.DiscoveryRegistryID.String()
+		} else {
+			customRegistryPrefix = previous.DiscoveryRegistry
+		}
+	}
+	if discoveryMode == models.GitRepositoryDiscoveryRegistry {
+		if selectedRegistryID != "" && customRegistryPrefix != "" {
+			return nil, fmt.Errorf("choose a configured registry or a custom registry prefix, not both")
+		}
+		if selectedRegistryID == "" && customRegistryPrefix == "" {
+			return nil, fmt.Errorf("registry discovery requires a configured registry or custom registry prefix")
+		}
+		if customRegistryPrefix != "" {
+			normalizedPrefix, err := gitservice.NormalizeRegistryDiscoveryPrefix(customRegistryPrefix)
+			if err != nil {
+				return nil, err
+			}
+			item.DiscoveryRegistry = normalizedPrefix
+		} else {
+			registryID, err := uuid.Parse(selectedRegistryID)
+			if err != nil {
+				return nil, fmt.Errorf("invalid discovery_registry_id")
+			}
+			if db == nil {
+				return nil, fmt.Errorf("selected discovery registry is unavailable")
+			}
+			var registry models.Registry
+			if err := db.NewSelect().Model(&registry).Where("id = ?", registryID).Scan(gitRepositoryRequestContext(c)); err != nil {
+				return nil, fmt.Errorf("selected discovery registry is unavailable")
+			}
+			available, err := registryAvailableToRepository(c, db, item, &registry)
+			if err != nil {
+				return nil, fmt.Errorf("failed to check discovery registry access: %w", err)
+			}
+			if !available {
+				return nil, fmt.Errorf("selected discovery registry must be available to the same workspace")
+			}
+			if _, err := gitservice.NormalizeConfiguredRegistryDiscoveryPrefix(registry.URL); err != nil {
+				return nil, fmt.Errorf("selected discovery registry URL: %w", err)
+			}
+			item.DiscoveryRegistryID = &registryID
+		}
 	}
 	if credential != "" {
 		encrypted, err := crypto.Encrypt(crypto.KeyFromString(config.Config.Encryption.Key), credential)

--- a/services/backend/handlers/gitrepositories/gitrepositories_test.go
+++ b/services/backend/handlers/gitrepositories/gitrepositories_test.go
@@ -70,6 +70,32 @@ func TestBuildStoresCompleteGitAuthentication(t *testing.T) {
 	}
 }
 
+func TestBuildRegistryDiscoveryAcceptsCustomPrefixWithoutEntrypoints(t *testing.T) {
+	item, err := build(nil, nil, repositoryRequest{
+		CloneURL:          "https://git.example.com/group/repository.git",
+		DiscoveryMode:     models.GitRepositoryDiscoveryRegistry,
+		DiscoveryRegistry: " Registry.Example.com/Team/ ",
+		Entrypoints:       nil,
+	}, uuid.New(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if item.DiscoveryRegistry != "registry.example.com/team" || item.DiscoveryRegistryID != nil {
+		t.Fatalf("unexpected registry discovery settings: %#v", item)
+	}
+}
+
+func TestBuildRegistryDiscoveryRejectsUnsafeCustomPrefix(t *testing.T) {
+	_, err := build(nil, nil, repositoryRequest{
+		CloneURL:          "https://git.example.com/group/repository.git",
+		DiscoveryMode:     models.GitRepositoryDiscoveryRegistry,
+		DiscoveryRegistry: "https://registry.example.com/team",
+	}, uuid.New(), nil)
+	if err == nil || !strings.Contains(err.Error(), "omit the URL scheme") {
+		t.Fatalf("unsafe registry prefix error = %v", err)
+	}
+}
+
 func TestBuildHelmSourceStoresDirectCredentialsAndRestrictsPaths(t *testing.T) {
 	previousConfig := config.Config
 	config.Config = &config.RestfulConf{Encryption: config.EncryptionConf{Key: "helm-source-test-encryption-key"}}

--- a/services/backend/pkg/models/git_repositories.go
+++ b/services/backend/pkg/models/git_repositories.go
@@ -20,6 +20,12 @@ const (
 	GitRepositoryDiscoveryAuto      = "auto"
 	GitRepositoryDiscoveryKustomize = "kustomize"
 	GitRepositoryDiscoveryManifests = "manifests"
+	// GitRepositoryDiscoveryRegistry scans repository text files for concrete
+	// image references under a configured or manually supplied registry prefix.
+	GitRepositoryDiscoveryRegistry = "registry"
+	// GitRepositoryDiscoveryGitLabCI extracts images from GitLab CI image and
+	// service declarations. Entrypoints contains one or more CI config paths.
+	GitRepositoryDiscoveryGitLabCI = "gitlab_ci"
 
 	GitRepositoryRunQueued      = "queued"
 	GitRepositoryRunDiscovering = "discovering"
@@ -53,6 +59,8 @@ type GitRepository struct {
 	Enabled              bool       `bun:"enabled,type:bool,notnull,default:false" json:"enabled"`
 	RescanPolicy         string     `bun:"rescan_policy,type:text,notnull,default:'changed'" json:"rescan_policy"`
 	DiscoveryMode        string     `bun:"discovery_mode,type:text,notnull,default:'auto'" json:"discovery_mode"`
+	DiscoveryRegistryID  *uuid.UUID `bun:"discovery_registry_id,type:uuid" json:"discovery_registry_id,omitempty"`
+	DiscoveryRegistry    string     `bun:"discovery_registry,type:text,notnull,default:''" json:"discovery_registry"`
 	Entrypoints          []string   `bun:"entrypoints,type:jsonb,notnull,default:'[]'" json:"entrypoints"`
 	TagIDs               []string   `bun:"tag_ids,type:jsonb,notnull,default:'[]'" json:"tag_ids"`
 	CreatedByID          uuid.UUID  `bun:"created_by_id,type:uuid,notnull" json:"created_by_id"`

--- a/services/backend/scanner/registry.go
+++ b/services/backend/scanner/registry.go
@@ -37,8 +37,7 @@ func ResolveRegistryForScan(ctx context.Context, db bun.IDB, imageName string, r
 	}
 
 	for _, registry := range registries {
-		host := normalizeRegistryHost(registry.URL)
-		if !strings.HasPrefix(imageName, host+"/") && host != "docker.io" {
+		if !RegistryMatchesImage(imageName, &registry) {
 			continue
 		}
 
@@ -104,6 +103,26 @@ func normalizeRegistryHost(url string) string {
 	host = strings.TrimPrefix(host, "http://")
 	host = strings.TrimSuffix(host, "/")
 	return host
+}
+
+// RegistryMatchesImage reports whether an image reference is addressed to a
+// registry endpoint. Unqualified names are treated as Docker Hub images, as
+// they are by Docker and by ResolveRegistryForScan. Keeping this predicate
+// separate lets repository discovery identify a configured registry without
+// decrypting its credentials first.
+func RegistryMatchesImage(imageName string, registry *models.Registry) bool {
+	if registry == nil {
+		return false
+	}
+	host := normalizeRegistryHost(registry.URL)
+	if host == "" {
+		return false
+	}
+	trimmedName := strings.Trim(strings.TrimSpace(imageName), "/")
+	if trimmedName == "" {
+		return false
+	}
+	return strings.HasPrefix(trimmedName, host+"/") || (host == "docker.io" && !hasRegistryHost(trimmedName))
 }
 
 // NormalizeScanTarget trims user input, removes accidental leading/trailing

--- a/services/backend/scanner/registry_test.go
+++ b/services/backend/scanner/registry_test.go
@@ -117,3 +117,26 @@ func TestNormalizeScanTargetWithXrayRepository_TrivyBehaviorUnchanged(t *testing
 		t.Fatalf("expected trivy normalization to stay unchanged, got %q", imageName)
 	}
 }
+
+func TestRegistryMatchesImageUsesExactHostBoundaries(t *testing.T) {
+	registry := &models.Registry{URL: "https://registry.example.com/"}
+	if !RegistryMatchesImage("registry.example.com/team/app", registry) {
+		t.Fatal("matching registry host was not detected")
+	}
+	if RegistryMatchesImage("registry.example.com.evil/team/app", registry) {
+		t.Fatal("registry host prefix without a boundary was detected")
+	}
+	if RegistryMatchesImage("team/app", registry) {
+		t.Fatal("unqualified image matched a non-Docker registry")
+	}
+}
+
+func TestRegistryMatchesImageTreatsUnqualifiedNamesAsDockerHub(t *testing.T) {
+	registry := &models.Registry{URL: "https://docker.io/"}
+	if !RegistryMatchesImage("alpine", registry) {
+		t.Fatal("unqualified image did not match Docker Hub")
+	}
+	if RegistryMatchesImage("ghcr.io/team/app", registry) {
+		t.Fatal("another registry host matched Docker Hub")
+	}
+}

--- a/services/docs/content/docs/integrations/gitlab-ci.mdx
+++ b/services/docs/content/docs/integrations/gitlab-ci.mdx
@@ -13,3 +13,7 @@ justscan_scan:
 ```
 
 For archive-based workflows and the complete request/response model, see [CI/CD integration](/integrations/ci-cd). Confirm that a nonzero exit code fails the job; do not use an unconditional `allow_failure` once JustScan is the release gate.
+
+To discover and schedule scans for image and service declarations in GitLab CI, connect the repository and choose **GitLab CI configuration** as its discovery method. Paths are optional: leave them empty for the conventional root `.gitlab-ci.yml` or `.gitlab-ci.yaml`, or provide relative files, directories, or patterns for repositories with CI configuration elsewhere. This schema-aware mode follows local includes and skips references that still contain runtime variables. See [Git repository discovery](/scan-and-analyze/gitops#gitlab-ci-discovery).
+
+If the goal is to find concrete references throughout the repository without maintaining CI paths, choose **Registry image references** instead. It searches automatically under a selected configured registry or a custom host/path; see [Registry image-reference discovery](/scan-and-analyze/gitops#registry-image-reference-discovery).

--- a/services/docs/content/docs/scan-and-analyze/gitops.mdx
+++ b/services/docs/content/docs/scan-and-analyze/gitops.mdx
@@ -1,17 +1,77 @@
 ---
-title: GitOps repository discovery
-description: Discover deployment images from Kustomize, Helm, and plain Kubernetes manifests.
+title: Git repository discovery
+description: Discover container images from registry references, GitLab CI, Kustomize, Helm, and Kubernetes manifests.
 ---
 
 Connect a Git repository in the application, validate access, then run discovery before scheduling scans. A dry run renders the configured deployment inputs and discovers images only; it never queues scans.
 
 ## Discovery modes
 
+- **Registry image references (recommended)** searches repository text and configuration for concrete references under one selected configured registry or custom host/path. It discovers files automatically; no CI, manifest, or other path list is required.
 - **Auto** detects unreferenced Kustomize roots and falls back to Kubernetes workload manifests.
 - **Kustomize entrypoints** renders only operator-selected repository paths.
 - **Plain Kubernetes manifests** extracts images from `containers`, `initContainers`, and `ephemeralContainers`.
+- **GitLab CI configuration** extracts global, default, and job-level `image` and `services` declarations. Add one or more relative CI config paths, or leave the paths empty to use `.gitlab-ci.yml` or `.gitlab-ci.yaml` at the repository root.
 
 After a dry run, review discovered images, select the ones that should be tracked, then create scans. Excluded images remain visible in the review so their deployment context is retained without scheduling future scans.
+
+## Registry image-reference discovery
+
+Choose **Registry image references** when image declarations are spread across deployment files, scripts, and other repository configuration. Select a configured registry from the workspace, or choose **Custom registry host or path** and enter a prefix such as `registry.example.com/team`. JustScan searches automatically and still shows the source file and line for each result so the dry-run review is auditable.
+
+Only concrete, fully qualified references below the selected prefix are returned. Include an explicit tag, such as `registry.example.com/team/api:1.2.3` or `:latest`, or a digest, such as `registry.example.com/team/api@sha256:...`. Unqualified or tagless names, wildcard references, URLs, and unresolved variables or templates are skipped. Prefix matching respects host and repository-path boundaries, so `registry.example.com/team` does not match `registry.example.com/team-other`.
+
+Discovery is bounded and intended for source/configuration files. JustScan skips binary or invalid text files, symlinks, `.git`, common dependency/build/generated directories, files larger than 5 MiB, and stops reading after 64 MiB of text for one discovery. Duplicate references are combined while retaining their source locations.
+
+### Configured registry or custom prefix
+
+- A **configured registry** is selected from the registries available in the repository's workspace. Its configured scan provider and encrypted credentials are used for matching images, and the selected entry is applied to discovered images unless a per-image override replaces it.
+- A **custom registry prefix** is kept as written in each image reference and has no JustScan credential attached. Scans therefore run anonymously. For a private custom host, configure a registry entry and use it as the discovery source, or assign a configured registry as a per-image override after the dry run.
+
+Changing the discovery source causes the next run to evaluate the images with the new registry choice. If a selected configured registry is removed or is no longer available to the workspace, discovery reports an error rather than silently scanning anonymously.
+
+## GitLab CI discovery
+
+Use **GitLab CI configuration** when you want schema-aware discovery limited to CI declarations. Paths are optional: add one or more relative files, directories, or patterns when the repository keeps CI configuration outside the root, or leave the field empty to inspect `.gitlab-ci.yml` and `.gitlab-ci.yaml` at the repository root. This mode is separate from the path-free Registry image references mode.
+
+GitLab CI discovery accepts scalar declarations and mappings with a `name` field. It follows local `include` files without making network requests for remote or project includes, and resolves variables declared statically in the same CI file. References that still contain runtime variables such as `$CI_COMMIT_SHA` are skipped because they are not concrete scan targets.
+
+```yaml
+variables:
+  REGISTRY: registry.example.com
+
+default:
+  image: alpine:3.20
+
+build:
+  image:
+    name: ${REGISTRY}/team/builder:2.0
+  services:
+    - docker:27-dind
+    - name: ${REGISTRY}/team/cache:3.0
+```
+
+JustScan records the CI file, job, and declaration path for every result. Script commands and unrelated YAML keys are not treated as image declarations.
+
+For a repository that combines GitLab CI with deployment inputs, use multiple sources in `.justscan.yaml`:
+
+```yaml
+version: 1
+discovery:
+  sources:
+    - type: gitlab_ci
+      paths:
+        - .gitlab-ci.yml
+        - ci/release.yml
+    - type: kustomize
+      root: deploy
+```
+
+## Registry matching outside registry-reference discovery
+
+For images discovered by Auto, Kustomize, manifests, GitLab CI, or Helm, JustScan can compare the image host with registry entries available to the repository's workspace. A matching configured registry supplies its scan provider and credentials automatically. A saved per-image registry override takes precedence over automatic matching. Registry image-reference discovery uses the explicitly selected configured registry or custom prefix described above.
+
+A fully qualified image from an unconfigured custom registry is kept exactly as written and can be scanned anonymously. No registry record or credential is created implicitly.
 
 ## Per-image registry and credential
 
@@ -32,6 +92,10 @@ discovery:
     - type: manifests
       paths:
         - manifests
+    - type: gitlab_ci
+      paths:
+        - .gitlab-ci.yml
+        - ci/release.yml
     - type: helm
       chart: charts/standalone-service
       releaseName: standalone-service
@@ -41,6 +105,7 @@ discovery:
 
 - A `kustomize` source accepts a discovery `root` or explicit `paths` to `kustomization.yaml` files.
 - A `manifests` source requires `paths` to plain Kubernetes YAML files or directories.
+- A `gitlab_ci` source accepts optional CI config `paths`, directories, or patterns. With no paths, it uses the conventional root GitLab CI filename.
 - A `helm` source requires a chart directory in the same repository. JustScan resolves declared chart dependencies in an isolated temporary directory before rendering; it never writes them back to Git.
 
 ## Managed Helm sources

--- a/services/frontend/app/(app)/git-repositories/[id]/page.tsx
+++ b/services/frontend/app/(app)/git-repositories/[id]/page.tsx
@@ -64,6 +64,7 @@ import {
   setGitRepositoryImageRegistryOverride,
   updateGitRepositoryHelmSource,
   type GitRepository,
+  type GitRepositoryDiscoveryMode,
   type GitRepositoryHelmSource,
   type GitRepositoryHelmSourceInput,
   type GitRepositoryImageExclusion,
@@ -158,7 +159,9 @@ function ImageRegistrySelect({
           <ListBox.Item id="automatic" textValue="Automatic matching">
             <div className="flex min-w-0 flex-col items-start gap-0.5">
               <Label>Automatic matching</Label>
-              <Description className="!block">Match the image host or use the default.</Description>
+              <Description className="!block">
+                Match a configured image host; leave an unconfigured host as entered.
+              </Description>
             </div>
             <ListBox.ItemIndicator />
           </ListBox.Item>
@@ -182,9 +185,106 @@ function ImageRegistrySelect({
       </Select.Popover>
       <Description>
         Choose another configured registry entry when this image needs a different endpoint or
-        token. Create a second entry with the same URL for a second credential.
+        token. This selector uses saved JustScan entries; add a new credential from Registries.
       </Description>
     </Select>
+  );
+}
+
+function imageRegistryHost(imageRef: string): string | null {
+  const trimmed = imageRef.trim().replace(/^\/+|\/+$/g, '');
+  if (!trimmed.includes('/')) return null;
+  const firstSegment = trimmed.split('/')[0]?.toLowerCase() ?? '';
+  if (
+    !firstSegment ||
+    (firstSegment !== 'localhost' && !firstSegment.includes('.') && !firstSegment.includes(':'))
+  ) {
+    return null;
+  }
+  return firstSegment;
+}
+
+function RegistryResolutionSummary({
+  image,
+  override,
+  overrideRegistry,
+  inferredRegistry,
+}: {
+  image: GitRepositoryRunImage;
+  override?: GitRepositoryImageRegistryOverride;
+  overrideRegistry?: Registry;
+  inferredRegistry?: Registry;
+}) {
+  const host = imageRegistryHost(image.full_ref);
+
+  if (override) {
+    return (
+      <div className="space-y-2">
+        <div className="flex flex-wrap items-center gap-2">
+          <Chip className="shrink-0" color="accent" size="sm" variant="soft">
+            Configured override
+          </Chip>
+          {host ? <code className="truncate text-xs text-muted">{host}</code> : null}
+        </div>
+        <Description className="!block">
+          {overrideRegistry
+            ? `This image is pinned to the configured ${overrideRegistry.name} registry entry.`
+            : 'This image has an override for a registry entry that is not available in the current workspace.'}
+        </Description>
+      </div>
+    );
+  }
+
+  if (image.registry_id) {
+    return (
+      <div className="space-y-2">
+        <div className="flex flex-wrap items-center gap-2">
+          <Chip
+            className="shrink-0"
+            color={inferredRegistry ? 'accent' : 'warning'}
+            size="sm"
+            variant="soft"
+          >
+            {inferredRegistry ? 'Configured match' : 'Configured match unavailable'}
+          </Chip>
+          {host ? <code className="truncate text-xs text-muted">{host}</code> : null}
+        </div>
+        <Description className="!block">
+          {inferredRegistry
+            ? `Automatic matching selected the configured ${inferredRegistry.name} registry entry${host ? ` for ${host}` : ''}.`
+            : 'Automatic matching found a configured registry entry, but it is not available in the current workspace view.'}
+        </Description>
+      </div>
+    );
+  }
+
+  if (host) {
+    return (
+      <div className="space-y-2">
+        <div className="flex flex-wrap items-center gap-2">
+          <Chip className="shrink-0" color="warning" size="sm" variant="soft">
+            Custom / unconfigured host
+          </Chip>
+          <code className="truncate text-xs text-muted">{host}</code>
+        </div>
+        <Description className="!block">
+          No JustScan registry entry matches this host. Automatic matching keeps the original host;
+          add a registry entry from Registries if this image needs credentials.
+        </Description>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      <Chip className="shrink-0" size="sm" variant="soft">
+        Default matching
+      </Chip>
+      <Description className="!block">
+        This image reference has no explicit registry host. Automatic matching uses the default
+        Docker Hub behavior when a matching entry is available.
+      </Description>
+    </div>
   );
 }
 
@@ -192,15 +292,52 @@ function locationsFor(image: GitRepositoryRunImage) {
   return image.locations?.items ?? [];
 }
 
-function targetGroup(target: string) {
+function discoveryModeLabel(mode: GitRepositoryDiscoveryMode) {
+  switch (mode) {
+    case 'kustomize':
+      return 'Kustomize entrypoints';
+    case 'manifests':
+      return 'Plain Kubernetes manifests';
+    case 'registry':
+      return 'Registry references';
+    case 'gitlab_ci':
+      return 'GitLab CI configuration';
+    default:
+      return 'Automatic discovery';
+  }
+}
+
+function registryDiscoverySource(repository: GitRepository, registries: Registry[]) {
+  if (repository.discovery_registry_id) {
+    const registry = registries.find((item) => item.id === repository.discovery_registry_id);
+    if (registry) return `configured registry “${registry.name}” (${registry.url})`;
+    return 'a configured registry that is not available in this workspace';
+  }
+  if (repository.discovery_registry?.trim()) {
+    return `custom registry prefix “${repository.discovery_registry.trim()}”`;
+  }
+  return 'an unconfigured registry source';
+}
+
+function targetGroup(
+  target: string,
+  discoveryMode?: GitRepositoryDiscoveryMode,
+  locationKind?: string
+) {
   if (target.startsWith('Helm chart ')) {
     return { label: 'Helm', path: target.slice('Helm chart '.length) };
   }
   if (target.startsWith('Helm values ')) {
     return { label: 'Helm', path: target.slice('Helm values '.length) };
   }
+  if (discoveryMode === 'registry' || /registry/i.test(locationKind ?? '')) {
+    return { label: 'Registry references', path: target };
+  }
   if (/kustomization\.ya?ml$/i.test(target)) {
     return { label: 'Kustomize', path: target };
+  }
+  if (discoveryMode === 'gitlab_ci' || locationKind === 'GitLabCI') {
+    return { label: 'GitLab CI', path: target };
   }
   return { label: 'Manifests', path: target };
 }
@@ -694,30 +831,34 @@ export default function GitRepositoryDetailPage() {
   }
 
   const files = useMemo(() => {
-    const grouped = new Map<string, string[]>();
+    const grouped = new Map<string, { file: string; kind?: string; refs: string[] }>();
     for (const image of preview?.images ?? []) {
       for (const location of locationsFor(image)) {
         const source = location.target || location.file;
-        const refs = grouped.get(source) ?? [];
-        refs.push(image.full_ref);
-        grouped.set(source, refs);
+        const key = `${location.kind ?? ''}\u0000${source}`;
+        const item = grouped.get(key) ?? { file: source, kind: location.kind, refs: [] };
+        item.refs.push(image.full_ref);
+        grouped.set(key, item);
       }
     }
-    return [...grouped.entries()].sort(([left], [right]) => left.localeCompare(right));
+    return [...grouped.values()].sort(
+      (left, right) =>
+        left.file.localeCompare(right.file) || (left.kind ?? '').localeCompare(right.kind ?? '')
+    );
   }, [preview]);
 
   const filesByDeploymentType = useMemo(() => {
     const groups = new Map<string, Array<[string, string[]]>>();
-    for (const [file, refs] of files) {
-      const group = targetGroup(file);
+    for (const { file, kind, refs } of files) {
+      const group = targetGroup(file, repository?.discovery_mode, kind);
       const items = groups.get(group.label) ?? [];
       items.push([group.path, refs]);
       groups.set(group.label, items);
     }
-    return ['Kustomize', 'Helm', 'Manifests']
+    return ['Kustomize', 'Helm', 'GitLab CI', 'Registry references', 'Manifests']
       .map((label) => [label, groups.get(label) ?? []] as const)
       .filter(([, items]) => items.length > 0);
-  }, [files]);
+  }, [files, repository?.discovery_mode]);
 
   const previewImages = preview?.images ?? [];
   const exclusionByRef = useMemo(
@@ -800,7 +941,7 @@ export default function GitRepositoryDetailPage() {
           { label: 'Git repositories', href: '/git-repositories' },
           { label: repository.name },
         ]}
-        description={`${repository.clone_url} · ${repository.ref}${repository.owner_type === 'org' ? ' · Scans appear in the organization workspace.' : ''}`}
+        description={`${repository.clone_url} · ${repository.ref} · ${discoveryModeLabel(repository.discovery_mode)}${repository.discovery_mode === 'registry' ? ` · ${registryDiscoverySource(repository, registries)}` : ''}${repository.owner_type === 'org' ? ' · Scans appear in the organization workspace.' : ''}`}
         actions={
           <div className="flex items-center gap-2">
             {activeRun ? (
@@ -877,13 +1018,23 @@ export default function GitRepositoryDetailPage() {
         />
         <MetricCard
           title={
-            repository.discovery_mode === 'manifests' ? 'Files with images' : 'Deployment targets'
+            repository.discovery_mode === 'manifests'
+              ? 'Files with images'
+              : repository.discovery_mode === 'registry'
+                ? 'Registry reference files'
+                : repository.discovery_mode === 'gitlab_ci'
+                  ? 'CI config files'
+                  : 'Deployment targets'
           }
           value={String(files.length)}
           detail={
             repository.discovery_mode === 'manifests'
               ? 'manifest files represented'
-              : 'rendered entrypoints represented'
+              : repository.discovery_mode === 'registry'
+                ? 'files with matching image references'
+                : repository.discovery_mode === 'gitlab_ci'
+                  ? 'GitLab CI image declarations represented'
+                  : 'rendered entrypoints represented'
           }
         />
         <MetricCard
@@ -1138,8 +1289,11 @@ export default function GitRepositoryDetailPage() {
                 <div className="min-w-0">
                   <Card.Title>Discovered images</Card.Title>
                   <Card.Description>
-                    Review the images found in this dry run, then scan only the workloads you want
-                    to track.
+                    {repository.discovery_mode === 'registry'
+                      ? `This discovery searches ${registryDiscoverySource(repository, registries)} and keeps each matching image reference tied to its source file. Review the results, then scan only the workloads you want to track.`
+                      : repository.discovery_mode === 'gitlab_ci'
+                        ? 'Images and service declarations found in GitLab CI YAML. Review the results, then scan only the workloads you want to track.'
+                        : 'Review the images found in this dry run, then scan only the workloads you want to track.'}
                   </Card.Description>
                 </div>
               </div>
@@ -1227,6 +1381,10 @@ export default function GitRepositoryDetailPage() {
                   const selectedRegistry = registryOverride
                     ? registryByID.get(registryOverride.registry_id)
                     : undefined;
+                  const inferredRegistry = image.registry_id
+                    ? registryByID.get(image.registry_id)
+                    : undefined;
+                  const imageHost = imageRegistryHost(image.full_ref);
                   const latestScan = latestScanByRef.get(image.full_ref);
                   return (
                     <div
@@ -1279,7 +1437,22 @@ export default function GitRepositoryDetailPage() {
                               ) : null}
                               {registryOverride ? (
                                 <Chip className="shrink-0" color="accent" size="sm" variant="soft">
-                                  {selectedRegistry?.name ?? 'Custom registry'}
+                                  {selectedRegistry?.name ?? 'Configured override'}
+                                </Chip>
+                              ) : image.registry_id ? (
+                                <Chip
+                                  className="shrink-0"
+                                  color={inferredRegistry ? 'accent' : 'warning'}
+                                  size="sm"
+                                  variant="soft"
+                                >
+                                  {inferredRegistry
+                                    ? `Matched: ${inferredRegistry.name}`
+                                    : 'Configured match unavailable'}
+                                </Chip>
+                              ) : imageHost ? (
+                                <Chip className="shrink-0" color="warning" size="sm" variant="soft">
+                                  Custom host: {imageHost}
                                 </Chip>
                               ) : null}
                               {latestScan ? (
@@ -1296,14 +1469,22 @@ export default function GitRepositoryDetailPage() {
                           <Accordion.Panel>
                             <Accordion.Body className="mt-3 border-t border-divider/70 pt-3">
                               <div className="mb-4 rounded-lg border border-divider/70 bg-surface-secondary p-3">
-                                <ImageRegistrySelect
-                                  registries={registries}
-                                  value={registryOverride?.registry_id ?? null}
-                                  isDisabled={savingImageRegistryRef === image.full_ref}
-                                  onChange={(value) =>
-                                    void updateImageRegistry(image.full_ref, value)
-                                  }
+                                <RegistryResolutionSummary
+                                  image={image}
+                                  inferredRegistry={inferredRegistry}
+                                  override={registryOverride}
+                                  overrideRegistry={selectedRegistry}
                                 />
+                                <div className="mt-4 border-t border-divider/70 pt-4">
+                                  <ImageRegistrySelect
+                                    registries={registries}
+                                    value={registryOverride?.registry_id ?? null}
+                                    isDisabled={savingImageRegistryRef === image.full_ref}
+                                    onChange={(value) =>
+                                      void updateImageRegistry(image.full_ref, value)
+                                    }
+                                  />
+                                </div>
                               </div>
                               <p className="mb-2 text-[10px] font-semibold uppercase tracking-widest text-muted">
                                 Deployment locations
@@ -1392,7 +1573,11 @@ export default function GitRepositoryDetailPage() {
                         <span className="mt-0.5 block truncate text-xs text-muted">
                           {repository.discovery_mode === 'manifests'
                             ? 'Source manifests and their detected image references'
-                            : 'Rendered deployment targets and their detected image references'}
+                            : repository.discovery_mode === 'registry'
+                              ? `Registry references from ${registryDiscoverySource(repository, registries)}`
+                              : repository.discovery_mode === 'gitlab_ci'
+                                ? 'GitLab CI config files and their detected image references'
+                                : 'Rendered deployment targets and their detected image references'}
                         </span>
                       </span>
                     </span>

--- a/services/frontend/app/(app)/git-repositories/page.tsx
+++ b/services/frontend/app/(app)/git-repositories/page.tsx
@@ -4,6 +4,7 @@ import {
   Button,
   Card,
   Chip,
+  Description,
   Label,
   ListBox,
   Modal,
@@ -35,10 +36,13 @@ import {
   createGitRepository,
   deleteGitRepository,
   listGitRepositories,
+  listRegistries,
   runGitRepository,
   updateGitRepository,
   type GitRepository,
+  type GitRepositoryDiscoveryMode,
   type GitRepositoryInput,
+  type Registry,
 } from '@/lib/api';
 import { deferEffect } from '@/lib/defer-effect';
 import { timeAgo } from '@/lib/time';
@@ -57,7 +61,14 @@ type Draft = Required<
     | 'rescan_policy'
     | 'discovery_mode'
   >
-> & { credential: string; entrypoints: string };
+> & {
+  credential: string;
+  entrypoints: string;
+  discovery_registry_id: string;
+  discovery_registry: string;
+  registry_source: string;
+};
+const CUSTOM_REGISTRY_VALUE = '__custom_registry__';
 const initialDraft: Draft = {
   name: '',
   clone_url: '',
@@ -71,6 +82,9 @@ const initialDraft: Draft = {
   rescan_policy: 'changed',
   discovery_mode: 'auto',
   entrypoints: '',
+  discovery_registry_id: '',
+  discovery_registry: '',
+  registry_source: '',
 };
 
 export default function GitRepositoriesPage() {
@@ -78,6 +92,9 @@ export default function GitRepositoriesPage() {
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState('');
   const [draft, setDraft] = useState<Draft>(initialDraft);
+  const [registries, setRegistries] = useState<Registry[]>([]);
+  const [registriesLoading, setRegistriesLoading] = useState(false);
+  const [registryLoadError, setRegistryLoadError] = useState('');
   const [saving, setSaving] = useState(false);
   const [pendingAction, setPendingAction] = useState<string | null>(null);
   const [editingRepository, setEditingRepository] = useState<GitRepository | null>(null);
@@ -90,12 +107,30 @@ export default function GitRepositoriesPage() {
   const load = useCallback(async () => {
     setLoading(true);
     setLoadError('');
+    setRegistriesLoading(true);
+    setRegistryLoadError('');
     try {
-      setRepositories(await listGitRepositories(workspaceScope));
+      const [repositoryResult, registryResult] = await Promise.allSettled([
+        listGitRepositories(workspaceScope),
+        listRegistries(),
+      ]);
+      if (repositoryResult.status === 'rejected') throw repositoryResult.reason;
+      setRepositories(repositoryResult.value);
+      if (registryResult.status === 'fulfilled') {
+        setRegistries(registryResult.value);
+      } else {
+        setRegistries([]);
+        setRegistryLoadError(
+          registryResult.reason instanceof Error
+            ? registryResult.reason.message
+            : 'Could not load configured registries.'
+        );
+      }
     } catch (error) {
       setLoadError(error instanceof Error ? error.message : 'Could not load Git repositories.');
     } finally {
       setLoading(false);
+      setRegistriesLoading(false);
     }
   }, [workspaceScope]);
   useEffect(
@@ -108,14 +143,55 @@ export default function GitRepositoriesPage() {
 
   async function save() {
     if (saving) return;
+    if (draft.discovery_mode === 'registry') {
+      if (draft.registry_source === CUSTOM_REGISTRY_VALUE) {
+        if (!draft.discovery_registry.trim()) {
+          showError('Enter a custom registry host or path.');
+          return;
+        }
+      } else if (draft.registry_source) {
+        if (!registries.some((registry) => registry.id === draft.registry_source)) {
+          showError(
+            'That configured registry is no longer available in this workspace. Select another registry or use a custom host or path.'
+          );
+          return;
+        }
+      } else {
+        showError('Select a configured registry or enter a custom registry host or path.');
+        return;
+      }
+    }
     setSaving(true);
     try {
+      const usesEntrypoints =
+        draft.discovery_mode === 'kustomize' || draft.discovery_mode === 'gitlab_ci';
+      const usesRegistry = draft.discovery_mode === 'registry';
       const input: GitRepositoryInput = {
-        ...draft,
-        entrypoints: draft.entrypoints
-          .split('\n')
-          .map((value) => value.trim())
-          .filter(Boolean),
+        name: draft.name,
+        clone_url: draft.clone_url,
+        ref: draft.ref,
+        auth_type: draft.auth_type,
+        username: draft.username,
+        credential: draft.credential,
+        schedule: draft.schedule,
+        timezone: draft.timezone,
+        enabled: draft.enabled,
+        rescan_policy: draft.rescan_policy,
+        discovery_mode: draft.discovery_mode,
+        entrypoints: usesEntrypoints
+          ? draft.entrypoints
+              .split('\n')
+              .map((value) => value.trim())
+              .filter(Boolean)
+          : [],
+        discovery_registry_id:
+          usesRegistry && draft.registry_source && draft.registry_source !== CUSTOM_REGISTRY_VALUE
+            ? draft.registry_source
+            : null,
+        discovery_registry:
+          usesRegistry && draft.registry_source === CUSTOM_REGISTRY_VALUE
+            ? draft.discovery_registry.trim()
+            : '',
       };
       if (editingRepository) {
         await updateGitRepository(editingRepository.id, input);
@@ -160,8 +236,27 @@ export default function GitRepositoriesPage() {
       rescan_policy: repository.rescan_policy,
       discovery_mode: repository.discovery_mode ?? 'auto',
       entrypoints: repository.entrypoints?.join('\n') ?? '',
+      discovery_registry_id: repository.discovery_registry_id ?? '',
+      discovery_registry: repository.discovery_registry ?? '',
+      registry_source:
+        repository.discovery_registry_id ??
+        (repository.discovery_registry ? CUSTOM_REGISTRY_VALUE : ''),
     });
     overlay.open();
+  }
+
+  function updateDiscoveryMode(value: string) {
+    const nextMode = value as GitRepositoryDiscoveryMode;
+    setDraft((current) => ({
+      ...current,
+      discovery_mode: nextMode,
+      // Keep only fields that apply to the selected mode so switching modes
+      // cannot submit stale CI paths or registry settings.
+      entrypoints: nextMode === 'kustomize' || nextMode === 'gitlab_ci' ? current.entrypoints : '',
+      discovery_registry_id: nextMode === 'registry' ? current.discovery_registry_id : '',
+      discovery_registry: nextMode === 'registry' ? current.discovery_registry : '',
+      registry_source: nextMode === 'registry' ? current.registry_source : '',
+    }));
   }
   async function run(
     repository: GitRepository,
@@ -368,9 +463,7 @@ export default function GitRepositoriesPage() {
                 <Select
                   aria-label="Discovery method"
                   value={draft.discovery_mode}
-                  onChange={(value) =>
-                    setDraft({ ...draft, discovery_mode: String(value) as Draft['discovery_mode'] })
-                  }
+                  onChange={(value) => updateDiscoveryMode(String(value))}
                   variant="secondary"
                 >
                   <Label>Discovery method</Label>
@@ -385,22 +478,141 @@ export default function GitRepositoriesPage() {
                       </ListBox.Item>
                       <ListBox.Item id="kustomize">Kustomize entrypoints</ListBox.Item>
                       <ListBox.Item id="manifests">Plain Kubernetes manifests</ListBox.Item>
+                      <ListBox.Item id="registry">Registry references</ListBox.Item>
+                      <ListBox.Item id="gitlab_ci">GitLab CI configuration</ListBox.Item>
                     </ListBox>
                   </Select.Popover>
+                  <Description>
+                    {draft.discovery_mode === 'gitlab_ci'
+                      ? 'Discover image and service declarations from GitLab CI YAML. Paths are optional and default to CI config files in the repository.'
+                      : draft.discovery_mode === 'registry'
+                        ? 'Find concrete image references under one configured registry or a custom host/path. Registry discovery does not need CI or manifest paths.'
+                        : draft.discovery_mode === 'kustomize'
+                          ? 'Render only the Kustomize entrypoints listed below.'
+                          : draft.discovery_mode === 'manifests'
+                            ? 'Read image declarations from plain Kubernetes manifests.'
+                            : 'Render detected Kustomize roots, then fall back to plain manifests.'}
+                  </Description>
                 </Select>
-                {draft.discovery_mode === 'kustomize' ? (
+                {draft.discovery_mode === 'registry' ? (
+                  <div className="grid gap-3 rounded-xl border border-divider/70 bg-surface-secondary p-3">
+                    <Select
+                      aria-label="Registry reference source"
+                      className="w-full"
+                      value={draft.registry_source || null}
+                      onChange={(value) => {
+                        const selection = String(value ?? '');
+                        setDraft((current) => ({
+                          ...current,
+                          registry_source: selection,
+                          discovery_registry_id:
+                            selection && selection !== CUSTOM_REGISTRY_VALUE ? selection : '',
+                          discovery_registry:
+                            selection === CUSTOM_REGISTRY_VALUE ? current.discovery_registry : '',
+                        }));
+                      }}
+                      variant="secondary"
+                    >
+                      <Label>Registry reference source</Label>
+                      <Select.Trigger>
+                        <Select.Value />
+                        <Select.Indicator />
+                      </Select.Trigger>
+                      <Select.Popover>
+                        <ListBox>
+                          {draft.discovery_registry_id &&
+                          !registries.some(
+                            (registry) => registry.id === draft.discovery_registry_id
+                          ) ? (
+                            <ListBox.Item
+                              id={draft.discovery_registry_id}
+                              isDisabled
+                              textValue="Unavailable configured registry"
+                            >
+                              <div className="flex min-w-0 flex-col items-start gap-0.5">
+                                <Label>Unavailable configured registry</Label>
+                                <Description className="!block">
+                                  This registry is no longer accessible in the current workspace.
+                                </Description>
+                              </div>
+                            </ListBox.Item>
+                          ) : null}
+                          {registries.map((registry) => (
+                            <ListBox.Item
+                              id={registry.id}
+                              key={registry.id}
+                              textValue={`${registry.name} ${registry.url}`}
+                            >
+                              <div className="flex min-w-0 flex-col items-start gap-0.5">
+                                <Label>{registry.name}</Label>
+                                <Description className="!block break-all">
+                                  {registry.url} ·{' '}
+                                  {registry.scan_provider === 'artifactory_xray' ? 'Xray' : 'Trivy'}
+                                </Description>
+                              </div>
+                              <ListBox.ItemIndicator />
+                            </ListBox.Item>
+                          ))}
+                          <ListBox.Item
+                            id={CUSTOM_REGISTRY_VALUE}
+                            textValue="Custom registry host or path"
+                          >
+                            <div className="flex min-w-0 flex-col items-start gap-0.5">
+                              <Label>Custom registry host or path</Label>
+                              <Description className="!block">
+                                Enter a registry host or path prefix manually.
+                              </Description>
+                            </div>
+                            <ListBox.ItemIndicator />
+                          </ListBox.Item>
+                        </ListBox>
+                      </Select.Popover>
+                      <Description>
+                        {registryLoadError
+                          ? 'Configured registries could not be loaded. You can still use a custom host or path.'
+                          : registriesLoading
+                            ? 'Loading registries available in this workspace…'
+                            : 'Choose a registry configured for this workspace, or use a custom host/path when the reference is not backed by a saved credential.'}
+                      </Description>
+                    </Select>
+                    {draft.registry_source === CUSTOM_REGISTRY_VALUE ? (
+                      <FormField
+                        id="discovery-registry"
+                        label="Custom registry host or path"
+                        required
+                        value={draft.discovery_registry}
+                        onChange={(event) =>
+                          setDraft({ ...draft, discovery_registry: event.target.value })
+                        }
+                        placeholder="registry.example.com/team"
+                        description="Use the host or path prefix exactly as it appears in image references."
+                      />
+                    ) : null}
+                  </div>
+                ) : null}
+                {draft.discovery_mode === 'kustomize' || draft.discovery_mode === 'gitlab_ci' ? (
                   <div className="grid gap-2">
-                    <Label htmlFor="kustomize-entrypoints">Kustomize entrypoints</Label>
+                    <Label htmlFor="discovery-entrypoints">
+                      {draft.discovery_mode === 'gitlab_ci'
+                        ? 'GitLab CI config paths'
+                        : 'Kustomize entrypoints'}
+                    </Label>
                     <TextArea
-                      id="kustomize-entrypoints"
+                      id="discovery-entrypoints"
                       value={draft.entrypoints}
                       onChange={(event) => setDraft({ ...draft, entrypoints: event.target.value })}
-                      placeholder={'envs/demo/dev/qdrant\nenvs/demo/dev/n8n'}
+                      placeholder={
+                        draft.discovery_mode === 'gitlab_ci'
+                          ? '.gitlab-ci.yml\nci/release.yml'
+                          : 'envs/demo/dev/qdrant\nenvs/demo/dev/n8n'
+                      }
                       rows={3}
                       variant="secondary"
                     />
                     <p className="text-xs text-foreground/60">
-                      One relative repository path per line.
+                      {draft.discovery_mode === 'gitlab_ci'
+                        ? 'Optional. Leave blank to inspect GitLab CI config files in the repository; otherwise use one relative path or glob per line.'
+                        : 'One relative repository path per line.'}
                     </p>
                   </div>
                 ) : null}

--- a/services/frontend/lib/api/types/git-repositories.ts
+++ b/services/frontend/lib/api/types/git-repositories.ts
@@ -1,7 +1,8 @@
 import type { OwnerType } from './common';
 
 export type GitRepositoryRescanPolicy = 'changed' | 'all';
-export type GitRepositoryDiscoveryMode = 'auto' | 'kustomize' | 'manifests';
+export type GitRepositoryDiscoveryMode =
+  'auto' | 'kustomize' | 'manifests' | 'registry' | 'gitlab_ci';
 export type GitRepositoryRunStatus =
   'queued' | 'discovering' | 'scanning' | 'completed' | 'partial' | 'failed' | 'cancelled';
 
@@ -18,6 +19,10 @@ export interface GitRepository {
   enabled: boolean;
   rescan_policy: GitRepositoryRescanPolicy;
   discovery_mode: GitRepositoryDiscoveryMode;
+  /** Configured registry used by registry-reference discovery, when accessible. */
+  discovery_registry_id?: string | null;
+  /** Registry host or path prefix used by registry-reference discovery. */
+  discovery_registry?: string;
   entrypoints: string[];
   tag_ids: string[];
   owner_type: OwnerType;
@@ -80,7 +85,7 @@ export interface GitRepositoryDiscoveryRule {
   id: string;
   repository_id: string;
   path_pattern: string;
-  resolution: 'kustomize' | 'helm' | 'manifests' | 'ignore';
+  resolution: 'kustomize' | 'helm' | 'manifests' | 'gitlab_ci' | 'ignore';
   config: Record<string, unknown>;
   active: boolean;
   created_at: string;
@@ -124,6 +129,8 @@ export interface GitDiscoveredImage {
   full_ref: string;
   image_name: string;
   image_tag: string;
+  /** Configured JustScan registry selected by automatic host matching. */
+  registry_id?: string | null;
   locations: Array<{
     file: string;
     target?: string;


### PR DESCRIPTION
## Summary

- Add GitLab CI image discovery with variable expansion and local include support.
- Add registry-prefix scanning across repository text files with safety limits and exclusions.
- Persist discovery registry configuration and expose discovery results in the backend and frontend.
- Document GitLab CI and GitOps image discovery workflows.

## Testing

- Added backend unit tests for GitLab CI parsing, registry discovery, path validation, and service behavior.
- Added scanner and handler coverage for repository image discovery.
- Not run: full backend and frontend test suites.