### PR TITLE
Add Git repository discovery exclusions

### DIFF
--- a/services/backend/database/migrations/115_git_repository_discovery_excludes.go
+++ b/services/backend/database/migrations/115_git_repository_discovery_excludes.go
@@ -1,0 +1,25 @@
+package migrations
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/uptrace/bun"
+)
+
+// Repository discovery exclusions are persisted as ordered JSON patterns so
+// they can be reviewed and edited without introducing another child resource.
+func init() {
+	Migrations.MustRegister(func(ctx context.Context, db *bun.DB) error {
+		if _, err := db.NewRaw(`ALTER TABLE git_repositories
+			ADD COLUMN IF NOT EXISTS discovery_excludes JSONB NOT NULL DEFAULT '[]'`).Exec(ctx); err != nil {
+			return fmt.Errorf("migration 115 Git repository discovery exclusions: %w", err)
+		}
+		return nil
+	}, func(ctx context.Context, db *bun.DB) error {
+		if _, err := db.NewRaw(`ALTER TABLE git_repositories DROP COLUMN IF EXISTS discovery_excludes`).Exec(ctx); err != nil {
+			return fmt.Errorf("migration 115 Git repository discovery exclusions rollback: %w", err)
+		}
+		return nil
+	})
+}

--- a/services/backend/functions/gitrepositories/discovery_excludes.go
+++ b/services/backend/functions/gitrepositories/discovery_excludes.go
@@ -1,0 +1,190 @@
+package gitrepositories
+
+import (
+	"fmt"
+	"path"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	maxDiscoveryExcludePatterns = 256
+	maxDiscoveryExcludeLength   = 512
+)
+
+// NormalizeDiscoveryExcludes validates and canonicalizes repository-relative
+// discovery exclusion globs. Paths are persisted with slash separators so the
+// same configuration behaves consistently on every worker platform.
+func NormalizeDiscoveryExcludes(patterns []string) ([]string, error) {
+	if len(patterns) > maxDiscoveryExcludePatterns {
+		return nil, fmt.Errorf("discovery_excludes must contain at most %d patterns", maxDiscoveryExcludePatterns)
+	}
+
+	result := make([]string, 0, len(patterns))
+	seen := make(map[string]struct{}, len(patterns))
+	for _, raw := range patterns {
+		pattern, err := normalizeDiscoveryExclude(raw)
+		if err != nil {
+			return nil, err
+		}
+		if _, ok := seen[pattern]; ok {
+			continue
+		}
+		seen[pattern] = struct{}{}
+		result = append(result, pattern)
+	}
+	return result, nil
+}
+
+// ValidateDiscoveryExcludes is the validation-only form used by callers that
+// do not need the canonicalized values.
+func ValidateDiscoveryExcludes(patterns []string) error {
+	_, err := NormalizeDiscoveryExcludes(patterns)
+	return err
+}
+
+func normalizeDiscoveryExclude(raw string) (string, error) {
+	pattern := strings.TrimSpace(raw)
+	if pattern == "" {
+		return "", fmt.Errorf("discovery exclusion patterns must not be empty")
+	}
+	if len(pattern) > maxDiscoveryExcludeLength {
+		return "", fmt.Errorf("discovery exclusion pattern must be at most %d characters", maxDiscoveryExcludeLength)
+	}
+	if strings.ContainsAny(pattern, "\x00\r\n\t\\") {
+		return "", fmt.Errorf("discovery exclusion pattern %q contains unsafe control or path separator characters", raw)
+	}
+	if filepath.IsAbs(pattern) || strings.HasPrefix(pattern, "/") || hasWindowsVolume(pattern) {
+		return "", fmt.Errorf("discovery exclusion pattern %q must be a relative repository path", raw)
+	}
+
+	// A trailing slash has no useful distinction for a repository path. Accept
+	// it for ergonomic input, but do not allow it to create an empty segment.
+	pattern = strings.TrimRight(pattern, "/")
+	if pattern == "" {
+		return "", fmt.Errorf("discovery exclusion pattern %q must name a relative path", raw)
+	}
+	segments := strings.Split(pattern, "/")
+	for _, segment := range segments {
+		if segment == "" || segment == "." || segment == ".." {
+			return "", fmt.Errorf("discovery exclusion pattern %q contains an unsafe path segment", raw)
+		}
+		if _, err := path.Match(segment, "discovery-exclude-check"); err != nil {
+			return "", fmt.Errorf("discovery exclusion pattern %q is not a valid glob: %w", raw, err)
+		}
+	}
+	return strings.Join(segments, "/"), nil
+}
+
+func hasWindowsVolume(value string) bool {
+	return len(value) >= 2 && ((value[0] >= 'a' && value[0] <= 'z') || (value[0] >= 'A' && value[0] <= 'Z')) && value[1] == ':'
+}
+
+type discoveryExcludeGlob struct {
+	segments []string
+}
+
+// discoveryPathMatcher owns the repository root used to turn absolute walker
+// paths into repository-relative paths. A matched directory is considered
+// excluded for all of its descendants, allowing walkers to prune it before
+// reading any files.
+type discoveryPathMatcher struct {
+	root     string
+	patterns []discoveryExcludeGlob
+}
+
+func newDiscoveryPathMatcher(root string, patterns []string) (discoveryPathMatcher, error) {
+	normalized, err := NormalizeDiscoveryExcludes(patterns)
+	if err != nil {
+		return discoveryPathMatcher{}, err
+	}
+	matcher := discoveryPathMatcher{root: filepath.Clean(root), patterns: make([]discoveryExcludeGlob, 0, len(normalized))}
+	for _, pattern := range normalized {
+		matcher.patterns = append(matcher.patterns, discoveryExcludeGlob{segments: strings.Split(pattern, "/")})
+	}
+	return matcher, nil
+}
+
+func emptyDiscoveryPathMatcher(root string) discoveryPathMatcher {
+	return discoveryPathMatcher{root: filepath.Clean(root)}
+}
+
+func (matcher discoveryPathMatcher) relative(pathname string) (string, bool) {
+	if matcher.root != "" && filepath.IsAbs(pathname) {
+		relative, err := filepath.Rel(matcher.root, pathname)
+		if err != nil || relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
+			return "", false
+		}
+		if relative == "." {
+			return "", true
+		}
+		return filepath.ToSlash(relative), true
+	}
+	relative := filepath.ToSlash(filepath.Clean(pathname))
+	if relative == "." {
+		return "", true
+	}
+	if strings.HasPrefix(relative, "../") || relative == ".." || strings.HasPrefix(relative, "/") {
+		return "", false
+	}
+	return relative, true
+}
+
+// Excluded reports whether pathname itself, or an excluded directory ancestor,
+// matches one of the configured patterns. The empty relative path is the
+// repository root and is intentionally never excluded so a pattern such as
+// ** prunes all children without preventing the walker from starting.
+func (matcher discoveryPathMatcher) Excluded(pathname string) bool {
+	if len(matcher.patterns) == 0 {
+		return false
+	}
+	relative, ok := matcher.relative(pathname)
+	if !ok || relative == "" {
+		return false
+	}
+	segments := strings.Split(relative, "/")
+	for length := len(segments); length > 0; length-- {
+		candidate := segments[:length]
+		for _, pattern := range matcher.patterns {
+			if matchDiscoveryGlob(pattern.segments, candidate) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func matchDiscoveryGlob(pattern, value []string) bool {
+	state := make(map[[2]int]bool)
+	known := make(map[[2]int]bool)
+	var match func(int, int) bool
+	match = func(patternIndex, valueIndex int) bool {
+		key := [2]int{patternIndex, valueIndex}
+		if known[key] {
+			return state[key]
+		}
+		known[key] = true
+		matched := false
+		switch {
+		case patternIndex == len(pattern):
+			matched = valueIndex == len(value)
+		case pattern[patternIndex] == "**":
+			// ** consumes zero or more complete path segments. This makes
+			// .archive/** match .archive itself and every descendant.
+			for index := valueIndex; index <= len(value); index++ {
+				if match(patternIndex+1, index) {
+					matched = true
+					break
+				}
+			}
+		case valueIndex < len(value):
+			matched, _ = path.Match(pattern[patternIndex], value[valueIndex])
+			if matched {
+				matched = match(patternIndex+1, valueIndex+1)
+			}
+		}
+		state[key] = matched
+		return matched
+	}
+	return match(0, 0)
+}

--- a/services/backend/functions/gitrepositories/discovery_excludes_test.go
+++ b/services/backend/functions/gitrepositories/discovery_excludes_test.go
@@ -1,0 +1,165 @@
+package gitrepositories
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"justscan-backend/pkg/models"
+)
+
+func TestNormalizeDiscoveryExcludesValidatesSafeRelativeGlobs(t *testing.T) {
+	got, err := NormalizeDiscoveryExcludes([]string{" .archive/** ", "envs/*/generated", "envs/*/generated"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := []string{".archive/**", "envs/*/generated"}; !sameStrings(got, want) {
+		t.Fatalf("normalized exclusions = %#v, want %#v", got, want)
+	}
+
+	for _, pattern := range []string{"", "/tmp/archive", "../archive", "envs/../archive", "C:/archive", "envs\\archive", "envs/[broken"} {
+		if _, err := NormalizeDiscoveryExcludes([]string{pattern}); err == nil {
+			t.Errorf("NormalizeDiscoveryExcludes(%q) accepted an unsafe pattern", pattern)
+		}
+	}
+}
+
+func TestDiscoveryPathMatcherPrunesArchiveDirectoriesAndDescendants(t *testing.T) {
+	root := t.TempDir()
+	matcher, err := newDiscoveryPathMatcher(root, []string{".archive/**", "**/generated/**", "*.secret"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, path := range []string{
+		filepath.Join(root, ".archive"),
+		filepath.Join(root, ".archive", "old", "kustomization.yaml"),
+		filepath.Join(root, "envs", "generated"),
+		filepath.Join(root, "envs", "generated", "nested", "manifest.yaml"),
+		filepath.Join(root, "credentials.secret"),
+	} {
+		if !matcher.Excluded(path) {
+			t.Errorf("matcher did not exclude %q", path)
+		}
+	}
+	for _, path := range []string{root, filepath.Join(root, "envs", "dev", "deployment.yaml")} {
+		if matcher.Excluded(path) {
+			t.Errorf("matcher unexpectedly excluded %q", path)
+		}
+	}
+}
+
+func TestDiscoveryExcludesApplyToManifestGitLabRegistryAndCandidates(t *testing.T) {
+	root := t.TempDir()
+	writeDiscoveryTestFile(t, filepath.Join(root, "kept", "manifest.yaml"), discoveryManifest("kept.example.com/app:1"))
+	writeDiscoveryTestFile(t, filepath.Join(root, ".archive", "manifest.yaml"), discoveryManifest("archive.example.com/app:1"))
+	writeDiscoveryTestFile(t, filepath.Join(root, "ci", "kept.yml"), "build:\n  image: kept.example.com/ci:1\n")
+	writeDiscoveryTestFile(t, filepath.Join(root, "ci", ".archive", "ignored.yml"), "build:\n  image: archive.example.com/ci:1\n")
+	writeDiscoveryTestFile(t, filepath.Join(root, "images.txt"), "kept.example.com/app:1\narchive.example.com/app:1\n")
+	writeDiscoveryTestFile(t, filepath.Join(root, "envs", "kept", "values.yaml"), "image: kept.example.com/app:1\n")
+	writeDiscoveryTestFile(t, filepath.Join(root, ".archive", "envs", "values.yaml"), "image: archive.example.com/app:1\n")
+
+	matcher, err := newDiscoveryPathMatcher(root, []string{".archive/**", "ci/.archive/**"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifests, err := discoverYAMLWithMatcher(root, matcher)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasDiscoveredRef(manifests, "kept.example.com/app:1") || hasDiscoveredRef(manifests, "archive.example.com/app:1") {
+		t.Fatalf("manifest exclusions failed: %#v", manifests)
+	}
+
+	ci, err := discoverGitLabCIWithMatcher(root, []string{"ci"}, matcher)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasDiscoveredRef(ci, "kept.example.com/ci:1") || hasDiscoveredRef(ci, "archive.example.com/ci:1") {
+		t.Fatalf("GitLab CI exclusions failed: %#v", ci)
+	}
+
+	registry, err := discoverRegistryWithMatcher(root, "kept.example.com", matcher)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasDiscoveredRef(registry, "kept.example.com/app:1") || !hasDiscoveredRef(registry, "kept.example.com/ci:1") || hasDiscoveredRef(registry, "archive.example.com/app:1") {
+		t.Fatalf("registry exclusions failed: %#v", registry)
+	}
+
+	candidates := findDiscoveryCandidatesWithMatcher(root, nil, justScanConfig{}, nil, matcher)
+	if len(candidates) != 1 || candidates[0].Path != "envs/kept/values.yaml" {
+		t.Fatalf("candidate exclusions failed: %#v", candidates)
+	}
+}
+
+func TestDiscoverRepositoryRejectsExplicitExcludedKustomizeEntrypoint(t *testing.T) {
+	root := t.TempDir()
+	writeDiscoveryTestFile(t, filepath.Join(root, ".archive", "kustomization.yaml"), "apiVersion: kustomize.config.k8s.io/v1beta1\nkind: Kustomization\n")
+	_, err := discoverRepository(context.Background(), root, models.GitRepository{
+		DiscoveryMode:     models.GitRepositoryDiscoveryAuto,
+		Entrypoints:       []string{".archive/kustomization.yaml"},
+		DiscoveryExcludes: []string{".archive/**"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "is excluded") {
+		t.Fatalf("explicit excluded entrypoint error = %v", err)
+	}
+}
+
+func TestAutomaticKustomizeDiscoveryContinuesAfterBrokenRoot(t *testing.T) {
+	root := t.TempDir()
+	writeDiscoveryTestFile(t, filepath.Join(root, "broken", "kustomization.yaml"), "apiVersion: kustomize.config.k8s.io/v1beta1\nkind: Kustomization\nresources:\n  - missing.yaml\n")
+	writeDiscoveryTestFile(t, filepath.Join(root, "valid", "kustomization.yaml"), "apiVersion: kustomize.config.k8s.io/v1beta1\nkind: Kustomization\nresources:\n  - deployment.yaml\n")
+	writeDiscoveryTestFile(t, filepath.Join(root, "valid", "deployment.yaml"), discoveryManifest("valid.example.com/app:1"))
+
+	matcher, err := newDiscoveryPathMatcher(root, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	discovery, err := discoverRepositoryWithMatcher(context.Background(), root, models.GitRepository{DiscoveryMode: models.GitRepositoryDiscoveryAuto}, matcher)
+	if err != nil {
+		t.Fatalf("automatic discovery returned an error: %v", err)
+	}
+	if len(discovery.images) != 1 || discovery.images[0].FullRef != "valid.example.com/app:1" {
+		t.Fatalf("automatic discovery images = %#v", discovery.images)
+	}
+	if len(discovery.warnings) != 1 || discovery.warnings[0].Path != "broken/kustomization.yaml" || discovery.warnings[0].Status != models.GitRepositoryCandidateUnresolved {
+		t.Fatalf("automatic discovery warnings = %#v", discovery.warnings)
+	}
+}
+
+func writeDiscoveryTestFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func discoveryManifest(image string) string {
+	return "apiVersion: v1\nkind: Pod\nmetadata:\n  name: discovery-test\nspec:\n  containers:\n    - name: app\n      image: " + image + "\n"
+}
+
+func hasDiscoveredRef(images []DiscoveredImage, fullRef string) bool {
+	for _, image := range images {
+		if image.FullRef == fullRef {
+			return true
+		}
+	}
+	return false
+}
+
+func sameStrings(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for index := range left {
+		if left[index] != right[index] {
+			return false
+		}
+	}
+	return true
+}

--- a/services/backend/functions/gitrepositories/gitlab_ci.go
+++ b/services/backend/functions/gitrepositories/gitlab_ci.go
@@ -29,14 +29,18 @@ var (
 // root .gitlab-ci.yml/.gitlab-ci.yaml files are used. Explicit paths may be
 // files, directories, or filepath globs; all paths are resolved below root.
 func discoverGitLabCI(root string, paths []string) ([]DiscoveredImage, error) {
-	files, err := gitLabCIConfigFiles(root, paths)
+	return discoverGitLabCIWithMatcher(root, paths, emptyDiscoveryPathMatcher(root))
+}
+
+func discoverGitLabCIWithMatcher(root string, paths []string, discoveryMatcher discoveryPathMatcher) ([]DiscoveredImage, error) {
+	files, err := gitLabCIConfigFilesWithMatcher(root, paths, discoveryMatcher)
 	if err != nil {
 		return nil, err
 	}
 	byRef := map[string]*DiscoveredImage{}
 	visited := map[string]bool{}
 	for _, file := range files {
-		if err := appendGitLabCIFile(root, file, byRef, visited, 0); err != nil {
+		if err := appendGitLabCIFileWithMatcher(root, file, byRef, visited, 0, discoveryMatcher); err != nil {
 			return nil, err
 		}
 	}
@@ -44,6 +48,11 @@ func discoverGitLabCI(root string, paths []string) ([]DiscoveredImage, error) {
 }
 
 func gitLabCIConfigFiles(root string, paths []string) ([]string, error) {
+	return gitLabCIConfigFilesWithMatcher(root, paths, emptyDiscoveryPathMatcher(root))
+}
+
+func gitLabCIConfigFilesWithMatcher(root string, paths []string, discoveryMatcher discoveryPathMatcher) ([]string, error) {
+	explicitPaths := len(paths) > 0
 	if len(paths) == 0 {
 		paths = []string{gitLabCIFileName, gitLabCIAltFileName}
 	}
@@ -54,7 +63,7 @@ func gitLabCIConfigFiles(root string, paths []string) ([]string, error) {
 		if raw == "" {
 			continue
 		}
-		matches, err := gitLabCIPathMatches(root, raw)
+		matches, err := gitLabCIPathMatchesWithMatcher(root, raw, discoveryMatcher, explicitPaths)
 		if err != nil {
 			return nil, err
 		}
@@ -71,10 +80,20 @@ func gitLabCIConfigFiles(root string, paths []string) ([]string, error) {
 }
 
 func gitLabCIPathMatches(root, raw string) ([]string, error) {
+	return gitLabCIPathMatchesWithMatcher(root, raw, emptyDiscoveryPathMatcher(root), false)
+}
+
+func gitLabCIPathMatchesWithMatcher(root, raw string, discoveryMatcher discoveryPathMatcher, explicitPath bool) ([]string, error) {
 	if !hasGitLabCIGlob(raw) {
 		path, err := resolveRepositoryPath(root, raw)
 		if err != nil {
 			return nil, err
+		}
+		if discoveryMatcher.Excluded(path) {
+			if explicitPath {
+				return nil, fmt.Errorf("GitLab CI config path %q is excluded", raw)
+			}
+			return nil, nil
 		}
 		info, err := os.Stat(path)
 		if os.IsNotExist(err) && (raw == gitLabCIFileName || raw == gitLabCIAltFileName) {
@@ -86,7 +105,7 @@ func gitLabCIPathMatches(root, raw string) ([]string, error) {
 			return nil, fmt.Errorf("stat GitLab CI config %q: %w", raw, err)
 		}
 		if info.IsDir() {
-			return gitLabCIWalkFiles(root, path)
+			return gitLabCIWalkFilesWithMatcher(root, path, discoveryMatcher)
 		}
 		return []string{path}, nil
 	}
@@ -104,12 +123,18 @@ func gitLabCIPathMatches(root, raw string) ([]string, error) {
 		if !pathWithin(root, match) {
 			return nil, fmt.Errorf("GitLab CI config path %q is outside the repository", raw)
 		}
+		if discoveryMatcher.Excluded(match) {
+			if explicitPath {
+				return nil, fmt.Errorf("GitLab CI config path %q is excluded", raw)
+			}
+			continue
+		}
 		info, statErr := os.Stat(match)
 		if statErr != nil {
 			return nil, fmt.Errorf("stat GitLab CI config %q: %w", raw, statErr)
 		}
 		if info.IsDir() {
-			walked, walkErr := gitLabCIWalkFiles(root, match)
+			walked, walkErr := gitLabCIWalkFilesWithMatcher(root, match, discoveryMatcher)
 			if walkErr != nil {
 				return nil, walkErr
 			}
@@ -123,10 +148,23 @@ func gitLabCIPathMatches(root, raw string) ([]string, error) {
 }
 
 func gitLabCIWalkFiles(root, directory string) ([]string, error) {
+	return gitLabCIWalkFilesWithMatcher(root, directory, emptyDiscoveryPathMatcher(root))
+}
+
+func gitLabCIWalkFilesWithMatcher(root, directory string, discoveryMatcher discoveryPathMatcher) ([]string, error) {
 	files := []string{}
 	err := filepath.WalkDir(directory, func(path string, entry os.DirEntry, walkErr error) error {
 		if walkErr != nil {
 			return walkErr
+		}
+		if entry == nil {
+			return nil
+		}
+		if discoveryMatcher.Excluded(path) {
+			if entry.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
 		}
 		if entry.IsDir() {
 			if entry.Name() == ".git" {
@@ -147,7 +185,14 @@ func gitLabCIWalkFiles(root, directory string) ([]string, error) {
 }
 
 func appendGitLabCIFile(root, file string, byRef map[string]*DiscoveredImage, visited map[string]bool, depth int) error {
+	return appendGitLabCIFileWithMatcher(root, file, byRef, visited, depth, emptyDiscoveryPathMatcher(root))
+}
+
+func appendGitLabCIFileWithMatcher(root, file string, byRef map[string]*DiscoveredImage, visited map[string]bool, depth int, discoveryMatcher discoveryPathMatcher) error {
 	file = filepath.Clean(file)
+	if discoveryMatcher.Excluded(file) {
+		return nil
+	}
 	if visited[file] {
 		return nil
 	}
@@ -213,14 +258,14 @@ func appendGitLabCIFile(root, file string, byRef map[string]*DiscoveredImage, vi
 		}
 
 		for _, include := range gitLabCILocalIncludes(configuration["include"]) {
-			includePath, includeErr := resolveGitLabCILocalInclude(root, file, include)
+			includePath, includeErr := resolveGitLabCILocalIncludeWithMatcher(root, file, include, discoveryMatcher)
 			if includeErr != nil {
 				return includeErr
 			}
 			if includePath == "" {
 				continue
 			}
-			if err := appendGitLabCIFile(root, includePath, byRef, visited, depth+1); err != nil {
+			if err := appendGitLabCIFileWithMatcher(root, includePath, byRef, visited, depth+1, discoveryMatcher); err != nil {
 				return err
 			}
 		}
@@ -385,6 +430,10 @@ func gitLabCILocalIncludes(value any) []string {
 }
 
 func resolveGitLabCILocalInclude(root, includingFile, include string) (string, error) {
+	return resolveGitLabCILocalIncludeWithMatcher(root, includingFile, include, emptyDiscoveryPathMatcher(root))
+}
+
+func resolveGitLabCILocalIncludeWithMatcher(root, includingFile, include string, discoveryMatcher discoveryPathMatcher) (string, error) {
 	include = strings.TrimSpace(include)
 	if include == "" || strings.HasPrefix(include, "http://") || strings.HasPrefix(include, "https://") {
 		return "", nil
@@ -393,6 +442,9 @@ func resolveGitLabCILocalInclude(root, includingFile, include string) (string, e
 	path, err := resolveRepositoryPath(root, include)
 	if err != nil {
 		return "", fmt.Errorf("resolve GitLab CI local include %q: %w", include, err)
+	}
+	if discoveryMatcher.Excluded(path) {
+		return "", nil
 	}
 	if _, err := os.Stat(path); err == nil {
 		return path, nil
@@ -403,6 +455,9 @@ func resolveGitLabCILocalInclude(root, includingFile, include string) (string, e
 	// root-relative path remains the GitLab-defined interpretation.
 	nested := filepath.Join(filepath.Dir(includingFile), include)
 	if pathWithin(root, nested) {
+		if discoveryMatcher.Excluded(nested) {
+			return "", nil
+		}
 		if _, err := os.Stat(nested); err == nil {
 			return filepath.Clean(nested), nil
 		}

--- a/services/backend/functions/gitrepositories/registry_discovery.go
+++ b/services/backend/functions/gitrepositories/registry_discovery.go
@@ -183,6 +183,10 @@ func NormalizeConfiguredRegistryDiscoveryPrefix(value string) (string, error) {
 // addressed to prefix. It never follows symlinked files and skips common
 // generated/dependency trees before reading file contents.
 func discoverRegistry(root, prefix string) ([]DiscoveredImage, error) {
+	return discoverRegistryWithMatcher(root, prefix, emptyDiscoveryPathMatcher(root))
+}
+
+func discoverRegistryWithMatcher(root, prefix string, discoveryMatcher discoveryPathMatcher) ([]DiscoveredImage, error) {
 	normalizedPrefix, err := NormalizeRegistryDiscoveryPrefix(prefix)
 	if err != nil {
 		return nil, err
@@ -199,6 +203,12 @@ func discoverRegistry(root, prefix string) ([]DiscoveredImage, error) {
 			return walkErr
 		}
 		if entry == nil {
+			return nil
+		}
+		if discoveryMatcher.Excluded(path) {
+			if entry.IsDir() {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 		if entry.IsDir() {

--- a/services/backend/functions/gitrepositories/service.go
+++ b/services/backend/functions/gitrepositories/service.go
@@ -66,6 +66,11 @@ type DiscoveryCandidate struct {
 	RuleID       *uuid.UUID
 }
 
+type repositoryDiscoveryResult struct {
+	images   []DiscoveredImage
+	warnings []DiscoveryCandidate
+}
+
 // justScanConfig is optional repository-owned discovery configuration. It
 // composes multiple deployment mechanisms in one dry run.
 type justScanConfig struct {
@@ -846,6 +851,10 @@ func DiscoverReview(ctx context.Context, repository models.GitRepository) ([]Dis
 	if err := clone(cloneCtx, repository, dir); err != nil {
 		return nil, nil, "", err
 	}
+	discoveryMatcher, err := newDiscoveryPathMatcher(dir, repository.DiscoveryExcludes)
+	if err != nil {
+		return nil, nil, "", err
+	}
 	commit, err := gitOutput(cloneCtx, dir, "rev-parse", "HEAD")
 	if err != nil {
 		return nil, nil, "", err
@@ -855,11 +864,12 @@ func DiscoverReview(ctx context.Context, repository models.GitRepository) ([]Dis
 	if configErr != nil {
 		return nil, nil, strings.TrimSpace(commit), configErr
 	}
-	images, err := discoverRepository(ctx, dir, repository)
+	discovery, err := discoverRepositoryWithMatcher(ctx, dir, repository, discoveryMatcher)
 	if err != nil {
 		return nil, nil, strings.TrimSpace(commit), err
 	}
-	managedImages, err := discoverManagedHelmSources(ctx, dir, repository)
+	images := discovery.images
+	managedImages, err := discoverManagedHelmSources(ctx, dir, repository, discoveryMatcher)
 	if err != nil {
 		return nil, nil, strings.TrimSpace(commit), err
 	}
@@ -869,7 +879,7 @@ func DiscoverReview(ctx context.Context, repository models.GitRepository) ([]Dis
 		return nil, nil, strings.TrimSpace(commit), err
 	}
 	if !configured && len(rules) > 0 {
-		if resolved, err := discoverRuleSources(ctx, dir, rules, repository); err == nil {
+		if resolved, err := discoverRuleSourcesWithMatcher(ctx, dir, rules, repository, discoveryMatcher); err == nil {
 			images = mergeDiscoveredImages(images, resolved)
 		}
 	}
@@ -877,7 +887,10 @@ func DiscoverReview(ctx context.Context, repository models.GitRepository) ([]Dis
 		rules = nil // A committed repository configuration takes precedence over UI rules.
 	}
 	images = detectImageRegistries(ctx, repository, images)
-	return images, findDiscoveryCandidates(dir, rules, configuration, managedSources), strings.TrimSpace(commit), nil
+	candidates := findDiscoveryCandidatesWithMatcher(dir, rules, configuration, managedSources, discoveryMatcher)
+	candidates = append(candidates, discovery.warnings...)
+	sort.Slice(candidates, func(i, j int) bool { return candidates[i].Path < candidates[j].Path })
+	return images, candidates, strings.TrimSpace(commit), nil
 }
 
 func loadDiscoveryRules(ctx context.Context, repositoryID uuid.UUID) []models.GitRepositoryDiscoveryRule {
@@ -911,7 +924,7 @@ func loadHelmSources(ctx context.Context, repositoryID uuid.UUID) ([]models.GitR
 // Managed Helm sources are deliberately independent of repository-owned
 // .justscan.yaml configuration: connector IDs and encrypted credentials cannot
 // be committed safely, and an external chart can complement local sources.
-func discoverManagedHelmSources(ctx context.Context, repositoryRoot string, repository models.GitRepository) ([]DiscoveredImage, error) {
+func discoverManagedHelmSources(ctx context.Context, repositoryRoot string, repository models.GitRepository, discoveryMatcher discoveryPathMatcher) ([]DiscoveredImage, error) {
 	sources, err := loadHelmSources(ctx, repository.ID)
 	if err != nil || len(sources) == 0 {
 		return nil, err
@@ -921,11 +934,27 @@ func discoverManagedHelmSources(ctx context.Context, repositoryRoot string, repo
 	state.Unlock()
 	byRef := map[string]*DiscoveredImage{}
 	for _, source := range sources {
+		for _, configuredValue := range source.Values {
+			valuePath, valueErr := resolveRepositoryPath(repositoryRoot, configuredValue)
+			if valueErr != nil {
+				return nil, valueErr
+			}
+			if discoveryMatcher.Excluded(valuePath) {
+				return nil, fmt.Errorf("managed Helm values path %q is excluded", configuredValue)
+			}
+		}
 		chartRoot := repositoryRoot
 		chartLabel := relativePath(repositoryRoot, filepath.Join(repositoryRoot, source.ChartPath))
 		var removeChartRoot func()
 		switch source.SourceType {
 		case "local":
+			chartPath, chartErr := resolveRepositoryPath(repositoryRoot, source.ChartPath)
+			if chartErr != nil {
+				return nil, chartErr
+			}
+			if discoveryMatcher.Excluded(chartPath) {
+				return nil, fmt.Errorf("managed Helm chart path %q is excluded", source.ChartPath)
+			}
 			chartLabel = relativePath(repositoryRoot, filepath.Join(repositoryRoot, source.ChartPath))
 		case "repository", "url":
 			chartRepository, err := managedHelmChartRepository(ctx, db, source)
@@ -973,6 +1002,14 @@ func managedHelmChartRepository(ctx context.Context, db *bun.DB, source models.G
 }
 
 func discoverRuleSources(ctx context.Context, root string, rules []models.GitRepositoryDiscoveryRule, repository models.GitRepository) ([]DiscoveredImage, error) {
+	discoveryMatcher, err := newDiscoveryPathMatcher(root, repository.DiscoveryExcludes)
+	if err != nil {
+		return nil, err
+	}
+	return discoverRuleSourcesWithMatcher(ctx, root, rules, repository, discoveryMatcher)
+}
+
+func discoverRuleSourcesWithMatcher(ctx context.Context, root string, rules []models.GitRepositoryDiscoveryRule, repository models.GitRepository, discoveryMatcher discoveryPathMatcher) ([]DiscoveredImage, error) {
 	configuration := justScanConfig{Version: 1}
 	for _, rule := range rules {
 		if rule.Resolution == "ignore" {
@@ -992,7 +1029,8 @@ func discoverRuleSources(ctx context.Context, root string, rules []models.GitRep
 	if len(configuration.Discovery.Sources) == 0 {
 		return nil, nil
 	}
-	return discoverConfiguredSources(ctx, root, configuration, repository)
+	discovery, err := discoverConfiguredSourcesWithMatcher(ctx, root, configuration, repository, discoveryMatcher)
+	return discovery.images, err
 }
 
 func mergeDiscoveredImages(groups ...[]DiscoveredImage) []DiscoveredImage {
@@ -1013,10 +1051,27 @@ func mergeDiscoveredImages(groups ...[]DiscoveredImage) []DiscoveredImage {
 }
 
 func findDiscoveryCandidates(root string, rules []models.GitRepositoryDiscoveryRule, configuration justScanConfig, helmSources []models.GitRepositoryHelmSource) []DiscoveryCandidate {
+	discoveryMatcher := emptyDiscoveryPathMatcher(root)
+	return findDiscoveryCandidatesWithMatcher(root, rules, configuration, helmSources, discoveryMatcher)
+}
+
+func findDiscoveryCandidatesWithMatcher(root string, rules []models.GitRepositoryDiscoveryRule, configuration justScanConfig, helmSources []models.GitRepositoryHelmSource, discoveryMatcher discoveryPathMatcher) []DiscoveryCandidate {
 	result := []DiscoveryCandidate{}
-	consumedValues := kustomizeValuesFiles(root)
+	consumedValues := kustomizeValuesFilesWithMatcher(root, discoveryMatcher)
 	_ = filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
-		if err != nil || entry.IsDir() {
+		if err != nil {
+			return nil
+		}
+		if entry == nil {
+			return nil
+		}
+		if discoveryMatcher.Excluded(path) {
+			if entry.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if entry.IsDir() {
 			if entry != nil && entry.IsDir() && (entry.Name() == ".git" || (path != root && isAutoDiscoveryFixtureDirectory(relativePath(root, path)))) {
 				return filepath.SkipDir
 			}
@@ -1093,9 +1148,22 @@ func chartFilename(path string) string {
 }
 
 func kustomizeValuesFiles(root string) map[string]bool {
+	return kustomizeValuesFilesWithMatcher(root, emptyDiscoveryPathMatcher(root))
+}
+
+func kustomizeValuesFilesWithMatcher(root string, discoveryMatcher discoveryPathMatcher) map[string]bool {
 	result := map[string]bool{}
 	_ = filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
-		if err != nil || entry.IsDir() || !isKustomizationFile(entry.Name()) {
+		if err != nil || entry == nil {
+			return nil
+		}
+		if discoveryMatcher.Excluded(path) {
+			if entry.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if entry.IsDir() || !isKustomizationFile(entry.Name()) {
 			return nil
 		}
 		content, err := os.ReadFile(path)
@@ -1259,48 +1327,65 @@ func defaultTimezone(value string) string {
 }
 
 func discoverRepository(ctx context.Context, root string, repository models.GitRepository) ([]DiscoveredImage, error) {
-	if repositoryConfig, configured, err := loadJustScanConfig(root); err != nil {
+	discoveryMatcher, err := newDiscoveryPathMatcher(root, repository.DiscoveryExcludes)
+	if err != nil {
 		return nil, err
+	}
+	discovery, err := discoverRepositoryWithMatcher(ctx, root, repository, discoveryMatcher)
+	if err != nil {
+		return nil, err
+	}
+	return discovery.images, nil
+}
+
+func discoverRepositoryWithMatcher(ctx context.Context, root string, repository models.GitRepository, discoveryMatcher discoveryPathMatcher) (repositoryDiscoveryResult, error) {
+	if repositoryConfig, configured, err := loadJustScanConfig(root); err != nil {
+		return repositoryDiscoveryResult{}, err
 	} else if configured {
-		return discoverConfiguredSources(ctx, root, repositoryConfig, repository)
+		return discoverConfiguredSourcesWithMatcher(ctx, root, repositoryConfig, repository, discoveryMatcher)
 	}
 	mode := repository.DiscoveryMode
 	if mode == "" {
 		mode = models.GitRepositoryDiscoveryAuto
 	}
 	if mode == models.GitRepositoryDiscoveryManifests {
-		return discoverYAML(root)
+		images, err := discoverYAMLWithMatcher(root, discoveryMatcher)
+		return repositoryDiscoveryResult{images: images}, err
 	}
 	if mode == models.GitRepositoryDiscoveryRegistry {
 		prefix, registryID, err := registryDiscoverySelection(ctx, repository)
 		if err != nil {
-			return nil, err
+			return repositoryDiscoveryResult{}, err
 		}
-		images, err := discoverRegistry(root, prefix)
+		images, err := discoverRegistryWithMatcher(root, prefix, discoveryMatcher)
 		if err != nil {
-			return nil, err
+			return repositoryDiscoveryResult{}, err
 		}
 		if registryID != nil {
 			for index := range images {
 				images[index].RegistryID = registryID
 			}
 		}
-		return images, nil
+		return repositoryDiscoveryResult{images: images}, nil
 	}
 	if mode == models.GitRepositoryDiscoveryGitLabCI {
-		return discoverGitLabCI(root, repository.Entrypoints)
+		images, err := discoverGitLabCIWithMatcher(root, repository.Entrypoints, discoveryMatcher)
+		return repositoryDiscoveryResult{images: images}, err
 	}
-	roots, err := findKustomizationRoots(root, repository.Entrypoints)
+	explicitEntrypoints := len(repository.Entrypoints) > 0
+	roots, err := findKustomizationRootsWithMatcher(root, repository.Entrypoints, discoveryMatcher)
 	if err != nil {
-		return nil, err
+		return repositoryDiscoveryResult{}, err
 	}
 	if len(roots) == 0 {
 		if mode == models.GitRepositoryDiscoveryKustomize {
-			return nil, fmt.Errorf("no Kustomize entrypoints found")
+			return repositoryDiscoveryResult{}, fmt.Errorf("no Kustomize entrypoints found")
 		}
-		return discoverYAML(root)
+		images, err := discoverYAMLWithMatcher(root, discoveryMatcher)
+		return repositoryDiscoveryResult{images: images}, err
 	}
-	return discoverKustomizeRoots(root, roots)
+	images, warnings, err := discoverKustomizeRootsWithMatcher(root, roots, discoveryMatcher, explicitEntrypoints)
+	return repositoryDiscoveryResult{images: images, warnings: warnings}, err
 }
 
 func loadJustScanConfig(root string) (justScanConfig, bool, error) {
@@ -1328,7 +1413,17 @@ func loadJustScanConfig(root string) (justScanConfig, bool, error) {
 }
 
 func discoverConfiguredSources(ctx context.Context, root string, configuration justScanConfig, repository models.GitRepository) ([]DiscoveredImage, error) {
+	discoveryMatcher, err := newDiscoveryPathMatcher(root, repository.DiscoveryExcludes)
+	if err != nil {
+		return nil, err
+	}
+	discovery, err := discoverConfiguredSourcesWithMatcher(ctx, root, configuration, repository, discoveryMatcher)
+	return discovery.images, err
+}
+
+func discoverConfiguredSourcesWithMatcher(ctx context.Context, root string, configuration justScanConfig, repository models.GitRepository, discoveryMatcher discoveryPathMatcher) (repositoryDiscoveryResult, error) {
 	byRef := map[string]*DiscoveredImage{}
+	warnings := []DiscoveryCandidate{}
 	sources := append([]justScanSource{}, configuration.Discovery.Sources...)
 	for _, rule := range configuration.Discovery.Rules {
 		source := justScanSource{Type: rule.Type, Chart: rule.Chart, Values: rule.Values, ReleaseName: rule.ReleaseName, Paths: rule.Paths}
@@ -1345,40 +1440,45 @@ func discoverConfiguredSources(ctx context.Context, root string, configuration j
 		case "kustomize":
 			var roots []string
 			var err error
+			explicitRoots := len(source.Paths) > 0
 			if len(source.Paths) > 0 {
-				roots, err = findKustomizationRoots(root, source.Paths)
+				roots, err = findKustomizationRootsWithMatcher(root, source.Paths, discoveryMatcher)
 			} else {
 				discoveryRoot, resolveErr := resolveRepositoryPath(root, source.Root)
 				if resolveErr != nil {
 					err = resolveErr
+				} else if discoveryMatcher.Excluded(discoveryRoot) {
+					err = fmt.Errorf("Kustomize discovery root %q is excluded", source.Root)
 				} else {
-					roots, err = findKustomizationRoots(discoveryRoot, nil)
+					roots, err = findKustomizationRootsWithMatcher(discoveryRoot, nil, discoveryMatcher)
 				}
 			}
 			if err != nil {
-				return nil, fmt.Errorf(".justscan.yaml source %d (kustomize): %w", index+1, err)
+				return repositoryDiscoveryResult{}, fmt.Errorf(".justscan.yaml source %d (kustomize): %w", index+1, err)
 			}
 			if len(roots) == 0 {
-				return nil, fmt.Errorf(".justscan.yaml source %d (kustomize): no entrypoints found", index+1)
+				return repositoryDiscoveryResult{}, fmt.Errorf(".justscan.yaml source %d (kustomize): no entrypoints found", index+1)
 			}
-			if err := appendKustomizeRoots(root, byRef, roots); err != nil {
-				return nil, err
+			rootWarnings, err := appendKustomizeRootsWithMatcher(root, byRef, roots, discoveryMatcher, explicitRoots)
+			if err != nil {
+				return repositoryDiscoveryResult{}, fmt.Errorf(".justscan.yaml source %d (kustomize): %w", index+1, err)
 			}
+			warnings = append(warnings, rootWarnings...)
 		case "manifests":
 			if len(source.Paths) == 0 {
-				return nil, fmt.Errorf(".justscan.yaml source %d (manifests): paths is required", index+1)
+				return repositoryDiscoveryResult{}, fmt.Errorf(".justscan.yaml source %d (manifests): paths is required", index+1)
 			}
-			if err := appendManifestPaths(root, byRef, source.Paths); err != nil {
-				return nil, fmt.Errorf(".justscan.yaml source %d (manifests): %w", index+1, err)
+			if err := appendManifestPathsWithMatcher(root, byRef, source.Paths, discoveryMatcher); err != nil {
+				return repositoryDiscoveryResult{}, fmt.Errorf(".justscan.yaml source %d (manifests): %w", index+1, err)
 			}
 		case "gitlab_ci", "gitlab-ci", "gitlab":
 			paths := source.Paths
 			if len(paths) == 0 && strings.TrimSpace(source.Root) != "" {
 				paths = []string{source.Root}
 			}
-			images, err := discoverGitLabCI(root, paths)
+			images, err := discoverGitLabCIWithMatcher(root, paths, discoveryMatcher)
 			if err != nil {
-				return nil, fmt.Errorf(".justscan.yaml source %d (gitlab_ci): %w", index+1, err)
+				return repositoryDiscoveryResult{}, fmt.Errorf(".justscan.yaml source %d (gitlab_ci): %w", index+1, err)
 			}
 			for _, image := range images {
 				item := image
@@ -1391,14 +1491,30 @@ func discoverConfiguredSources(ctx context.Context, root string, configuration j
 				byRef[image.FullRef] = &item
 			}
 		case "helm":
+			chartPath, chartErr := resolveRepositoryPath(root, source.Chart)
+			if chartErr != nil {
+				return repositoryDiscoveryResult{}, fmt.Errorf(".justscan.yaml source %d (helm): %w", index+1, chartErr)
+			}
+			if discoveryMatcher.Excluded(chartPath) {
+				return repositoryDiscoveryResult{}, fmt.Errorf(".justscan.yaml source %d (helm): chart path %q is excluded", index+1, source.Chart)
+			}
+			for _, configuredValue := range source.Values {
+				valuePath, valueErr := resolveRepositoryPath(root, configuredValue)
+				if valueErr != nil {
+					return repositoryDiscoveryResult{}, fmt.Errorf(".justscan.yaml source %d (helm): %w", index+1, valueErr)
+				}
+				if discoveryMatcher.Excluded(valuePath) {
+					return repositoryDiscoveryResult{}, fmt.Errorf(".justscan.yaml source %d (helm): values path %q is excluded", index+1, configuredValue)
+				}
+			}
 			if err := appendHelmChartFromRoots(ctx, root, root, byRef, source, "", repository, nil, nil); err != nil {
-				return nil, fmt.Errorf(".justscan.yaml source %d (helm): %w", index+1, err)
+				return repositoryDiscoveryResult{}, fmt.Errorf(".justscan.yaml source %d (helm): %w", index+1, err)
 			}
 		default:
-			return nil, fmt.Errorf(".justscan.yaml source %d has unsupported type %q", index+1, source.Type)
+			return repositoryDiscoveryResult{}, fmt.Errorf(".justscan.yaml source %d has unsupported type %q", index+1, source.Type)
 		}
 	}
-	return sortedDiscoveredImages(byRef), nil
+	return repositoryDiscoveryResult{images: sortedDiscoveredImages(byRef), warnings: warnings}, nil
 }
 
 func resolveRepositoryPath(root, relative string) (string, error) {
@@ -1417,10 +1533,23 @@ func resolveRepositoryPath(root, relative string) (string, error) {
 // Kubernetes manifests. It intentionally ignores Helm values and other
 // declarations because those are not proof that an image is deployed.
 func discoverYAML(root string) ([]DiscoveredImage, error) {
+	return discoverYAMLWithMatcher(root, emptyDiscoveryPathMatcher(root))
+}
+
+func discoverYAMLWithMatcher(root string, discoveryMatcher discoveryPathMatcher) ([]DiscoveredImage, error) {
 	byRef := map[string]*DiscoveredImage{}
 	err := filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
 		if err != nil {
 			return err
+		}
+		if entry == nil {
+			return nil
+		}
+		if discoveryMatcher.Excluded(path) {
+			if entry.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
 		}
 		if entry.IsDir() {
 			if entry.Name() == ".git" {
@@ -1471,30 +1600,63 @@ func isAutoDiscoveryFixtureDirectory(relative string) bool {
 }
 
 func discoverKustomizeRoots(root string, roots []string) ([]DiscoveredImage, error) {
+	images, _, err := discoverKustomizeRootsWithMatcher(root, roots, emptyDiscoveryPathMatcher(root), true)
+	return images, err
+}
+
+func discoverKustomizeRootsWithMatcher(root string, roots []string, discoveryMatcher discoveryPathMatcher, failOnRenderError bool) ([]DiscoveredImage, []DiscoveryCandidate, error) {
 	byRef := map[string]*DiscoveredImage{}
-	if err := appendKustomizeRoots(root, byRef, roots); err != nil {
-		return nil, err
+	warnings, err := appendKustomizeRootsWithMatcher(root, byRef, roots, discoveryMatcher, failOnRenderError)
+	if err != nil {
+		return nil, nil, err
 	}
-	return sortedDiscoveredImages(byRef), nil
+	return sortedDiscoveredImages(byRef), warnings, nil
 }
 
 func appendKustomizeRoots(root string, byRef map[string]*DiscoveredImage, roots []string) error {
+	_, err := appendKustomizeRootsWithMatcher(root, byRef, roots, emptyDiscoveryPathMatcher(root), true)
+	return err
+}
+
+func appendKustomizeRootsWithMatcher(root string, byRef map[string]*DiscoveredImage, roots []string, discoveryMatcher discoveryPathMatcher, failOnRenderError bool) ([]DiscoveryCandidate, error) {
+	warnings := []DiscoveryCandidate{}
 	for _, target := range roots {
+		if discoveryMatcher.Excluded(target) {
+			return nil, fmt.Errorf("Kustomize entrypoint %q is excluded", relativePath(root, target))
+		}
 		output, err := renderKustomization(target)
 		if err != nil {
-			return fmt.Errorf("render %s: %w", relativePath(root, target), err)
+			if failOnRenderError {
+				return nil, fmt.Errorf("render %s: %w", relativePath(root, target), err)
+			}
+			path := relativePath(root, filepath.Join(target, kustomizationFilename(target)))
+			warnings = append(warnings, DiscoveryCandidate{
+				Path:         path,
+				DetectedType: "kustomize",
+				Confidence:   "ambiguous",
+				Evidence:     models.JSONObject{"error": err.Error(), "directory": relativePath(root, target)},
+				Status:       models.GitRepositoryCandidateUnresolved,
+			})
+			continue
 		}
 		entrypoint := relativePath(root, filepath.Join(target, kustomizationFilename(target)))
 		appendManifestImages(byRef, output, "(rendered)", entrypoint)
 	}
-	return nil
+	return warnings, nil
 }
 
 func appendManifestPaths(root string, byRef map[string]*DiscoveredImage, paths []string) error {
+	return appendManifestPathsWithMatcher(root, byRef, paths, emptyDiscoveryPathMatcher(root))
+}
+
+func appendManifestPathsWithMatcher(root string, byRef map[string]*DiscoveredImage, paths []string, discoveryMatcher discoveryPathMatcher) error {
 	for _, configuredPath := range paths {
 		path, err := resolveRepositoryPath(root, configuredPath)
 		if err != nil {
 			return err
+		}
+		if discoveryMatcher.Excluded(path) {
+			return fmt.Errorf("manifest path %q is excluded", configuredPath)
 		}
 		info, err := os.Stat(path)
 		if err != nil {
@@ -1504,6 +1666,15 @@ func appendManifestPaths(root string, byRef map[string]*DiscoveredImage, paths [
 			err = filepath.WalkDir(path, func(candidate string, entry os.DirEntry, walkErr error) error {
 				if walkErr != nil {
 					return walkErr
+				}
+				if entry == nil {
+					return nil
+				}
+				if discoveryMatcher.Excluded(candidate) {
+					if entry.IsDir() {
+						return filepath.SkipDir
+					}
+					return nil
 				}
 				if entry.IsDir() {
 					if entry.Name() == ".git" {
@@ -1973,13 +2144,27 @@ func renderKustomization(target string) ([]byte, error) {
 }
 
 func findKustomizationRoots(root string, entrypoints []string) ([]string, error) {
+	return findKustomizationRootsWithMatcher(root, entrypoints, emptyDiscoveryPathMatcher(root))
+}
+
+func findKustomizationRootsWithMatcher(root string, entrypoints []string, discoveryMatcher discoveryPathMatcher) ([]string, error) {
 	if len(entrypoints) > 0 {
 		roots := make([]string, 0, len(entrypoints))
 		seen := map[string]bool{}
 		for _, entrypoint := range entrypoints {
+			selectedPath, err := resolveRepositoryPath(root, entrypoint)
+			if err != nil {
+				return nil, err
+			}
+			if discoveryMatcher.Excluded(selectedPath) {
+				return nil, fmt.Errorf("Kustomize entrypoint %q is excluded", entrypoint)
+			}
 			target, err := resolveKustomizationEntrypoint(root, entrypoint)
 			if err != nil {
 				return nil, err
+			}
+			if discoveryMatcher.Excluded(target) {
+				return nil, fmt.Errorf("Kustomize entrypoint %q is excluded", entrypoint)
 			}
 			if !seen[target] {
 				seen[target] = true
@@ -1995,6 +2180,15 @@ func findKustomizationRoots(root string, entrypoints []string) ([]string, error)
 	err := filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
 		if err != nil {
 			return err
+		}
+		if entry == nil {
+			return nil
+		}
+		if discoveryMatcher.Excluded(path) {
+			if entry.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
 		}
 		if entry.IsDir() {
 			if entry.Name() == ".git" {

--- a/services/backend/handlers/gitrepositories/gitrepositories.go
+++ b/services/backend/handlers/gitrepositories/gitrepositories.go
@@ -37,6 +37,7 @@ type repositoryRequest struct {
 	DiscoveryRegistryID string   `json:"discovery_registry_id"`
 	DiscoveryRegistry   string   `json:"discovery_registry"`
 	Entrypoints         []string `json:"entrypoints"`
+	DiscoveryExcludes   []string `json:"discovery_excludes"`
 	TagIDs              []string `json:"tag_ids"`
 	OrgID               string   `json:"org_id"`
 }
@@ -1005,7 +1006,17 @@ func build(c *gin.Context, db *bun.DB, body repositoryRequest, userID uuid.UUID,
 	if discoveryMode == models.GitRepositoryDiscoveryKustomize && len(entrypoints) == 0 {
 		return nil, fmt.Errorf("Kustomize discovery requires at least one entrypoint")
 	}
-	item := &models.GitRepository{Name: strings.TrimSpace(body.Name), CloneURL: url, Ref: strings.TrimSpace(body.Ref), AuthType: authType, Username: username, Schedule: schedule, Timezone: timezone, Enabled: body.Enabled, RescanPolicy: policy, DiscoveryMode: discoveryMode, Entrypoints: entrypoints, TagIDs: body.TagIDs, CreatedByID: userID, OwnerType: models.OwnerTypeUser, OwnerUserID: &userID, CreatedAt: time.Now(), UpdatedAt: time.Now()}
+	discoveryExcludesInput := body.DiscoveryExcludes
+	if discoveryExcludesInput == nil && previous != nil {
+		// Preserve exclusions for older clients that do not send the newly
+		// introduced field during an otherwise unrelated repository update.
+		discoveryExcludesInput = previous.DiscoveryExcludes
+	}
+	discoveryExcludes, err := gitservice.NormalizeDiscoveryExcludes(discoveryExcludesInput)
+	if err != nil {
+		return nil, err
+	}
+	item := &models.GitRepository{Name: strings.TrimSpace(body.Name), CloneURL: url, Ref: strings.TrimSpace(body.Ref), AuthType: authType, Username: username, Schedule: schedule, Timezone: timezone, Enabled: body.Enabled, RescanPolicy: policy, DiscoveryMode: discoveryMode, Entrypoints: entrypoints, DiscoveryExcludes: discoveryExcludes, TagIDs: body.TagIDs, CreatedByID: userID, OwnerType: models.OwnerTypeUser, OwnerUserID: &userID, CreatedAt: time.Now(), UpdatedAt: time.Now()}
 	if item.Name == "" {
 		item.Name = url
 	}

--- a/services/backend/pkg/models/git_repositories.go
+++ b/services/backend/pkg/models/git_repositories.go
@@ -62,6 +62,7 @@ type GitRepository struct {
 	DiscoveryRegistryID  *uuid.UUID `bun:"discovery_registry_id,type:uuid" json:"discovery_registry_id,omitempty"`
 	DiscoveryRegistry    string     `bun:"discovery_registry,type:text,notnull,default:''" json:"discovery_registry"`
 	Entrypoints          []string   `bun:"entrypoints,type:jsonb,notnull,default:'[]'" json:"entrypoints"`
+	DiscoveryExcludes    []string   `bun:"discovery_excludes,type:jsonb,notnull,default:'[]'" json:"discovery_excludes"`
 	TagIDs               []string   `bun:"tag_ids,type:jsonb,notnull,default:'[]'" json:"tag_ids"`
 	CreatedByID          uuid.UUID  `bun:"created_by_id,type:uuid,notnull" json:"created_by_id"`
 	OwnerType            string     `bun:"owner_type,type:text,notnull,default:'user'" json:"owner_type"`

--- a/services/docs/content/docs/scan-and-analyze/gitops.mdx
+++ b/services/docs/content/docs/scan-and-analyze/gitops.mdx
@@ -15,6 +15,19 @@ Connect a Git repository in the application, validate access, then run discovery
 
 After a dry run, review discovered images, select the ones that should be tracked, then create scans. Excluded images remain visible in the review so their deployment context is retained without scheduling future scans.
 
+## Ignored discovery paths
+
+Configure **Ignored discovery paths** on a Git repository when automatic discovery should skip archived, generated, or deprecated content. Enter one glob per line. Patterns are matched against repository-relative paths, and matching files and directories are skipped before JustScan walks or renders them. For example:
+
+```text
+.archive/**
+**/deprecated/**
+```
+
+`.archive/**` skips the `.archive` directory at the repository root and everything below it. `**/deprecated/**` skips every `deprecated` directory at any depth. These patterns apply to automatic Kustomize, manifest, GitLab CI, and registry-reference discovery.
+
+Ignored paths are also enforced for configured Kustomize entrypoints. An explicitly selected entrypoint inside an ignored path is rejected rather than silently skipped. When Auto discovery finds a broken Kustomize root, JustScan reports that root while continuing to discover valid roots elsewhere in the repository.
+
 ## Registry image-reference discovery
 
 Choose **Registry image references** when image declarations are spread across deployment files, scripts, and other repository configuration. Select a configured registry from the workspace, or choose **Custom registry host or path** and enter a prefix such as `registry.example.com/team`. JustScan searches automatically and still shows the source file and line for each result so the dry-run review is auditable.

--- a/services/frontend/app/(app)/git-repositories/[id]/page.tsx
+++ b/services/frontend/app/(app)/git-repositories/[id]/page.tsx
@@ -1045,6 +1045,24 @@ export default function GitRepositoryDetailPage() {
         />
       </div>
 
+      {repository.discovery_excludes?.length ? (
+        <Card>
+          <Card.Header>
+            <Card.Title>Ignored discovery paths</Card.Title>
+            <Card.Description>
+              These repository-relative globs are skipped before automatic discovery scans.
+            </Card.Description>
+          </Card.Header>
+          <Card.Content className="flex flex-wrap gap-2">
+            {repository.discovery_excludes.map((path) => (
+              <Chip key={path} size="sm" variant="soft">
+                <code>{path}</code>
+              </Chip>
+            ))}
+          </Card.Content>
+        </Card>
+      ) : null}
+
       <Card className="overflow-hidden">
         <Card.Header className="!flex-row items-start justify-between gap-4">
           <div className="flex min-w-0 items-start gap-3">

--- a/services/frontend/app/(app)/git-repositories/page.tsx
+++ b/services/frontend/app/(app)/git-repositories/page.tsx
@@ -67,6 +67,7 @@ type Draft = Required<
   discovery_registry_id: string;
   discovery_registry: string;
   registry_source: string;
+  discovery_excludes: string;
 };
 const CUSTOM_REGISTRY_VALUE = '__custom_registry__';
 const initialDraft: Draft = {
@@ -85,6 +86,7 @@ const initialDraft: Draft = {
   discovery_registry_id: '',
   discovery_registry: '',
   registry_source: '',
+  discovery_excludes: '',
 };
 
 export default function GitRepositoriesPage() {
@@ -178,6 +180,10 @@ export default function GitRepositoriesPage() {
         enabled: draft.enabled,
         rescan_policy: draft.rescan_policy,
         discovery_mode: draft.discovery_mode,
+        discovery_excludes: draft.discovery_excludes
+          .split('\n')
+          .map((value) => value.trim())
+          .filter(Boolean),
         entrypoints: usesEntrypoints
           ? draft.entrypoints
               .split('\n')
@@ -241,6 +247,7 @@ export default function GitRepositoriesPage() {
       registry_source:
         repository.discovery_registry_id ??
         (repository.discovery_registry ? CUSTOM_REGISTRY_VALUE : ''),
+      discovery_excludes: repository.discovery_excludes?.join('\n') ?? '',
     });
     overlay.open();
   }
@@ -494,6 +501,23 @@ export default function GitRepositoriesPage() {
                             : 'Render detected Kustomize roots, then fall back to plain manifests.'}
                   </Description>
                 </Select>
+                <div className="grid gap-2">
+                  <Label htmlFor="discovery-excludes">Ignored discovery paths</Label>
+                  <TextArea
+                    id="discovery-excludes"
+                    value={draft.discovery_excludes}
+                    onChange={(event) =>
+                      setDraft({ ...draft, discovery_excludes: event.target.value })
+                    }
+                    placeholder=".archive/**\n**/deprecated/**"
+                    rows={3}
+                    variant="secondary"
+                  />
+                  <Description>
+                    Optional. Add one repo-relative glob per line. Matching paths are skipped before
+                    automatic Kustomize, manifest, CI, or registry discovery scans.
+                  </Description>
+                </div>
                 {draft.discovery_mode === 'registry' ? (
                   <div className="grid gap-3 rounded-xl border border-divider/70 bg-surface-secondary p-3">
                     <Select

--- a/services/frontend/lib/api/types/git-repositories.ts
+++ b/services/frontend/lib/api/types/git-repositories.ts
@@ -23,6 +23,8 @@ export interface GitRepository {
   discovery_registry_id?: string | null;
   /** Registry host or path prefix used by registry-reference discovery. */
   discovery_registry?: string;
+  /** Repository-relative glob patterns excluded before automatic discovery. */
+  discovery_excludes?: string[];
   entrypoints: string[];
   tag_ids: string[];
   owner_type: OwnerType;


### PR DESCRIPTION
## Summary

- Add configurable, validated exclusion glob patterns for Git repository discovery.
- Apply exclusions across manifests, Kustomize, GitLab CI, registry, Helm, and candidate discovery.
- Report unresolved automatic Kustomize entrypoints as warnings and document the feature.

## Testing

- Added backend unit tests covering pattern normalization, path matching, discovery pruning, explicit exclusions, and broken Kustomize roots.
- Not run: full backend test suite.